### PR TITLE
add `--hostname-override` option to kube-proxy.

### DIFF
--- a/op/k8s/proxy_restart.go
+++ b/op/k8s/proxy_restart.go
@@ -41,9 +41,14 @@ func (o *kubeProxyRestartOp) NextCommand() cke.Commander {
 			"--tmpfs=/run",
 			"--privileged",
 		}
+		paramsMap := make(map[string]cke.ServiceParams)
+		for _, n := range o.nodes {
+			params := ProxyParams(n)
+			paramsMap[n.Address] = params
+		}
 		return common.RunContainerCommand(o.nodes, op.KubeProxyContainerName, cke.HyperkubeImage,
 			common.WithOpts(opts),
-			common.WithParams(ProxyParams()),
+			common.WithParamsMap(paramsMap),
 			common.WithExtra(o.params),
 			common.WithRestart())
 	}

--- a/server/node_filter.go
+++ b/server/node_filter.go
@@ -475,11 +475,11 @@ func (nf *NodeFilter) ProxyStoppedNodes() (nodes []*cke.Node) {
 
 // ProxyOutdatedNodes returns nodes that are running kube-proxy with outdated image or params.
 func (nf *NodeFilter) ProxyOutdatedNodes() (nodes []*cke.Node) {
-	currentBuiltIn := k8s.ProxyParams()
 	currentExtra := nf.cluster.Options.Proxy
 
 	for _, n := range nf.cluster.Nodes {
 		st := nf.nodeStatus(n).Proxy
+		currentBuiltIn := k8s.ProxyParams(n)
 		switch {
 		case !st.Running:
 			// stopped nodes are excluded

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -194,12 +194,12 @@ func (d testData) withKubelet(domain, dns string, allowSwap bool) testData {
 }
 
 func (d testData) withProxy() testData {
-	for _, v := range d.Status.NodeStatuses {
-		st := &v.Proxy
+	for _, n := range d.Cluster.Nodes {
+		st := &d.NodeStatus(n).Proxy
 		st.Running = true
 		st.IsHealthy = true
 		st.Image = cke.HyperkubeImage.Name()
-		st.BuiltInParams = k8s.ProxyParams()
+		st.BuiltInParams = k8s.ProxyParams(n)
 	}
 	return d
 }


### PR DESCRIPTION
Without this, `kube-proxy` fails to detect local pods for load balancers with
`externalTrafficPolicy` set to `Local`.