### PR TITLE
Add Service for etcd Endpoints resource.

### DIFF
--- a/mtest/kubernetes_test.go
+++ b/mtest/kubernetes_test.go
@@ -48,4 +48,11 @@ var _ = Describe("Kubernetes", func() {
 			return errors.New("pod is not yet ready")
 		}).Should(Succeed())
 	})
+
+	It("has kube-system/cke-etcd Service and Endpoints", func() {
+		_, err := kubectl("-n", "kube-system", "get", "services/cke-etcd")
+		Expect(err).ShouldNot(HaveOccurred())
+		_, err = kubectl("-n", "kube-system", "get", "endpoints/cke-etcd")
+		Expect(err).ShouldNot(HaveOccurred())
+	})
 })

--- a/op/status.go
+++ b/op/status.go
@@ -226,7 +226,8 @@ func GetKubernetesClusterStatus(ctx context.Context, inf cke.Infrastructure, n *
 		return cke.KubernetesClusterStatus{}, err
 	}
 
-	ep, err := clientset.CoreV1().Endpoints("kube-system").Get(etcdEndpointsName, metav1.GetOptions{})
+	ep, err := clientset.CoreV1().Endpoints("kube-system").Get(etcdEndpointsName,
+		metav1.GetOptions{IncludeUninitialized: true})
 	switch {
 	case err == nil:
 		s.EtcdEndpoints = ep


### PR DESCRIPTION
Kubernetes does not allow Endpoints exists w/o corresponding Service.
Such Endpoints are removed automagically by the endpoints controller.

https://github.com/kubernetes/kubernetes/blob/b7c2d923ef4e166b9572d3aa09ca72231b59b28b/pkg/controller/endpoint/endpoints_controller.go#L392-L397

This commit creates a headless Service "cke-etcd" in "kube-system"
namespace to protect etcd Endpoints from auto removal.