### PR TITLE
Update hyperkube container to k8s 1.12.3

### DIFF
--- a/images.go
+++ b/images.go
@@ -12,7 +12,7 @@ func (i Image) Name() string {
 const (
 	EtcdImage      = Image("quay.io/cybozu/etcd:3.3.9-4")
 	ToolsImage     = Image("quay.io/cybozu/cke-tools:1.2.1-1")
-	HyperkubeImage = Image("quay.io/cybozu/hyperkube:1.12.2-1")
+	HyperkubeImage = Image("quay.io/cybozu/hyperkube:1.12.3-2")
 	PauseImage     = Image("quay.io/cybozu/pause:3.1-2")
 	CoreDNSImage   = Image("quay.io/cybozu/coredns:1.2.5-1")
 	UnboundImage   = Image("quay.io/cybozu/unbound:1.8.1-2")


### PR DESCRIPTION
to resolve critical security issue CVE-2018-1002105.