### PR TITLE
[op] Add NodeRestriction plugin

### DIFF
--- a/op/k8s/apiserver_boot.go
+++ b/op/k8s/apiserver_boot.go
@@ -25,6 +25,9 @@ var (
 		"MutatingAdmissionWebhook",
 		"ValidatingAdmissionWebhook",
 		"ResourceQuota",
+
+		// NodeRestriction is not in the list above, but added to restrict kubelet privilege.
+		"NodeRestriction",
 	}
 )
 


### PR DESCRIPTION
NodeRestriction plugin limit a kubelet to modify its own node or pods bound to itself.