### PR TITLE
Update Go modules for Go 1.11.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,6 @@ require (
 	gopkg.in/yaml.v2 v2.2.1
 	gotest.tools v2.1.0+incompatible // indirect
 	k8s.io/api v0.0.0-20180904230853-4e7be11eab3f
-	k8s.io/apimachinery v0.0.0-20180904193909-def12e63c512
-	k8s.io/client-go v2.0.0-alpha.0.0.20180821074022-f2f85107cac6+incompatible
+	k8s.io/apimachinery v0.0.0-20181026144827-8ee1a638bafa
+	k8s.io/client-go v8.0.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -341,7 +341,7 @@ gotest.tools v2.1.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/api v0.0.0-20180904230853-4e7be11eab3f h1:DLRkv8Ps4Sdx8Srj+UtGisj4whV7v/HezlHx6QqiZqE=
 k8s.io/api v0.0.0-20180904230853-4e7be11eab3f/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
-k8s.io/apimachinery v0.0.0-20180904193909-def12e63c512 h1:/Z1m/6oEN6hE2SzWP4BHW2yATeUrBRr+1GxNf1Ny58Y=
-k8s.io/apimachinery v0.0.0-20180904193909-def12e63c512/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
-k8s.io/client-go v2.0.0-alpha.0.0.20180821074022-f2f85107cac6+incompatible h1:6ddQDNaV+7SQmePpW9k3xaK57gHf9vhHIzThzo4ci1A=
-k8s.io/client-go v2.0.0-alpha.0.0.20180821074022-f2f85107cac6+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
+k8s.io/apimachinery v0.0.0-20181026144827-8ee1a638bafa h1:i0EOpPFWExNx7efINILpw8LJeah7gakRl1zjvwVfjiI=
+k8s.io/apimachinery v0.0.0-20181026144827-8ee1a638bafa/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
+k8s.io/client-go v8.0.0+incompatible h1:tTI4hRmb1DRMl4fG6Vclfdi6nTM82oIrTT7HfitmxC4=
+k8s.io/client-go v8.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=

--- a/vendor/k8s.io/client-go/pkg/version/base.go
+++ b/vendor/k8s.io/client-go/pkg/version/base.go
@@ -55,8 +55,8 @@ var (
 	// NOTE: The $Format strings are replaced during 'git archive' thanks to the
 	// companion .gitattributes file containing 'export-subst' in this same
 	// directory.  See also https://git-scm.com/docs/gitattributes
-	gitVersion   string = "v0.0.0-master+f2f85107"
-	gitCommit    string = "f2f85107cac6fe04c30435ca0ac0c3318fd1b94c" // sha1 from git, output of $(git rev-parse HEAD)
+	gitVersion   string = "v0.0.0-master+$Format:%h$"
+	gitCommit    string = "$Format:%H$" // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = ""            // state of git tree, either "clean" or "dirty"
 
 	buildDate string = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')

--- a/vendor/k8s.io/client-go/transport/round_trippers.go
+++ b/vendor/k8s.io/client-go/transport/round_trippers.go
@@ -129,7 +129,7 @@ func SetAuthProxyHeaders(req *http.Request, username string, groups []string, ex
 	}
 	for key, values := range extra {
 		for _, value := range values {
-			req.Header.Add("X-Remote-Extra-"+headerKeyEscape(key), value)
+			req.Header.Add("X-Remote-Extra-"+key, value)
 		}
 	}
 }
@@ -246,7 +246,7 @@ func (rt *impersonatingRoundTripper) RoundTrip(req *http.Request) (*http.Respons
 	}
 	for k, vv := range rt.impersonate.Extra {
 		for _, v := range vv {
-			req.Header.Add(ImpersonateUserExtraHeaderPrefix+headerKeyEscape(k), v)
+			req.Header.Add(ImpersonateUserExtraHeaderPrefix+k, v)
 		}
 	}
 
@@ -421,111 +421,4 @@ func (rt *debuggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 
 func (rt *debuggingRoundTripper) WrappedRoundTripper() http.RoundTripper {
 	return rt.delegatedRoundTripper
-}
-
-func legalHeaderByte(b byte) bool {
-	return int(b) < len(legalHeaderKeyBytes) && legalHeaderKeyBytes[b]
-}
-
-func shouldEscape(b byte) bool {
-	// url.PathUnescape() returns an error if any '%' is not followed by two
-	// hexadecimal digits, so we'll intentionally encode it.
-	return !legalHeaderByte(b) || b == '%'
-}
-
-func headerKeyEscape(key string) string {
-	buf := strings.Builder{}
-	for i := 0; i < len(key); i++ {
-		b := key[i]
-		if shouldEscape(b) {
-			// %-encode bytes that should be escaped:
-			// https://tools.ietf.org/html/rfc3986#section-2.1
-			fmt.Fprintf(&buf, "%%%02X", b)
-			continue
-		}
-		buf.WriteByte(b)
-	}
-	return buf.String()
-}
-
-// legalHeaderKeyBytes was copied from net/http/lex.go's isTokenTable.
-// See https://httpwg.github.io/specs/rfc7230.html#rule.token.separators
-var legalHeaderKeyBytes = [127]bool{
-	'%':  true,
-	'!':  true,
-	'#':  true,
-	'$':  true,
-	'&':  true,
-	'\'': true,
-	'*':  true,
-	'+':  true,
-	'-':  true,
-	'.':  true,
-	'0':  true,
-	'1':  true,
-	'2':  true,
-	'3':  true,
-	'4':  true,
-	'5':  true,
-	'6':  true,
-	'7':  true,
-	'8':  true,
-	'9':  true,
-	'A':  true,
-	'B':  true,
-	'C':  true,
-	'D':  true,
-	'E':  true,
-	'F':  true,
-	'G':  true,
-	'H':  true,
-	'I':  true,
-	'J':  true,
-	'K':  true,
-	'L':  true,
-	'M':  true,
-	'N':  true,
-	'O':  true,
-	'P':  true,
-	'Q':  true,
-	'R':  true,
-	'S':  true,
-	'T':  true,
-	'U':  true,
-	'W':  true,
-	'V':  true,
-	'X':  true,
-	'Y':  true,
-	'Z':  true,
-	'^':  true,
-	'_':  true,
-	'`':  true,
-	'a':  true,
-	'b':  true,
-	'c':  true,
-	'd':  true,
-	'e':  true,
-	'f':  true,
-	'g':  true,
-	'h':  true,
-	'i':  true,
-	'j':  true,
-	'k':  true,
-	'l':  true,
-	'm':  true,
-	'n':  true,
-	'o':  true,
-	'p':  true,
-	'q':  true,
-	'r':  true,
-	's':  true,
-	't':  true,
-	'u':  true,
-	'v':  true,
-	'w':  true,
-	'x':  true,
-	'y':  true,
-	'z':  true,
-	'|':  true,
-	'~':  true,
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -322,7 +322,7 @@ k8s.io/api/settings/v1alpha1
 k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
-# k8s.io/apimachinery v0.0.0-20180904193909-def12e63c512
+# k8s.io/apimachinery v0.0.0-20181026144827-8ee1a638bafa
 k8s.io/apimachinery/pkg/apis/meta/v1/validation
 k8s.io/apimachinery/pkg/util/validation
 k8s.io/apimachinery/pkg/util/validation/field
@@ -359,7 +359,7 @@ k8s.io/apimachinery/pkg/apis/meta/v1beta1
 k8s.io/apimachinery/pkg/util/framer
 k8s.io/apimachinery/pkg/util/yaml
 k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
-# k8s.io/client-go v2.0.0-alpha.0.0.20180821074022-f2f85107cac6+incompatible
+# k8s.io/client-go v8.0.0+incompatible
 k8s.io/client-go/kubernetes
 k8s.io/client-go/rest
 k8s.io/client-go/tools/clientcmd/api


### PR DESCRIPTION
Go 1.11.2 fixes unstable checksum for k8s.io modules.
Unfortunatelly, to correct wrong checksum in go.sum, the dependencies
need to be re-acquired once.

This commit does following:
1. go get k8s.io/client-go@v8.0.0
2. go get k8s.io/api@release-1.11
3. go get k8s.io/apimachinery@release-1.11
4. go mod tidy
5. go mod vendor
6. git add -f vendor go.mod go.sum