### PR TITLE
Export etcd endpoints to Kubernetes

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -13,8 +13,9 @@ import (
 	"github.com/cybozu-go/cmd"
 	"github.com/cybozu-go/log"
 	yaml "gopkg.in/yaml.v2"
-	rbac "k8s.io/api/rbac/v1"
-	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -829,8 +830,8 @@ func (c makeRBACRoleCommand) Run(ctx context.Context, inf Infrastructure) error 
 		return err
 	}
 
-	_, err = cs.RbacV1().ClusterRoles().Create(&rbac.ClusterRole{
-		ObjectMeta: meta.ObjectMeta{
+	_, err = cs.RbacV1().ClusterRoles().Create(&rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: rbacRoleName,
 			Labels: map[string]string{
 				"kubernetes.io/bootstrapping": "rbac-defaults",
@@ -841,7 +842,7 @@ func (c makeRBACRoleCommand) Run(ctx context.Context, inf Infrastructure) error 
 				"rbac.authorization.kubernetes.io/autoupdate": "true",
 			},
 		},
-		Rules: []rbac.PolicyRule{
+		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{""},
 				// these are virtual resources.
@@ -878,8 +879,8 @@ func (c makeRBACRoleBindingCommand) Run(ctx context.Context, inf Infrastructure)
 		return err
 	}
 
-	_, err = cs.RbacV1().ClusterRoleBindings().Create(&rbac.ClusterRoleBinding{
-		ObjectMeta: meta.ObjectMeta{
+	_, err = cs.RbacV1().ClusterRoleBindings().Create(&rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: rbacRoleBindingName,
 			Labels: map[string]string{
 				"kubernetes.io/bootstrapping": "rbac-defaults",
@@ -890,12 +891,12 @@ func (c makeRBACRoleBindingCommand) Run(ctx context.Context, inf Infrastructure)
 				"rbac.authorization.kubernetes.io/autoupdate": "true",
 			},
 		},
-		RoleRef: rbac.RoleRef{
+		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
 			Name:     rbacRoleName,
 		},
-		Subjects: []rbac.Subject{
+		Subjects: []rbacv1.Subject{
 			{
 				APIGroup: "rbac.authorization.k8s.io",
 				Kind:     "User",
@@ -911,6 +912,78 @@ func (c makeRBACRoleBindingCommand) Command() Command {
 	return Command{
 		Name:   "makeClusterRoleBinding",
 		Target: rbacRoleBindingName,
+	}
+}
+
+type createEtcdEndpointsCommand struct {
+	apiserver *Node
+	endpoints []*Node
+}
+
+func (c createEtcdEndpointsCommand) Run(ctx context.Context, inf Infrastructure) error {
+	cs, err := inf.K8sClient(ctx, c.apiserver)
+	if err != nil {
+		return err
+	}
+
+	subset := corev1.EndpointSubset{
+		Addresses: make([]corev1.EndpointAddress, len(c.endpoints)),
+		Ports:     []corev1.EndpointPort{{Port: 2379}},
+	}
+	for i, n := range c.endpoints {
+		subset.Addresses[i].IP = n.Address
+	}
+
+	_, err = cs.CoreV1().Endpoints("kube-system").Create(&corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: etcdEndpointsName,
+		},
+		Subsets: []corev1.EndpointSubset{subset},
+	})
+
+	return err
+}
+
+func (c createEtcdEndpointsCommand) Command() Command {
+	return Command{
+		Name:   "createEtcdEndpointsCommand",
+		Target: "kube-system/" + etcdEndpointsName,
+	}
+}
+
+type updateEtcdEndpointsCommand struct {
+	apiserver *Node
+	endpoints []*Node
+}
+
+func (c updateEtcdEndpointsCommand) Run(ctx context.Context, inf Infrastructure) error {
+	cs, err := inf.K8sClient(ctx, c.apiserver)
+	if err != nil {
+		return err
+	}
+
+	subset := corev1.EndpointSubset{
+		Addresses: make([]corev1.EndpointAddress, len(c.endpoints)),
+		Ports:     []corev1.EndpointPort{{Port: 2379}},
+	}
+	for i, n := range c.endpoints {
+		subset.Addresses[i].IP = n.Address
+	}
+
+	_, err = cs.CoreV1().Endpoints("kube-system").Update(&corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: etcdEndpointsName,
+		},
+		Subsets: []corev1.EndpointSubset{subset},
+	})
+
+	return err
+}
+
+func (c updateEtcdEndpointsCommand) Command() Command {
+	return Command{
+		Name:   "updateEtcdEndpointsCommand",
+		Target: "kube-system/" + etcdEndpointsName,
 	}
 }
 

--- a/docs/etcd.md
+++ b/docs/etcd.md
@@ -1,0 +1,81 @@
+etcd
+====
+
+CKE bootstraps and maintains an [etcd][] cluster for Kubernetes.
+
+The etcd cluster is not only for Kubernetes, but users can use it
+for other applications.
+
+Administration
+--------------
+
+First of all, read [Role-based access control][RBAC] for etcd.
+Since the etcd cluster has RBAC enabled, you need to be authenticated as `root` to manage it.
+The cluster also enables [TLS-based user authentication](https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/authentication.md#using-tls-common-name)
+
+`ckecli etcd root-issue` issues a TLS client certificate for the `root` user that are valid for only 2 hours.  Use it to connect to etcd:
+
+```console
+$ CERT=$(ckecli etcd root-issue)
+$ echo "$CERT" | jq -r .ca_certificate > /tmp/etcd-ca.crt
+$ echo "$CERT" | jq -r .certificate > /tmp/etcd-root.crt
+$ echo "$CERT" | jq -r .private_key > /tmp/etcd-root.key
+$ export ETCDCTL_API=3
+$ export ETCDCTL_CACERT=/tmp/etcd-ca.crt
+$ export ETCDCTL_CERT=/tmp/etcd-root.crt
+$ export ETCDCTL_KEY=/tmp/etcd-root.key
+
+$ etcdctl --endpoints=CONTROL_PLANE_NODE_IP:2379 member list
+```
+
+Application
+-----------
+
+### User and key prefix
+
+Kubernetes is authenticated as `kube-apiserver` and its keys are prefixed by `/registry/`.
+
+Other applications should use different user names and prefixes.
+
+To create an etcd user and grant a prefix, use `ckecli` as follows:
+
+```console
+$ ckecli etcd user-add USER PREFIX
+```
+
+### TLS certificate for a user
+
+Use `ckecli etcd issue` to issue a TLS client certificate for a user.
+The command can specify TTL of the certificate long enough for application usage (default is 10 years).
+
+```console
+$ CERT=$(ckecli etcd issue -ttl=24h -output=json USER)
+
+$ echo "$CERT" | jq -r .ca_certificate > etcd-ca.crt
+$ echo "$CERT" | jq -r .certificate > USER.crt
+$ echo "$CERT" | jq -r .private_key > USER.key
+```
+
+### Etcd endpoints
+
+Since CKE automatically adds or removes etcd members, applications need
+to change the list of etcd endpoints.  To help applications running on
+Kubernetes, CKE exports the endpoint list as a Kubernetes resource.
+
+[`Endpoints`][Endpoints] is a Kubernetes resource to list service endpoints.
+CKE creates and maintains an `Endpoints` resource named `cke-etcd` in `kube-system` namespace.
+
+To view the contents, use `kubectl` as follows:
+
+```console
+$ kubectl -n kube-system get endpoints/cke-etcd -o yaml
+```
+
+Backup
+------
+
+**TBD**
+
+[etcd]: https://github.com/etcd-io/etcd
+[RBAC]: https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/authentication.md
+[Endpoints]: https://kubernetes.io/docs/concepts/services-networking/service/#services-without-selectors

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -161,6 +161,10 @@ type kubeProxyRestartOp struct {
 	finished bool
 }
 
+type kubeWaitOp struct {
+	apiserver *Node
+	finished  bool
+}
 type kubeRBACRoleInstallOp struct {
 	apiserver     *Node
 	roleExists    bool
@@ -852,6 +856,24 @@ func (o *kubeProxyRestartOp) NextCommand() Commander {
 		}
 	}
 	return nil
+}
+
+// KubeWaitOp returns an Operator to wait for Kubernetes resources gets initialized
+func KubeWaitOp(apiserver *Node) Operator {
+	return &kubeWaitOp{apiserver: apiserver}
+}
+
+func (o *kubeWaitOp) Name() string {
+	return "wait-kubernetes"
+}
+
+func (o *kubeWaitOp) NextCommand() Commander {
+	if o.finished {
+		return nil
+	}
+
+	o.finished = true
+	return waitKubeCommand{o.apiserver}
 }
 
 // KubeRBACRoleInstallOp returns an Operator to install ClusterRole and binding for RBAC.

--- a/mtest/operators_test.go
+++ b/mtest/operators_test.go
@@ -23,6 +23,7 @@ var _ = Describe("Operations", func() {
 		// - KubeletBootOp
 		// - KubeProxyBootOp
 		// - KubeRBACRoleInstallOp
+		// - KubeEtcdEndpointsCreateOp
 
 		By("Stopping etcd servers")
 		// this will run:
@@ -48,6 +49,7 @@ var _ = Describe("Operations", func() {
 		// - ToDo: K8sRemoveNodeOp
 		// - RiversRestartOp
 		// - APIServerRestartOp
+		// - KubeEtcdEndpointsUpdateOp
 		stopCKE()
 		execAt(node2, "sudo", "-b", "reboot", "-f", "-f")
 		time.Sleep(5 * time.Second)

--- a/mtest/operators_test.go
+++ b/mtest/operators_test.go
@@ -22,6 +22,7 @@ var _ = Describe("Operations", func() {
 		// - SchedulerBootOp
 		// - KubeletBootOp
 		// - KubeProxyBootOp
+		// - KubeWaitOp
 		// - KubeRBACRoleInstallOp
 		// - KubeEtcdEndpointsCreateOp
 

--- a/strategy.go
+++ b/strategy.go
@@ -140,6 +140,10 @@ func k8sMaintOps(cs *ClusterStatus, nf *NodeFilter) (ops []Operator) {
 	ks := cs.Kubernetes
 	apiServer := nf.HealthyAPIServer()
 
+	if !ks.IsReady {
+		return []Operator{KubeWaitOp(apiServer)}
+	}
+
 	if !ks.RBACRoleExists || !ks.RBACRoleBindingExists {
 		ops = append(ops, KubeRBACRoleInstallOp(apiServer, ks.RBACRoleExists))
 	}

--- a/strategy_test.go
+++ b/strategy_test.go
@@ -175,8 +175,14 @@ func (d testData) withAllServices() testData {
 	return d
 }
 
-func (d testData) withRBACResources() testData {
+func (d testData) withK8sReady() testData {
 	d.withAllServices()
+	d.Status.Kubernetes.IsReady = true
+	return d
+}
+
+func (d testData) withRBACResources() testData {
+	d.withK8sReady()
 	d.Status.Kubernetes.RBACRoleExists = true
 	d.Status.Kubernetes.RBACRoleBindingExists = true
 	return d
@@ -419,8 +425,13 @@ func TestDecideOps(t *testing.T) {
 			},
 		},
 		{
-			Name:        "RBAC",
+			Name:        "WaiKube",
 			Input:       newData().withAllServices(),
+			ExpectedOps: []string{"wait-kubernetes"},
+		},
+		{
+			Name:        "RBAC",
+			Input:       newData().withK8sReady(),
 			ExpectedOps: []string{"create-etcd-endpoints", "install-rbac-role"},
 		},
 		{

--- a/strategy_test.go
+++ b/strategy_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/coreos/etcd/etcdserver/etcdserverpb"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -174,10 +175,27 @@ func (d testData) withAllServices() testData {
 	return d
 }
 
-func (d testData) withResources() testData {
+func (d testData) withRBACResources() testData {
 	d.withAllServices()
 	d.Status.Kubernetes.RBACRoleExists = true
 	d.Status.Kubernetes.RBACRoleBindingExists = true
+	return d
+}
+
+func (d testData) withEtcdEndpoints() testData {
+	d.withRBACResources()
+	d.Status.Kubernetes.EtcdEndpoints = &corev1.Endpoints{
+		Subsets: []corev1.EndpointSubset{
+			{
+				Addresses: []corev1.EndpointAddress{
+					{IP: "10.0.0.11"},
+					{IP: "10.0.0.12"},
+					{IP: "10.0.0.13"},
+				},
+				Ports: []corev1.EndpointPort{{Port: 2379}},
+			},
+		},
+	}
 	return d
 }
 
@@ -403,11 +421,37 @@ func TestDecideOps(t *testing.T) {
 		{
 			Name:        "RBAC",
 			Input:       newData().withAllServices(),
-			ExpectedOps: []string{"install-rbac-role"},
+			ExpectedOps: []string{"create-etcd-endpoints", "install-rbac-role"},
+		},
+		{
+			Name:        "EtcdEndpointsCreate",
+			Input:       newData().withRBACResources(),
+			ExpectedOps: []string{"create-etcd-endpoints"},
+		},
+		{
+			Name: "EtcdEndpointsUpdate1",
+			Input: newData().withEtcdEndpoints().with(func(d testData) {
+				d.Status.Kubernetes.EtcdEndpoints.Subsets = []corev1.EndpointSubset{}
+			}),
+			ExpectedOps: []string{"update-etcd-endpoints"},
+		},
+		{
+			Name: "EtcdEndpointsUpdate2",
+			Input: newData().withEtcdEndpoints().with(func(d testData) {
+				d.Status.Kubernetes.EtcdEndpoints.Subsets[0].Ports = []corev1.EndpointPort{}
+			}),
+			ExpectedOps: []string{"update-etcd-endpoints"},
+		},
+		{
+			Name: "EtcdEndpointsUpdate1",
+			Input: newData().withEtcdEndpoints().with(func(d testData) {
+				d.Status.Kubernetes.EtcdEndpoints.Subsets[0].Addresses = []corev1.EndpointAddress{}
+			}),
+			ExpectedOps: []string{"update-etcd-endpoints"},
 		},
 		{
 			Name:        "AllGreen",
-			Input:       newData().withResources(),
+			Input:       newData().withEtcdEndpoints(),
 			ExpectedOps: nil,
 		},
 		{
@@ -434,7 +478,7 @@ func TestDecideOps(t *testing.T) {
 		},
 		{
 			Name: "EtcdIsNotGood",
-			Input: newData().withResources().with(func(d testData) {
+			Input: newData().withEtcdEndpoints().with(func(d testData) {
 				// a node is to be added
 				delete(d.Status.Etcd.Members, "10.0.0.13")
 				delete(d.Status.Etcd.InSyncMembers, "10.0.0.13")
@@ -476,7 +520,7 @@ func TestDecideOps(t *testing.T) {
 		},
 		{
 			Name: "Clean",
-			Input: newData().withResources().with(func(d testData) {
+			Input: newData().withEtcdEndpoints().with(func(d testData) {
 				st := d.Status.NodeStatuses["10.0.0.14"]
 				st.Etcd.Running = true
 				st.Etcd.HasData = true


### PR DESCRIPTION
To help applications running on Kubernetes use CKE maintained etcd,
CKE creates and maintains a Kubernetes resource `Endpoints` that lists
etcd endpoints addresses.