### PR TITLE
Update node annotations, labels, and taints

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -5,7 +5,38 @@ import (
 	"testing"
 
 	yaml "gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
+
+const testSSHKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAqGDTa8Fw0qWuQ/7xvsTdFfP0oqgpXUxl8FpOFWpJWTUM9ZhJ
+NidBfglbnAAQ14/7JfvTUHAQgQ7X0ih8IJ2Z6VDGGZ9kr1N42iN5/17yMCZwgGgR
+bwtvj+/X4lFUa0zVHe/dnLxkBQyV2hOvlLO/E7fUeVy70Mt/1NdlZtI15l1JX/+p
+JJVSW+YaL7QF4X4aYad+PSQU5jRQB5KMfhTSayuAMDJc/FCYcArqhHvC/eh6lbyu
+Qy3WokI1p+XaRb1giybfFW35ymfVT3EsGBZjkpsgZGCMfnQ5H+xr9JiItvLE7yAd
+nBZevx5DyKmrC95tvjKiDGSULd8j4IiAvlsALwIDAQABAoIBACQJJPZo3gaXIua2
+h3J2m4J5RaASMVggY6i/CvsWVkBbVDyzrOeEG0YoJo0KjpAz5mJItP8AHOgiDxqR
+Q4+Pa0M94EfXjyreyHyXHyMCZP7dGzLAEwsa/XNmt2NeWJzmQq43icxjnVxfRyr3
+D5rZpUlJDJY0vJWBGAirWK5ayuJUN9SFfsJWqEk4CDNQvONWNK1gvxazbppdCu93
+FuuQvNkutosx8tmyl9eCev6sIugB6pp/YRf57JLRKJ0BwG7qn3gRNpyQOhGrF1MX
++0I9Ldi42OluLKP1X7n6MOux7Alxh5KuIq28d4mrE0iKUGU3yBt9R61UUGgynWc/
+98QUQ/ECgYEA11Oj2fizzNnvEWn8nO1apYohtG+fjga8Tt472EpDjwwvhFVAX59f
+2VoTJZct/oCkgffeut+bTB9FIYMRPoO1OH7Vd5lqsa+GCO+vTDM2mezFdfItxPoe
+8h8u4brBy+x0aPyiNLEuYIjUh0ymUoviFGB4jP/J2QNzJvhM1nu12BsCgYEAyC7w
+nHiMmkfPEslG1DyKsD2rmPiVHLldjVzYSOgBcL8bPGU2SYQedRdQBpzK6OF9TqXv
+QsvO6HVgq8bmZVr2e0zhZhCak+NyxczObOdP2i+M2QUIXGBXG7ivCBexSiUH0DUd
+xV2LEWkXA+3WuJ9gKY9GBBBdTOD+jqssiLZvIX0CgYEAtlHgo9g8TZCeJy2Jskoa
+/Z2nCkOVYsl7OoBbRbkj2QRlW3RfzFeC7eOh4KtQS3UbVdzN34cj1GGJxGVY/YjB
+sfNaxijFuWu4XuqrkCaw7cYYL9T+QhHSkAotRP4/x24P5zE6GsmHTj+tTF5vWeeN
+ZtmEWUbf3vtXzkBhtx4Ki88CgYAaliFepqQF2YOm+xRtG51PyuD/cARdzECghbQz
++pw2XStA2jBbkzB4XKBEQI6yX0BFMcSVGnxgYzZzmfb/fxU9SviklY/yFEMqAglo
+bVAtqiMKr6BspF7tT5nveTYSothmzqclj0bpCQwFeZEK9B/RZTXnVEUP8NHeIN3J
+SnF4AQKBgCXupLs3AqbEWg2iUs+Eqeru0rEWopuTUiLJOvoT6X5NQlUIlpv5Ye+Z
+tsChz55NjCxNEpn4NvGyeGgJrBEGwAPbx/X2v2BWFxWPNWh6byHi9ZxELa0Utlc8
+B29lX8k9dqD0HitCL6ibsw0DqsU6FC3fd179rH8Bik83FuukuxvD
+-----END RSA PRIVATE KEY-----
+`
 
 func testClusterYAML(t *testing.T) {
 	t.Parallel()
@@ -184,11 +215,117 @@ func testClusterValidate(t *testing.T) {
 			true,
 		},
 		{
+			"invalid domain",
+			Cluster{
+				Name:          "testcluster",
+				ServiceSubnet: "10.0.0.0/14",
+				PodSubnet:     "10.1.0.0/16",
+				Options: Options{
+					Kubelet: KubeletParams{
+						Domain: "a_b.c",
+					},
+				},
+			},
+			true,
+		},
+		{
+			"invalid boot taint key",
+			Cluster{
+				Name:          "testcluster",
+				ServiceSubnet: "10.0.0.0/14",
+				PodSubnet:     "10.1.0.0/16",
+				Options: Options{
+					Kubelet: KubeletParams{
+						BootTaints: []corev1.Taint{
+							{
+								Key:    "a_b/c",
+								Value:  "hello",
+								Effect: "NoSchedule",
+							},
+						},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"invalid boot taint key 2",
+			Cluster{
+				Name:          "testcluster",
+				ServiceSubnet: "10.0.0.0/14",
+				PodSubnet:     "10.1.0.0/16",
+				Options: Options{
+					Kubelet: KubeletParams{
+						BootTaints: []corev1.Taint{
+							{
+								Key:    "a.b/c b",
+								Value:  "hello",
+								Effect: "NoSchedule",
+							},
+						},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"invalid boot taint value",
+			Cluster{
+				Name:          "testcluster",
+				ServiceSubnet: "10.0.0.0/14",
+				PodSubnet:     "10.1.0.0/16",
+				Options: Options{
+					Kubelet: KubeletParams{
+						BootTaints: []corev1.Taint{
+							{
+								Key:    "a.b/c",
+								Value:  "こんにちは",
+								Effect: "NoSchedule",
+							},
+						},
+					},
+				},
+			},
+			true,
+		},
+		{
+			"invalid boot taint effect",
+			Cluster{
+				Name:          "testcluster",
+				ServiceSubnet: "10.0.0.0/14",
+				PodSubnet:     "10.1.0.0/16",
+				Options: Options{
+					Kubelet: KubeletParams{
+						BootTaints: []corev1.Taint{
+							{
+								Key:    "a.b/c",
+								Value:  "hello",
+								Effect: "NoNoNo",
+							},
+						},
+					},
+				},
+			},
+			true,
+		},
+		{
 			"valid case",
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
 				PodSubnet:     "10.1.0.0/16",
+				Options: Options{
+					Kubelet: KubeletParams{
+						Domain: "cybozu.com",
+						BootTaints: []corev1.Taint{
+							{
+								Key:    "a.b/c",
+								Value:  "hello",
+								Effect: "NoSchedule",
+							},
+						},
+					},
+				},
 			},
 			false,
 		},
@@ -215,39 +352,18 @@ func testClusterValidateNode(t *testing.T) {
 		{
 			name: "valid case",
 			node: Node{
-				Address: "10.0.0.1",
-				User:    "testuser",
-				SSHKey: `
------BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEAqGDTa8Fw0qWuQ/7xvsTdFfP0oqgpXUxl8FpOFWpJWTUM9ZhJ
-NidBfglbnAAQ14/7JfvTUHAQgQ7X0ih8IJ2Z6VDGGZ9kr1N42iN5/17yMCZwgGgR
-bwtvj+/X4lFUa0zVHe/dnLxkBQyV2hOvlLO/E7fUeVy70Mt/1NdlZtI15l1JX/+p
-JJVSW+YaL7QF4X4aYad+PSQU5jRQB5KMfhTSayuAMDJc/FCYcArqhHvC/eh6lbyu
-Qy3WokI1p+XaRb1giybfFW35ymfVT3EsGBZjkpsgZGCMfnQ5H+xr9JiItvLE7yAd
-nBZevx5DyKmrC95tvjKiDGSULd8j4IiAvlsALwIDAQABAoIBACQJJPZo3gaXIua2
-h3J2m4J5RaASMVggY6i/CvsWVkBbVDyzrOeEG0YoJo0KjpAz5mJItP8AHOgiDxqR
-Q4+Pa0M94EfXjyreyHyXHyMCZP7dGzLAEwsa/XNmt2NeWJzmQq43icxjnVxfRyr3
-D5rZpUlJDJY0vJWBGAirWK5ayuJUN9SFfsJWqEk4CDNQvONWNK1gvxazbppdCu93
-FuuQvNkutosx8tmyl9eCev6sIugB6pp/YRf57JLRKJ0BwG7qn3gRNpyQOhGrF1MX
-+0I9Ldi42OluLKP1X7n6MOux7Alxh5KuIq28d4mrE0iKUGU3yBt9R61UUGgynWc/
-98QUQ/ECgYEA11Oj2fizzNnvEWn8nO1apYohtG+fjga8Tt472EpDjwwvhFVAX59f
-2VoTJZct/oCkgffeut+bTB9FIYMRPoO1OH7Vd5lqsa+GCO+vTDM2mezFdfItxPoe
-8h8u4brBy+x0aPyiNLEuYIjUh0ymUoviFGB4jP/J2QNzJvhM1nu12BsCgYEAyC7w
-nHiMmkfPEslG1DyKsD2rmPiVHLldjVzYSOgBcL8bPGU2SYQedRdQBpzK6OF9TqXv
-QsvO6HVgq8bmZVr2e0zhZhCak+NyxczObOdP2i+M2QUIXGBXG7ivCBexSiUH0DUd
-xV2LEWkXA+3WuJ9gKY9GBBBdTOD+jqssiLZvIX0CgYEAtlHgo9g8TZCeJy2Jskoa
-/Z2nCkOVYsl7OoBbRbkj2QRlW3RfzFeC7eOh4KtQS3UbVdzN34cj1GGJxGVY/YjB
-sfNaxijFuWu4XuqrkCaw7cYYL9T+QhHSkAotRP4/x24P5zE6GsmHTj+tTF5vWeeN
-ZtmEWUbf3vtXzkBhtx4Ki88CgYAaliFepqQF2YOm+xRtG51PyuD/cARdzECghbQz
-+pw2XStA2jBbkzB4XKBEQI6yX0BFMcSVGnxgYzZzmfb/fxU9SviklY/yFEMqAglo
-bVAtqiMKr6BspF7tT5nveTYSothmzqclj0bpCQwFeZEK9B/RZTXnVEUP8NHeIN3J
-SnF4AQKBgCXupLs3AqbEWg2iUs+Eqeru0rEWopuTUiLJOvoT6X5NQlUIlpv5Ye+Z
-tsChz55NjCxNEpn4NvGyeGgJrBEGwAPbx/X2v2BWFxWPNWh6byHi9ZxELa0Utlc8
-B29lX8k9dqD0HitCL6ibsw0DqsU6FC3fd179rH8Bik83FuukuxvD
------END RSA PRIVATE KEY-----
-`,
+				Address:     "10.0.0.1",
+				User:        "testuser",
+				SSHKey:      testSSHKey,
+				Labels:      map[string]string{"cybozu.com/foo": "bar"},
+				Annotations: map[string]string{"cybozu.com/fo_o": "こんにちは"},
+				Taints: []corev1.Taint{{
+					Key:    "cybozu.com/f_oo",
+					Value:  "bar",
+					Effect: "NoExecute",
+				}},
 			},
-			cluster: Cluster{SSHKey: ""},
+			cluster: Cluster{},
 			wantErr: false,
 		},
 		{
@@ -255,37 +371,8 @@ B29lX8k9dqD0HitCL6ibsw0DqsU6FC3fd179rH8Bik83FuukuxvD
 			node: Node{
 				Address: "10.0.0.1",
 				User:    "testuser",
-				SSHKey:  "",
 			},
-			cluster: Cluster{SSHKey: `
------BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEAqGDTa8Fw0qWuQ/7xvsTdFfP0oqgpXUxl8FpOFWpJWTUM9ZhJ
-NidBfglbnAAQ14/7JfvTUHAQgQ7X0ih8IJ2Z6VDGGZ9kr1N42iN5/17yMCZwgGgR
-bwtvj+/X4lFUa0zVHe/dnLxkBQyV2hOvlLO/E7fUeVy70Mt/1NdlZtI15l1JX/+p
-JJVSW+YaL7QF4X4aYad+PSQU5jRQB5KMfhTSayuAMDJc/FCYcArqhHvC/eh6lbyu
-Qy3WokI1p+XaRb1giybfFW35ymfVT3EsGBZjkpsgZGCMfnQ5H+xr9JiItvLE7yAd
-nBZevx5DyKmrC95tvjKiDGSULd8j4IiAvlsALwIDAQABAoIBACQJJPZo3gaXIua2
-h3J2m4J5RaASMVggY6i/CvsWVkBbVDyzrOeEG0YoJo0KjpAz5mJItP8AHOgiDxqR
-Q4+Pa0M94EfXjyreyHyXHyMCZP7dGzLAEwsa/XNmt2NeWJzmQq43icxjnVxfRyr3
-D5rZpUlJDJY0vJWBGAirWK5ayuJUN9SFfsJWqEk4CDNQvONWNK1gvxazbppdCu93
-FuuQvNkutosx8tmyl9eCev6sIugB6pp/YRf57JLRKJ0BwG7qn3gRNpyQOhGrF1MX
-+0I9Ldi42OluLKP1X7n6MOux7Alxh5KuIq28d4mrE0iKUGU3yBt9R61UUGgynWc/
-98QUQ/ECgYEA11Oj2fizzNnvEWn8nO1apYohtG+fjga8Tt472EpDjwwvhFVAX59f
-2VoTJZct/oCkgffeut+bTB9FIYMRPoO1OH7Vd5lqsa+GCO+vTDM2mezFdfItxPoe
-8h8u4brBy+x0aPyiNLEuYIjUh0ymUoviFGB4jP/J2QNzJvhM1nu12BsCgYEAyC7w
-nHiMmkfPEslG1DyKsD2rmPiVHLldjVzYSOgBcL8bPGU2SYQedRdQBpzK6OF9TqXv
-QsvO6HVgq8bmZVr2e0zhZhCak+NyxczObOdP2i+M2QUIXGBXG7ivCBexSiUH0DUd
-xV2LEWkXA+3WuJ9gKY9GBBBdTOD+jqssiLZvIX0CgYEAtlHgo9g8TZCeJy2Jskoa
-/Z2nCkOVYsl7OoBbRbkj2QRlW3RfzFeC7eOh4KtQS3UbVdzN34cj1GGJxGVY/YjB
-sfNaxijFuWu4XuqrkCaw7cYYL9T+QhHSkAotRP4/x24P5zE6GsmHTj+tTF5vWeeN
-ZtmEWUbf3vtXzkBhtx4Ki88CgYAaliFepqQF2YOm+xRtG51PyuD/cARdzECghbQz
-+pw2XStA2jBbkzB4XKBEQI6yX0BFMcSVGnxgYzZzmfb/fxU9SviklY/yFEMqAglo
-bVAtqiMKr6BspF7tT5nveTYSothmzqclj0bpCQwFeZEK9B/RZTXnVEUP8NHeIN3J
-SnF4AQKBgCXupLs3AqbEWg2iUs+Eqeru0rEWopuTUiLJOvoT6X5NQlUIlpv5Ye+Z
-tsChz55NjCxNEpn4NvGyeGgJrBEGwAPbx/X2v2BWFxWPNWh6byHi9ZxELa0Utlc8
-B29lX8k9dqD0HitCL6ibsw0DqsU6FC3fd179rH8Bik83FuukuxvD
------END RSA PRIVATE KEY-----
-`},
+			cluster: Cluster{SSHKey: testSSHKey},
 			wantErr: false,
 		},
 		{
@@ -295,17 +382,16 @@ B29lX8k9dqD0HitCL6ibsw0DqsU6FC3fd179rH8Bik83FuukuxvD
 				User:    "testuser",
 				SSHKey:  "aaa",
 			},
-			cluster: Cluster{SSHKey: "aaa"},
+			cluster: Cluster{SSHKey: testSSHKey},
 			wantErr: true,
 		},
 		{
 			name: "no user",
 			node: Node{
 				Address: "10.0.0.1",
-				User:    "",
 				SSHKey:  "aaa",
 			},
-			cluster: Cluster{SSHKey: "aaa"},
+			cluster: Cluster{SSHKey: testSSHKey},
 			wantErr: true,
 		},
 		{
@@ -313,9 +399,80 @@ B29lX8k9dqD0HitCL6ibsw0DqsU6FC3fd179rH8Bik83FuukuxvD
 			node: Node{
 				Address: "10.0.0.1",
 				User:    "testuser",
-				SSHKey:  "",
 			},
-			cluster: Cluster{SSHKey: ""},
+			cluster: Cluster{},
+			wantErr: true,
+		},
+		{
+			name: "bad label name",
+			node: Node{
+				Address: "10.0.0.1",
+				User:    "testuser",
+				Labels:  map[string]string{"a_b/c": "hello"},
+			},
+			cluster: Cluster{SSHKey: testSSHKey},
+			wantErr: true,
+		},
+		{
+			name: "bad label value",
+			node: Node{
+				Address: "10.0.0.1",
+				User:    "testuser",
+				Labels:  map[string]string{"a_b/c": "こんにちは"},
+			},
+			cluster: Cluster{SSHKey: testSSHKey},
+			wantErr: true,
+		},
+		{
+			name: "bad annotation",
+			node: Node{
+				Address:     "10.0.0.1",
+				User:        "testuser",
+				Annotations: map[string]string{"a.b/c_": "hello"},
+			},
+			cluster: Cluster{SSHKey: testSSHKey},
+			wantErr: true,
+		},
+		{
+			name: "bad taint key",
+			node: Node{
+				Address: "10.0.0.1",
+				User:    "testuser",
+				Taints: []corev1.Taint{{
+					Key:    "!!!",
+					Value:  "hello",
+					Effect: "NoSchedule",
+				}},
+			},
+			cluster: Cluster{SSHKey: testSSHKey},
+			wantErr: true,
+		},
+		{
+			name: "bad taint value",
+			node: Node{
+				Address: "10.0.0.1",
+				User:    "testuser",
+				Taints: []corev1.Taint{{
+					Key:    "cybozu.com/hello",
+					Value:  "こんにちは",
+					Effect: "NoSchedule",
+				}},
+			},
+			cluster: Cluster{SSHKey: testSSHKey},
+			wantErr: true,
+		},
+		{
+			name: "bad taint effect",
+			node: Node{
+				Address: "10.0.0.1",
+				User:    "testuser",
+				Taints: []corev1.Taint{{
+					Key:    "cybozu.com/hello",
+					Value:  "world",
+					Effect: "NoNoNo",
+				}},
+			},
+			cluster: Cluster{SSHKey: testSSHKey},
 			wantErr: true,
 		},
 	}
@@ -323,7 +480,7 @@ B29lX8k9dqD0HitCL6ibsw0DqsU6FC3fd179rH8Bik83FuukuxvD
 		t.Run(tt.name, func(t *testing.T) {
 			c := tt.cluster
 			n := tt.node
-			if err := c.validateNode(&n); (err != nil) != tt.wantErr {
+			if err := c.validateNode(&n, field.NewPath("node")); (err != nil) != tt.wantErr {
 				t.Errorf("Cluster.validateNode() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -34,6 +34,9 @@ Name            | Required | Type      | Description
 `labels`        | false    | object    | Node labels.
 `taints`        | false    | `[]Taint` | Node taints.
 
+`annotations`, `labels`, and `taints` are added or updated, but not removed.
+This is because other applications may edit their own annotations, labels, or taints.
+
 Taint
 -----
 

--- a/mtest/setup-cke.sh
+++ b/mtest/setup-cke.sh
@@ -109,10 +109,12 @@ EOF
 install_cke_configs
 
 if [ $(hostname) = 'host1' ]; then
-    run_etcd
-    sleep 1
-    run_vault
-    install_kubectl_config
+    if [ ! -f $HOME/.kube/config ]; then
+        run_etcd
+        sleep 1
+        run_vault
+        install_kubectl_config
+    fi
 fi
 
 cat <<EOF

--- a/mtest/suite_test.go
+++ b/mtest/suite_test.go
@@ -37,23 +37,7 @@ var _ = BeforeSuite(func() {
 		execSafeAt(h, "sync")
 	}
 
-	// wait cke
-	Eventually(func() error {
-		_, _, err := execAt(host1, "test", "-f", "/data/setup-cke.sh")
-		if err != nil {
-			return err
-		}
-		_, _, err = execAt(host2, "test", "-f", "/data/setup-cke.sh")
-		return err
-	}).Should(Succeed())
-
-	err = stopManagementEtcd(sshClients[host1])
-	Expect(err).NotTo(HaveOccurred())
-	err = stopVault(sshClients[host1])
-	Expect(err).NotTo(HaveOccurred())
-
 	for _, h := range []string{host1, host2} {
-		//execSafeAt(h, "/data/setup-cke.sh")
 		_, stderr, err := execAt(h, "/data/setup-cke.sh")
 		if err != nil {
 			fmt.Println("err!!!", string(stderr))

--- a/op/kube_node_update.go
+++ b/op/kube_node_update.go
@@ -1,0 +1,66 @@
+package op
+
+import (
+	"context"
+	"strings"
+
+	"github.com/cybozu-go/cke"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type kubeNodeUpdate struct {
+	apiserver *cke.Node
+	nodes     []*corev1.Node
+	done      bool
+}
+
+// KubeNodeUpdateOp updates k8s Node resources.
+func KubeNodeUpdateOp(apiserver *cke.Node, nodes []*corev1.Node) cke.Operator {
+	return &kubeNodeUpdate{apiserver: apiserver, nodes: nodes}
+}
+
+func (o *kubeNodeUpdate) Name() string {
+	return "update-node"
+}
+
+func (o *kubeNodeUpdate) NextCommand() cke.Commander {
+	if o.done {
+		return nil
+	}
+
+	o.done = true
+	return nodeUpdateCommand{o.apiserver, o.nodes}
+}
+
+type nodeUpdateCommand struct {
+	apiserver *cke.Node
+	nodes     []*corev1.Node
+}
+
+func (c nodeUpdateCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+	cs, err := inf.K8sClient(ctx, c.apiserver)
+	if err != nil {
+		return err
+	}
+
+	nodesAPI := cs.CoreV1().Nodes()
+	for _, n := range c.nodes {
+		_, err := nodesAPI.Update(n)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c nodeUpdateCommand) Command() cke.Command {
+	names := make([]string, len(c.nodes))
+	for i, n := range c.nodes {
+		names[i] = n.Name
+	}
+	return cke.Command{
+		Name:   "updateNode",
+		Target: strings.Join(names, ","),
+	}
+}

--- a/server/node_filter.go
+++ b/server/node_filter.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/cybozu-go/cke"
 	"github.com/cybozu-go/cke/op"
+	"github.com/cybozu-go/log"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // NodeFilter filters nodes to
@@ -418,4 +420,91 @@ func (nf *NodeFilter) HealthyAPIServer() *cke.Node {
 		}
 	}
 	return node
+}
+
+// OutdatedAttrsNodes returns nodes that have outdated set of labels,
+// attributes, and/or taints.
+func (nf *NodeFilter) OutdatedAttrsNodes() (nodes []*corev1.Node) {
+	curNodes := make(map[string]*corev1.Node)
+	for _, cn := range nf.status.Kubernetes.Nodes {
+		curNodes[cn.Name] = &cn
+	}
+
+	for _, n := range nf.cluster.Nodes {
+		current, ok := curNodes[n.Nodename()]
+		if !ok {
+			log.Warn("missing Kubernetes Node resource", map[string]interface{}{
+				"name":    n.Nodename(),
+				"address": n.Address,
+			})
+			continue
+		}
+
+		if nodeIsOutdated(n, current) {
+			newNode := current.DeepCopy()
+			for k, v := range n.Labels {
+				if newNode.Labels == nil {
+					newNode.Labels = make(map[string]string)
+				}
+				newNode.Labels[k] = v
+			}
+			for k, v := range n.Annotations {
+				if newNode.Annotations == nil {
+					newNode.Annotations = make(map[string]string)
+				}
+				newNode.Annotations[k] = v
+			}
+
+		OUTER:
+			for _, taint := range n.Taints {
+				for i, ct := range newNode.Spec.Taints {
+					if taint.Key == ct.Key {
+						newNode.Spec.Taints[i].Value = taint.Value
+						newNode.Spec.Taints[i].Effect = taint.Effect
+						continue OUTER
+					}
+				}
+				newNode.Spec.Taints = append(newNode.Spec.Taints, taint)
+			}
+
+			nodes = append(nodes, newNode)
+		}
+	}
+
+	return nodes
+}
+
+func nodeIsOutdated(n *cke.Node, current *corev1.Node) bool {
+	for k, v := range n.Labels {
+		cv, ok := current.Labels[k]
+		if !ok || v != cv {
+			return true
+		}
+	}
+
+	for k, v := range n.Annotations {
+		cv, ok := current.Annotations[k]
+		if !ok || v != cv {
+			return true
+		}
+	}
+
+	curTaints := make(map[string]corev1.Taint)
+	for _, taint := range current.Spec.Taints {
+		curTaints[taint.Key] = taint
+	}
+	for _, taint := range n.Taints {
+		cv, ok := curTaints[taint.Key]
+		if !ok {
+			return true
+		}
+		if taint.Value != cv.Value {
+			return true
+		}
+		if taint.Effect != cv.Effect {
+			return true
+		}
+	}
+
+	return false
 }

--- a/server/strategy.go
+++ b/server/strategy.go
@@ -155,7 +155,11 @@ func k8sMaintOps(cs *cke.ClusterStatus, nf *NodeFilter) (ops []cke.Operator) {
 		ops = append(ops, epOp)
 	}
 
-	// TODO: maintain Node resources
+	if nodes := nf.OutdatedAttrsNodes(); len(nodes) > 0 {
+		ops = append(ops, op.KubeNodeUpdateOp(apiServer, nodes))
+	}
+
+	// TODO: remove non-existent Node resources
 	return ops
 }
 

--- a/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func ValidateLabelSelector(ps *metav1.LabelSelector, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if ps == nil {
+		return allErrs
+	}
+	allErrs = append(allErrs, ValidateLabels(ps.MatchLabels, fldPath.Child("matchLabels"))...)
+	for i, expr := range ps.MatchExpressions {
+		allErrs = append(allErrs, ValidateLabelSelectorRequirement(expr, fldPath.Child("matchExpressions").Index(i))...)
+	}
+	return allErrs
+}
+
+func ValidateLabelSelectorRequirement(sr metav1.LabelSelectorRequirement, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	switch sr.Operator {
+	case metav1.LabelSelectorOpIn, metav1.LabelSelectorOpNotIn:
+		if len(sr.Values) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("values"), "must be specified when `operator` is 'In' or 'NotIn'"))
+		}
+	case metav1.LabelSelectorOpExists, metav1.LabelSelectorOpDoesNotExist:
+		if len(sr.Values) > 0 {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("values"), "may not be specified when `operator` is 'Exists' or 'DoesNotExist'"))
+		}
+	default:
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("operator"), sr.Operator, "not a valid selector operator"))
+	}
+	allErrs = append(allErrs, ValidateLabelName(sr.Key, fldPath.Child("key"))...)
+	return allErrs
+}
+
+// ValidateLabelName validates that the label name is correctly defined.
+func ValidateLabelName(labelName string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for _, msg := range validation.IsQualifiedName(labelName) {
+		allErrs = append(allErrs, field.Invalid(fldPath, labelName, msg))
+	}
+	return allErrs
+}
+
+// ValidateLabels validates that a set of labels are correctly defined.
+func ValidateLabels(labels map[string]string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for k, v := range labels {
+		allErrs = append(allErrs, ValidateLabelName(k, fldPath)...)
+		for _, msg := range validation.IsValidLabelValue(v) {
+			allErrs = append(allErrs, field.Invalid(fldPath, v, msg))
+		}
+	}
+	return allErrs
+}
+
+func ValidateDeleteOptions(options *metav1.DeleteOptions) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if options.OrphanDependents != nil && options.PropagationPolicy != nil {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("propagationPolicy"), options.PropagationPolicy, "orphanDependents and deletionPropagation cannot be both set"))
+	}
+	if options.PropagationPolicy != nil &&
+		*options.PropagationPolicy != metav1.DeletePropagationForeground &&
+		*options.PropagationPolicy != metav1.DeletePropagationBackground &&
+		*options.PropagationPolicy != metav1.DeletePropagationOrphan {
+		allErrs = append(allErrs, field.NotSupported(field.NewPath("propagationPolicy"), options.PropagationPolicy, []string{string(metav1.DeletePropagationForeground), string(metav1.DeletePropagationBackground), string(metav1.DeletePropagationOrphan), "nil"}))
+	}
+	return allErrs
+}
+
+const UninitializedStatusUpdateErrorMsg string = `must not update status when the object is uninitialized`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -11,9 +11,9 @@ contrib.go.opencensus.io/exporter/stackdriver/propagation
 # github.com/coreos/etcd v3.3.9+incompatible
 github.com/coreos/etcd/clientv3
 github.com/coreos/etcd/clientv3/clientv3util
-github.com/coreos/etcd/clientv3/concurrency
-github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes
 github.com/coreos/etcd/etcdserver/etcdserverpb
+github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes
+github.com/coreos/etcd/clientv3/concurrency
 github.com/coreos/etcd/auth/authpb
 github.com/coreos/etcd/mvcc/mvccpb
 github.com/coreos/etcd/pkg/types
@@ -323,6 +323,9 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apimachinery v0.0.0-20180904193909-def12e63c512
+k8s.io/apimachinery/pkg/apis/meta/v1/validation
+k8s.io/apimachinery/pkg/util/validation
+k8s.io/apimachinery/pkg/util/validation/field
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/api/resource
@@ -330,28 +333,26 @@ k8s.io/apimachinery/pkg/runtime
 k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/types
 k8s.io/apimachinery/pkg/util/intstr
-k8s.io/apimachinery/pkg/util/validation/field
+k8s.io/apimachinery/pkg/util/errors
+k8s.io/apimachinery/pkg/util/sets
+k8s.io/apimachinery/pkg/runtime/serializer/streaming
+k8s.io/apimachinery/pkg/util/net
+k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/pkg/conversion
 k8s.io/apimachinery/pkg/fields
 k8s.io/apimachinery/pkg/labels
 k8s.io/apimachinery/pkg/selection
-k8s.io/apimachinery/pkg/watch
-k8s.io/apimachinery/pkg/runtime/serializer/streaming
-k8s.io/apimachinery/pkg/util/net
-k8s.io/apimachinery/pkg/util/sets
-k8s.io/apimachinery/pkg/util/errors
-k8s.io/apimachinery/pkg/util/validation
 k8s.io/apimachinery/pkg/conversion/queryparams
 k8s.io/apimachinery/pkg/util/json
 k8s.io/apimachinery/pkg/util/runtime
-k8s.io/apimachinery/third_party/forked/golang/reflect
-k8s.io/apimachinery/pkg/util/wait
 k8s.io/apimachinery/pkg/runtime/serializer
 k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/util/clock
+k8s.io/apimachinery/pkg/util/wait
 k8s.io/apimachinery/pkg/runtime/serializer/json
 k8s.io/apimachinery/pkg/runtime/serializer/versioning
+k8s.io/apimachinery/third_party/forked/golang/reflect
 k8s.io/apimachinery/pkg/runtime/serializer/protobuf
 k8s.io/apimachinery/pkg/runtime/serializer/recognizer
 k8s.io/apimachinery/pkg/apis/meta/v1beta1
@@ -361,8 +362,8 @@ k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
 # k8s.io/client-go v2.0.0-alpha.0.0.20180821074022-f2f85107cac6+incompatible
 k8s.io/client-go/kubernetes
 k8s.io/client-go/rest
-k8s.io/client-go/tools/clientcmd
 k8s.io/client-go/tools/clientcmd/api
+k8s.io/client-go/tools/clientcmd
 k8s.io/client-go/util/homedir
 k8s.io/client-go/discovery
 k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1


### PR DESCRIPTION
This series of commits implement:

* validations for miscellaneous items in cluster.yml
* update Kubernetes `Node` resources to have annotations, labels, and taints specified in cluster.yml

Annotations, labels, and taints of nodes are added or updated but not removed.
This is because other applications may add their own annotations, labels, or taints.