### PR TITLE
Send container logs to journald

### DIFF
--- a/container.go
+++ b/container.go
@@ -83,6 +83,7 @@ func (c docker) Run(img Image, binds []Mount, command string) error {
 	args := []string{
 		"docker",
 		"run",
+		"--log-driver=journald",
 		"--rm",
 		"--network=host",
 		"--uts=host",
@@ -105,6 +106,7 @@ func (c docker) RunWithInput(img Image, binds []Mount, command, input string) er
 	args := []string{
 		"docker",
 		"run",
+		"--log-driver=journald",
 		"--rm",
 		"-i",
 		"--network=host",
@@ -139,6 +141,7 @@ func (c docker) RunSystem(name string, img Image, opts []string, params, extra S
 	args := []string{
 		"docker",
 		"run",
+		"--log-driver=journald",
 		"-d",
 		"--name=" + name,
 		"--read-only",

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,27 @@
+Logging
+=======
+
+CKE logs
+--------
+
+`cke` is built on [github.com/cybozu-go/well][well] framework that provides [standard logging options](https://github.com/cybozu-go/well#command-line-options).
+
+In addition, CKE records recent important operations in etcd.  Use [`ckecli history`](ckecli.md) to view them.
+
+Kubernetes programs
+-------------------
+
+CKE runs Kubernetes programs such as `apiserver` or `kubelet` by `docker run --log-driver=journald`
+to send their logs to `journald`.
+
+To view logs of a program, use `journalctl` as follows:
+
+```console
+$ sudo journalctl CONTAINER_NAME=kube-apiserver
+```
+
+Container names are defined in [op/constants.go](../op/constants.go).
+
+Ref: https://docs.docker.com/config/containers/logging/journald/#retrieve-log-messages-with-journalctl
+
+[well]: https://github.com/cybozu-go/well

--- a/op/k8s/config.go
+++ b/op/k8s/config.go
@@ -59,6 +59,7 @@ type KubeletConfiguration struct {
 
 	HealthzPort           int32    `json:"healthzPort,omitempty" yaml:"healthzPort,omitempty"`
 	HealthzBindAddress    string   `json:"healthzBindAddress,omitempty" yaml:"healthzBindAddress,omitempty"`
+	OOMScoreAdj           int32    `json:"oomScoreAdj" yaml:"oomScoreAdj"`
 	ClusterDomain         string   `json:"clusterDomain,omitempty" yaml:"clusterDomain,omitempty"`
 	ClusterDNS            []string `json:"clusterDNS,omitempty" yaml:"clusterDNS,omitempty"`
 	PodCIDR               string   `json:"podCIDR,omitempty" yaml:"podCIDR,omitempty"`

--- a/op/k8s/controller_manager_boot.go
+++ b/op/k8s/controller_manager_boot.go
@@ -42,17 +42,11 @@ func (o *controllerManagerBootOp) NextCommand() cke.Commander {
 		return common.ImagePullCommand(o.nodes, cke.HyperkubeImage)
 	case 1:
 		o.step++
-		dirs := []string{
-			"/var/log/kubernetes/controller-manager",
-		}
-		return common.MakeDirsCommand(o.nodes, dirs)
+		return prepareControllerManagerFilesCommand{o.cluster, o.files}
 	case 2:
 		o.step++
-		return prepareControllerManagerFilesCommand{o.cluster, o.files}
-	case 3:
-		o.step++
 		return o.files
-	case 4:
+	case 3:
 		o.step++
 		return common.RunContainerCommand(o.nodes,
 			op.KubeControllerManagerContainerName, cke.HyperkubeImage,
@@ -113,8 +107,6 @@ func ControllerManagerParams(clusterName, serviceSubnet string) cke.ServiceParam
 		"--cluster-name=" + clusterName,
 		"--service-cluster-ip-range=" + serviceSubnet,
 		"--kubeconfig=/etc/kubernetes/controller-manager/kubeconfig",
-		"--log-dir=/var/log/kubernetes/controller-manager",
-		"--logtostderr=false",
 
 		// ToDo: cluster signing
 		// https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/#a-note-to-cluster-administrators
@@ -141,19 +133,15 @@ func ControllerManagerParams(clusterName, serviceSubnet string) cke.ServiceParam
 				Destination: "/etc/machine-id",
 				ReadOnly:    true,
 				Propagation: "",
-				Label:       ""},
+				Label:       "",
+			},
 			{
 				Source:      "/etc/kubernetes",
 				Destination: "/etc/kubernetes",
 				ReadOnly:    true,
 				Propagation: "",
-				Label:       cke.LabelShared},
-			{
-				Source:      "/var/log/kubernetes/controller-manager",
-				Destination: "/var/log/kubernetes/controller-manager",
-				ReadOnly:    false,
-				Propagation: "",
-				Label:       cke.LabelPrivate},
+				Label:       cke.LabelShared,
+			},
 		},
 	}
 }

--- a/op/k8s/proxy_boot.go
+++ b/op/k8s/proxy_boot.go
@@ -40,17 +40,11 @@ func (o *kubeProxyBootOp) NextCommand() cke.Commander {
 		return common.ImagePullCommand(o.nodes, cke.HyperkubeImage)
 	case 1:
 		o.step++
-		dirs := []string{
-			"/var/log/kubernetes/proxy",
-		}
-		return common.MakeDirsCommand(o.nodes, dirs)
+		return prepareProxyFilesCommand{o.cluster, o.files}
 	case 2:
 		o.step++
-		return prepareProxyFilesCommand{o.cluster, o.files}
-	case 3:
-		o.step++
 		return o.files
-	case 4:
+	case 3:
 		o.step++
 		opts := []string{
 			"--tmpfs=/run",
@@ -101,8 +95,6 @@ func ProxyParams() cke.ServiceParams {
 		"proxy",
 		"--proxy-mode=ipvs",
 		"--kubeconfig=/etc/kubernetes/proxy/kubeconfig",
-		"--log-dir=/var/log/kubernetes/proxy",
-		"--logtostderr=false",
 	}
 	return cke.ServiceParams{
 		ExtraArguments: args,
@@ -127,13 +119,6 @@ func ProxyParams() cke.ServiceParams {
 				ReadOnly:    true,
 				Propagation: "",
 				Label:       "",
-			},
-			{
-				Source:      "/var/log/kubernetes/proxy",
-				Destination: "/var/log/kubernetes/proxy",
-				ReadOnly:    false,
-				Propagation: "",
-				Label:       cke.LabelPrivate,
 			},
 		},
 	}

--- a/op/k8s/rivers_boot.go
+++ b/op/k8s/rivers_boot.go
@@ -35,9 +35,6 @@ func (o *riversBootOp) NextCommand() cke.Commander {
 		return common.ImagePullCommand(o.nodes, cke.ToolsImage)
 	case 1:
 		o.step++
-		return common.MakeDirsCommand(o.nodes, []string{"/var/log/rivers"})
-	case 2:
-		o.step++
 		return common.RunContainerCommand(o.nodes, op.RiversContainerName, cke.ToolsImage,
 			common.WithParams(RiversParams(o.upstreams)),
 			common.WithExtra(o.params))
@@ -57,16 +54,5 @@ func RiversParams(upstreams []*cke.Node) cke.ServiceParams {
 		"--upstreams=" + strings.Join(ups, ","),
 		"--listen=" + "127.0.0.1:16443",
 	}
-	return cke.ServiceParams{
-		ExtraArguments: args,
-		ExtraBinds: []cke.Mount{
-			{
-				Source:      "/var/log/rivers",
-				Destination: "/var/log/rivers",
-				ReadOnly:    false,
-				Propagation: "",
-				Label:       cke.LabelShared,
-			},
-		},
-	}
+	return cke.ServiceParams{ExtraArguments: args}
 }


### PR DESCRIPTION
For easy log collection and rotation, CKE switches to send
logs from its containers to journald instead of files.

Other minor changes include:
- kubelet's OOM score is adjusted to -1000 to avoid OOM killer.
- /var/lib/dockershim for kubelet becomes a plain host directory.