### PR TITLE
[ckecli] ssh/scp command can use all nodes regardless cluster member

### DIFF
--- a/docs/ckecli.md
+++ b/docs/ckecli.md
@@ -145,25 +145,21 @@ Option  | Default value | Description
 ------- | ------------- | -----------
 `--ttl` | `2h`          | TTL of the client certificate
 
-`ckecli ssh NODE [COMMAND...]`
+`ckecli ssh [user@]NODE [COMMAND...]`
 ------------------------------
 
 Connect to the node via ssh.
 
 `NODE` is IP address or hostname of the node to be connected.
-The node should be defined in the cluster definition.
-The user name defined in the cluster will be used.
 
 If `COMMAND` is specified, it will be executed on the node.
 
-`ckecli scp [-r] [NODE1:]FILE1 ... [NODE2:]FILE2`
+`ckecli scp [-r] [[user@]NODE1:]FILE1 ... [[user@]NODE2:]FILE2`
 -------------------------------------------------
 
 Copy files between hosts via scp.
 
 `NODE` is IP address or hostname of the node.
-The node should be defined in the cluster definition.
-The user name defined in the cluster will be used.
 
 Option  | Default value | Description
 ------- | ------------- | -----------

--- a/mtest/ckecli_test.go
+++ b/mtest/ckecli_test.go
@@ -59,9 +59,20 @@ var _ = Describe("ckecli", func() {
 		Expect(cmd.Run()).ShouldNot(HaveOccurred())
 	})
 
-	It("should connect to all nodes by ssh", func() {
+	It("should ssh to all nodes", func() {
 		for _, node := range []string{node1, node2, node3, node4, node5, node6} {
 			ckecli("ssh", "cybozu@"+node, "/bin/true")
+		}
+	})
+
+	It("should scp to all nodes", func() {
+		scpData := localTempFile("scpData")
+		for _, node := range []string{node1, node2, node3, node4, node5, node6} {
+			destName := scpData.Name() + node
+			ckecli("scp", scpData.Name(), "cybozu@"+node+":"+destName)
+			ckecli("scp", "cybozu@"+node+":"+destName, "/tmp/")
+			_, err := os.Stat(destName)
+			Expect(err).NotTo(HaveOccurred())
 		}
 	})
 })

--- a/mtest/ckecli_test.go
+++ b/mtest/ckecli_test.go
@@ -58,4 +58,11 @@ var _ = Describe("ckecli", func() {
 		cmd.Stderr = os.Stderr
 		Expect(cmd.Run()).ShouldNot(HaveOccurred())
 	})
+
+	It("should connect to all nodes", func() {
+		for _, node := range []string{node1, node2, node3, node4, node5, node6} {
+			ckecli("ssh", node, "/bin/true")
+			ckecli("ssh", "cybozu@"+node, "/bin/true")
+		}
+	})
 })

--- a/mtest/ckecli_test.go
+++ b/mtest/ckecli_test.go
@@ -59,9 +59,8 @@ var _ = Describe("ckecli", func() {
 		Expect(cmd.Run()).ShouldNot(HaveOccurred())
 	})
 
-	It("should connect to all nodes", func() {
+	It("should connect to all nodes by ssh", func() {
 		for _, node := range []string{node1, node2, node3, node4, node5, node6} {
-			ckecli("ssh", node, "/bin/true")
 			ckecli("ssh", "cybozu@"+node, "/bin/true")
 		}
 	})

--- a/mtest/ckecli_test.go
+++ b/mtest/ckecli_test.go
@@ -73,6 +73,7 @@ var _ = Describe("ckecli", func() {
 			ckecli("scp", "cybozu@"+node+":"+destName, "/tmp/")
 			_, err := os.Stat(destName)
 			Expect(err).NotTo(HaveOccurred())
+			os.Remove(destName)
 		}
 	})
 })

--- a/mtest/kubernetes_test.go
+++ b/mtest/kubernetes_test.go
@@ -275,10 +275,10 @@ var _ = Describe("Kubernetes", func() {
 			}
 
 			if len(jobs.Items) < 1 {
-				return errors.New("no etcd backup jobs")
+				return fmt.Errorf("no etcd backup jobs, JobList: %v", jobs)
 			}
 			if jobs.Items[0].Status.Succeeded != 1 {
-				return errors.New(".Succeeded is not 1")
+				return fmt.Errorf(".Succeeded is not 1, JobList: %v", jobs)
 			}
 
 			return nil

--- a/mtest/kubernetes_test.go
+++ b/mtest/kubernetes_test.go
@@ -126,11 +126,18 @@ var _ = Describe("Kubernetes", func() {
 		}).Should(Succeed())
 
 		By("resolving domain names")
-		_, stderr, err = kubectl("exec", "-n=mtest", "client", "getent", "hosts", "nginx")
-		Expect(err).NotTo(HaveOccurred(), "stderr: %s", stderr)
+		Eventually(func() error {
+			_, stderr, err := kubectl("exec", "-n=mtest", "client", "getent", "hosts", "nginx")
+			if err != nil {
+				return fmt.Errorf("%v: stderr=%s", err, stderr)
+			}
 
-		_, stderr, err = kubectl("exec", "-n=mtest", "client", "getent", "hosts", "nginx.mtest.svc.cluster.local")
-		Expect(err).NotTo(HaveOccurred(), "stderr: %s", stderr)
+			_, stderr, err = kubectl("exec", "-n=mtest", "client", "getent", "hosts", "nginx.mtest.svc.cluster.local")
+			if err != nil {
+				return fmt.Errorf("%v: stderr=%s", err, stderr)
+			}
+			return nil
+		}).Should(Succeed())
 	})
 
 	It("updates unbound config", func() {

--- a/pkg/ckecli/cmd/scp.go
+++ b/pkg/ckecli/cmd/scp.go
@@ -61,7 +61,7 @@ func scp(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	fifo, err := sshPrivateKey(node)
+	fifo, err := sshPrivateKey(node.Address)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ var scpParams struct {
 
 // scpCmd represents the scp command
 var scpCmd = &cobra.Command{
-	Use:   "scp [NODE1:]FILE1 ... [NODE2:]FILE2",
+	Use:   "scp [[user@]NODE1:]FILE1 ... [[user@]NODE2:]FILE2",
 	Short: "copy files between hosts via scp",
 	Long: `Copy files between hosts via scp.
 

--- a/pkg/ckecli/cmd/scp.go
+++ b/pkg/ckecli/cmd/scp.go
@@ -16,11 +16,7 @@ func detectSCPNode(args []string) (string, error) {
 	var nodeName string
 	for _, arg := range args {
 		if strings.Contains(arg, ":") {
-			var err error
-			nodeName, err = detectSSHNode(arg[:strings.Index(arg, ":")])
-			if err != nil {
-				return "", err
-			}
+			nodeName = detectSSHNode(arg[:strings.Index(arg, ":")])
 			break
 		}
 	}

--- a/pkg/ckecli/cmd/scp.go
+++ b/pkg/ckecli/cmd/scp.go
@@ -12,11 +12,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func detectNode(ctx context.Context, args []string) (string, error) {
+func detectSCPNode(args []string) (string, error) {
 	var nodeName string
 	for _, arg := range args {
 		if strings.Contains(arg, ":") {
-			nodeName = arg[:strings.Index(arg, ":")]
+			var err error
+			nodeName, err = detectSSHNode(arg[:strings.Index(arg, ":")])
+			if err != nil {
+				return "", err
+			}
 			break
 		}
 	}
@@ -29,11 +33,11 @@ func detectNode(ctx context.Context, args []string) (string, error) {
 }
 
 func scp(ctx context.Context, args []string) error {
-	sshAddress, err := detectNode(ctx, args)
+	node, err := detectSCPNode(args)
 	if err != nil {
 		return err
 	}
-	fifo, err := sshPrivateKey(sshAddress)
+	fifo, err := sshPrivateKey(node)
 	if err != nil {
 		return err
 	}

--- a/pkg/ckecli/cmd/scp.go
+++ b/pkg/ckecli/cmd/scp.go
@@ -43,6 +43,7 @@ func scp(ctx context.Context, args []string) error {
 		"-i", fifo,
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "StrictHostKeyChecking=no",
+		"-o", "ConnectTimeout=60",
 	}
 	if scpParams.recursive {
 		scpArgs = append(scpArgs, "-r")

--- a/pkg/ckecli/cmd/ssh.go
+++ b/pkg/ckecli/cmd/ssh.go
@@ -37,25 +37,7 @@ func writeToFifo(fifo string, data string) {
 	}
 }
 
-func resolveNode(ctx context.Context, nodeName string) (*cke.Node, error) {
-	cluster, err := storage.GetCluster(ctx)
-	if err != nil {
-		return nil, err
-	}
-	var node *cke.Node
-	for _, n := range cluster.Nodes {
-		if n.Hostname == nodeName || n.Address == nodeName {
-			node = n
-			break
-		}
-	}
-	if node == nil {
-		return nil, errors.New("the node is not defined in the cluster: " + nodeName)
-	}
-	return node, nil
-}
-
-func sshPrivateKey(node *cke.Node) (string, error) {
+func sshPrivateKey(nodeName string) (string, error) {
 	usr, err := user.Current()
 	if err != nil {
 		return "", err
@@ -83,12 +65,12 @@ func sshPrivateKey(node *cke.Node) (string, error) {
 	}
 	privKeys := secret.Data
 
-	mykey, ok := privKeys[node.Address]
+	mykey, ok := privKeys[nodeName]
 	if !ok {
 		mykey = privKeys[""]
 	}
 	if mykey == nil {
-		return "", errors.New("no ssh private key for " + node.Address)
+		return "", errors.New("no ssh private key for " + nodeName)
 	}
 
 	go func() {
@@ -102,12 +84,8 @@ func sshPrivateKey(node *cke.Node) (string, error) {
 }
 
 func ssh(ctx context.Context, args []string) error {
-	nodeName := args[0]
-	node, err := resolveNode(ctx, nodeName)
-	if err != nil {
-		return err
-	}
-	fifo, err := sshPrivateKey(node)
+	sshAddress := args[0]
+	fifo, err := sshPrivateKey(sshAddress)
 	if err != nil {
 		return err
 	}
@@ -117,7 +95,7 @@ func ssh(ctx context.Context, args []string) error {
 		"-i", fifo,
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "StrictHostKeyChecking=no",
-		node.User + "@" + node.Address,
+		sshAddress,
 	}
 	sshArgs = append(sshArgs, args[1:]...)
 	c := exec.Command("ssh", sshArgs...)
@@ -129,7 +107,7 @@ func ssh(ctx context.Context, args []string) error {
 
 // sshCmd represents the ssh command
 var sshCmd = &cobra.Command{
-	Use:   "ssh NODE [COMMAND...]",
+	Use:   "ssh [user@]NODE [COMMAND...]",
 	Short: "connect to the node via ssh",
 	Long: `Connect to the node via ssh.
 

--- a/pkg/ckecli/cmd/ssh.go
+++ b/pkg/ckecli/cmd/ssh.go
@@ -104,6 +104,7 @@ func ssh(ctx context.Context, args []string) error {
 		"-i", fifo,
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "StrictHostKeyChecking=no",
+		"-o", "ConnectTimeout=60",
 	}
 	sshArgs = append(sshArgs, args...)
 	c := exec.Command("ssh", sshArgs...)

--- a/pkg/ckecli/cmd/ssh.go
+++ b/pkg/ckecli/cmd/ssh.go
@@ -18,17 +18,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func detectSSHNode(arg string) (string, error) {
+func detectSSHNode(arg string) string {
 	nodeName := arg
 	if strings.Contains(arg, "@") {
 		nodeName = arg[strings.Index(arg, "@")+1:]
 	}
-
-	if len(nodeName) == 0 {
-		return "", errors.New("node name is not specified")
-	}
-
-	return nodeName, nil
+	return nodeName
 }
 
 func writeToFifo(fifo string, data string) {
@@ -98,10 +93,7 @@ func sshPrivateKey(nodeName string) (string, error) {
 }
 
 func ssh(ctx context.Context, args []string) error {
-	node, err := detectSSHNode(args[0])
-	if err != nil {
-		return err
-	}
+	node := detectSSHNode(args[0])
 	fifo, err := sshPrivateKey(node)
 	if err != nil {
 		return err


### PR DESCRIPTION
Background:
`ckecli ssh NODE` can use only node who is in the cluster member.
It is useless if user want to login to non-member node.

Expect:
`ckecli ssh` and `ckecli scp` can use all nodes regardless cluster
member.