### PR TITLE
[mtest] check etcd cluster is good

### DIFF
--- a/mtest/run_test.go
+++ b/mtest/run_test.go
@@ -292,11 +292,16 @@ func checkCluster(c *cke.Cluster) error {
 	if err != nil {
 		return err
 	}
+
+	nf := cke.NewNodeFilter(c, status)
+	if !nf.EtcdIsGood() {
+		return errors.New("etcd cluster is not good")
+	}
+
 	ops := cke.DecideOps(c, status)
 	if len(ops) == 0 {
 		return nil
 	}
-
 	opNames := make([]string, len(ops))
 	for i, op := range ops {
 		opNames[i] = op.Name()


### PR DESCRIPTION
The current strategy may skip etcd maintenance operations
when the etcd cluster is not perfectly good.  In such cases,
DecideOps may return nil.

This commit adds a check for such cases.