### PR TITLE
Enable NodeRestriction Plugin

### DIFF
--- a/op/k8s/apiserver_boot.go
+++ b/op/k8s/apiserver_boot.go
@@ -25,6 +25,9 @@ var (
 		"MutatingAdmissionWebhook",
 		"ValidatingAdmissionWebhook",
 		"ResourceQuota",
+
+		// NodeRestriction is not in the list above, but added to restrict kubelet privilege.
+		"NodeRestriction",
 	}
 )
 

--- a/op/k8s/kubelet_boot.go
+++ b/op/k8s/kubelet_boot.go
@@ -16,6 +16,11 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
+const (
+	kubeconfigPath    = "/etc/kubernetes/kubelet/kubeconfig"
+	kubeletConfigPath = "/etc/kubernetes/kubelet/config.yml"
+)
+
 type kubeletBootOp struct {
 	nodes []*cke.Node
 
@@ -156,8 +161,6 @@ type prepareKubeletFilesCommand struct {
 }
 
 func (c prepareKubeletFilesCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
-	const kubeletConfigPath = "/etc/kubernetes/kubelet/config.yml"
-	const kubeconfigPath = "/etc/kubernetes/kubelet/kubeconfig"
 	caPath := op.K8sPKIPath("ca.crt")
 	tlsCertPath := op.K8sPKIPath("kubelet.crt")
 	tlsKeyPath := op.K8sPKIPath("kubelet.key")


### PR DESCRIPTION
- Add command line option to enable node restriction plugin
- Reissue client certs when kubelet and kube-proxy restarted, because the node name may change