### PR TITLE
[op] retry image pull command to be more robust

### DIFF
--- a/mtest/kubernetes_test.go
+++ b/mtest/kubernetes_test.go
@@ -286,7 +286,7 @@ var _ = Describe("Kubernetes", func() {
 			if len(jobs.Items) < 1 {
 				return fmt.Errorf("no etcd backup jobs, JobList: %v", jobs)
 			}
-			if jobs.Items[0].Status.Succeeded != 1 {
+			if jobs.Items[len(jobs.Items)-1].Status.Succeeded != 1 {
 				return fmt.Errorf(".Succeeded is not 1, JobList: %v", jobs)
 			}
 


### PR DESCRIPTION
Image pull may sometimes fail for miscellaneous reasons.
It is safe to retry pull several times, so do it.