### PR TITLE
Add "dns_service" to cluster definition

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -123,6 +123,7 @@ type Cluster struct {
 	ServiceSubnet string   `json:"service_subnet" yaml:"service_subnet"`
 	PodSubnet     string   `json:"pod_subnet"     yaml:"pod_subnet"`
 	DNSServers    []string `json:"dns_servers"    yaml:"dns_servers"`
+	DNSService    string   `json:"dns_service"    yaml:"dns_service"`
 	Options       Options  `json:"options"        yaml:"options"`
 }
 
@@ -152,6 +153,13 @@ func (c *Cluster) Validate() error {
 	for _, a := range c.DNSServers {
 		if net.ParseIP(a) == nil {
 			return errors.New("invalid IP address: " + a)
+		}
+	}
+
+	if len(c.DNSService) > 0 {
+		fields := strings.Split(c.DNSService, "/")
+		if len(fields) != 2 {
+			return errors.New("invalid DNS service (no namespace?): " + c.DNSService)
 		}
 	}
 

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -24,6 +24,7 @@ nodes:
 service_subnet: 12.34.56.00/24
 pod_subnet: 10.1.0.0/16
 dns_servers: ["1.1.1.1", "8.8.8.8"]
+dns_service: kube-system/dns
 options:
   etcd:
     volume_name: myetcd
@@ -94,6 +95,9 @@ options:
 	}
 	if !reflect.DeepEqual(c.DNSServers, []string{"1.1.1.1", "8.8.8.8"}) {
 		t.Error(`!reflect.DeepEqual(c.DNSServers, []string{"1.1.1.1", "8.8.8.8"})`)
+	}
+	if c.DNSService != "kube-system/dns" {
+		t.Error(`c.DNSService != "kube-system/dns"`)
 	}
 
 	if c.Options.Etcd.VolumeName != "myetcd" {
@@ -174,6 +178,16 @@ func testClusterValidate(t *testing.T) {
 				ServiceSubnet: "10.0.0.0/14",
 				PodSubnet:     "10.1.0.0/16",
 				DNSServers:    []string{"a.b.c.d"},
+			},
+			true,
+		},
+		{
+			"invalid DNS service name",
+			Cluster{
+				Name:          "testcluster",
+				ServiceSubnet: "10.0.0.0/14",
+				PodSubnet:     "10.1.0.0/16",
+				DNSService:    "hoge",
 			},
 			true,
 		},
@@ -277,6 +291,7 @@ func testClusterValidate(t *testing.T) {
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
 				PodSubnet:     "10.1.0.0/16",
+				DNSService:    "kube-system/dns",
 				Options: Options{
 					Kubelet: KubeletParams{
 						Domain: "cybozu.com",

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -12,10 +12,15 @@ Name            | Required | Type      | Description
 `service_subnet`| true     | string    | CIDR subnet for k8s `Service`.
 `pod_subnet`    | true     | string    | CIDR subnet for k8s `Pod`.
 `dns_servers`   | false    | array     | List of upstream DNS server IP addresses.
+`dns_service`   | false    | string    | Upstream DNS service name with namespace as `namespace/service`.
 `options`       | false    | `Options` | See options.
 
 * IP addresses in `pod_subnet` are only used for host-local communication
   as a fallback CNI plugin.  They are never seen from outside of the cluster.
+* Upstream DNS servers can be specified one of the following ways:
+    * List server IP addresses in `dns_servers`.
+    * Specify Kubernetes `Service` name in `dns_service` (e.g. `"kube-system/dns"`).  
+      The service type must be `ClusterIP`.
 
 Node
 ----

--- a/server/get_status.go
+++ b/server/get_status.go
@@ -69,7 +69,7 @@ func (c Controller) GetClusterStatus(ctx context.Context, cluster *cke.Cluster, 
 	}
 
 	if livingMaster != nil {
-		cs.Kubernetes, err = op.GetKubernetesClusterStatus(ctx, inf, livingMaster)
+		cs.Kubernetes, err = op.GetKubernetesClusterStatus(ctx, inf, livingMaster, cluster)
 		if err != nil {
 			log.Error("failed to get kubernetes cluster status", map[string]interface{}{
 				log.FnError: err,

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -215,7 +215,6 @@ func (d testData) withK8sRBACReady() testData {
 
 func (d testData) withK8sClusterDNSReady(dnsServers []string, clusterDomain, clusterIP string) testData {
 	d.withK8sRBACReady()
-	d.Status.Kubernetes.DNSServers = dnsServers
 	d.Status.Kubernetes.ClusterDNS.ServiceAccountExists = true
 	d.Status.Kubernetes.ClusterDNS.RBACRoleExists = true
 	d.Status.Kubernetes.ClusterDNS.RBACRoleBindingExists = true
@@ -543,6 +542,18 @@ func TestDecideOps(t *testing.T) {
 				"create-etcd-endpoints",
 				"create-node-dns-configmap",
 				"create-node-dns-daemonset",
+			},
+		},
+		{
+			Name: "UpdateDNSService",
+			Input: newData().withEtcdEndpoints().with(func(d testData) {
+				svc := &corev1.Service{}
+				svc.Spec.ClusterIP = "1.1.1.1"
+				d.Status.Kubernetes.DNSService = svc
+			}),
+			ExpectedOps: []string{
+				"update-cluster-dns-configmap",
+				"update-node-dns-configmap",
 			},
 		},
 		{

--- a/status.go
+++ b/status.go
@@ -38,7 +38,7 @@ type KubernetesClusterStatus struct {
 	Nodes                 []corev1.Node
 	RBACRoleExists        bool
 	RBACRoleBindingExists bool
-	DNSServers            []string
+	DNSService            *corev1.Service
 	ClusterDNS            ClusterDNSStatus
 	NodeDNS               NodeDNSStatus
 	EtcdEndpoints         *corev1.Endpoints


### PR DESCRIPTION
If given, dns_service must be a Kubernetes service name referencing
upstream full DNS resolver.  Its ClusterIP will be set for cluster
and node-local DNS services as an upstream server address.