### PR TITLE
Data encryption at rest

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,17 @@ Features
 
     Details are described in [docs/etcd.md](docs/etcd.md).
 
+* CRI runtimes
+
+    In addition to Docker, CRI runtimes such as [containerd][] or [cri-o][]
+    can be used to run Kubernetes Pods.
+
 * Cluster features:
 
     * HA control plane.
     * [RBAC][] is enabled.
     * Ready for [PodSecurityPolicy][]
+    * `Secret` data are [encrypted at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
     * [CNI][] network plugins.
     * [CoreDNS][] add-on.
     * Node-local DNS cache services.
@@ -101,6 +107,8 @@ CKE is licensed under MIT license.
 [godoc]: https://godoc.org/github.com/cybozu-go/cke
 [Kubernetes]: https://kubernetes.io/
 [etcd]: https://github.com/etcd-io/etcd
+[containerd]: https://containerd.io/
+[cri-o]: https://cri-o.io/
 [Vault]: https://www.vaultproject.io
 [RBAC]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 [PodSecurityPolicy]: https://kubernetes.io/docs/concepts/policy/pod-security-policy/

--- a/docs/ckecli.md
+++ b/docs/ckecli.md
@@ -62,7 +62,7 @@ FILE should be a SSH private key file.  If FILE is `-`, the contents are read fr
 
 Generate a new cipher key to encrypt Kubernetes [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/).
 
-An old key is retained for key rotation.
+The current key, if any, is retained for key rotation.  Old keys are removed.
 
 **WARNING**
 

--- a/docs/ckecli.md
+++ b/docs/ckecli.md
@@ -57,6 +57,22 @@ used as the default key.
 
 FILE should be a SSH private key file.  If FILE is `-`, the contents are read from stdin.
 
+`ckecli vault enckey`
+---------------------
+
+Generate a new cipher key to encrypt Kubernetes [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/).
+
+An old key is retained for key rotation.
+
+**WARNING**
+
+Key rotation is not automated in the current version.
+You need to restart API servers manually and replace all secrets as follows:
+
+```console
+$ kubectl get secrets --all-namespaces -o json | kubectl replace -f -
+```
+
 `ckecli ca set NAME PEM`
 ------------------------
 
@@ -170,7 +186,7 @@ If `FILE` is "-", then resources are read from stdin.
 Note that Kubernetes resources will not be removed automatically.
 
 `ckecli ssh [user@]NODE [COMMAND...]`
-------------------------------
+-------------------------------------
 
 Connect to the node via ssh.
 
@@ -179,7 +195,7 @@ Connect to the node via ssh.
 If `COMMAND` is specified, it will be executed on the node.
 
 `ckecli scp [-r] [[user@]NODE1:]FILE1 ... [[user@]NODE2:]FILE2`
--------------------------------------------------
+---------------------------------------------------------------
 
 Copy files between hosts via scp.
 

--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -40,7 +40,7 @@ Data encryption at rest
 -----------------------
 
 Kubernetes can encrypt data at rest, i.e. data stored in [etcd][].
-For details, take a look at [Encrypting Secret Data at Rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#providers).
+For details, take a look at [Encrypting Secret Data at Rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
 
 CKE automatically encrypts [Secret][] resource data.  The encryption key is generated and
 stored in Vault.  The secret provider is currently `aescbc`.  `kms` provider is not used

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -27,12 +27,18 @@ Additionally, `kv` secret engine version 1 is mounted at `cke/secrets`.
 
 ## Secrets in `cke/secrets`
 
-Currently, there is only one secret `ssh` to hold SSH private keys
-to logging in to nodes.
+Currently, there are two secrets in `cke/secrets`.
+
+One is `ssh` that holds SSH private keys to logging in to nodes.
+Another is `k8s` that holds cipher keys to [encrypt data at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
 
 A secret in Vault can keep arbitrary number of key-value pairs.
+
 Keys in `ssh` are node addresses.  Empty key holds the default SSH
 private key used if matching key for the host is not found.
+
+Keys in `k8s` are provider names such as `aescbc` or `secretbox`.
+Values are JSON data of cipher keys.
 
 ## Policy
 

--- a/op/common/mkdirs.go
+++ b/op/common/mkdirs.go
@@ -12,11 +12,17 @@ import (
 type makeDirsCommand struct {
 	nodes []*cke.Node
 	dirs  []string
+	mode  string
 }
 
 // MakeDirsCommand returns a Commander to make directories on nodes.
 func MakeDirsCommand(nodes []*cke.Node, dirs []string) cke.Commander {
-	return makeDirsCommand{nodes, dirs}
+	return makeDirsCommand{nodes, dirs, "755"}
+}
+
+// MakeDirsCommandWithMode returns a Commander to make directories on nodes with given permission mode.
+func MakeDirsCommandWithMode(nodes []*cke.Node, dirs []string, mode string) cke.Commander {
+	return makeDirsCommand{nodes, dirs, mode}
 }
 
 func (c makeDirsCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
@@ -40,7 +46,11 @@ func (c makeDirsCommand) Run(ctx context.Context, inf cke.Infrastructure) error 
 		binds = append(binds, m)
 	}
 
-	arg := "/usr/local/cke-tools/bin/make_directories " + strings.Join(dests, " ")
+	args := append([]string{
+		"/usr/local/cke-tools/bin/make_directories",
+		"--mode=" + c.mode,
+	}, dests...)
+	arg := strings.Join(args, " ")
 
 	env := well.NewEnvironment(ctx)
 	for _, n := range c.nodes {

--- a/op/k8s/config.go
+++ b/op/k8s/config.go
@@ -122,3 +122,47 @@ func (a KubeletAuthentication) MarshalJSON() ([]byte, error) {
 type kubeletAuthorization struct {
 	Mode string `json:"mode" yaml:"mode"`
 }
+
+// EncryptionConfiguration is a simplified version of the struct defined in
+// https://github.com/kubernetes/apiserver/blob/master/pkg/apis/config/types.go
+//
+// Rationate: kubernetes repository is too large and not intended for client usage.
+type EncryptionConfiguration struct {
+	APIVersion string                  `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	Kind       string                  `json:"kind,omitempty" yaml:"kind,omitempty"`
+	Resources  []ResourceConfiguration `json:"resources" yaml:"resources"`
+}
+
+func newEncryptionConfiguration() EncryptionConfiguration {
+	return EncryptionConfiguration{
+		APIVersion: "apiserver.config.k8s.io/v1",
+		Kind:       "EncryptionConfiguration",
+	}
+}
+
+// ResourceConfiguration is a simplified version of the struct defined in
+// https://github.com/kubernetes/apiserver/blob/master/pkg/apis/config/types.go
+type ResourceConfiguration struct {
+	Resources []string                `json:"resources" yaml:"resources"`
+	Providers []ProviderConfiguration `json:"providers" yaml:"providers"`
+}
+
+// ProviderConfiguration is a simplified version of the struct defined in
+// https://github.com/kubernetes/apiserver/blob/master/pkg/apis/config/types.go
+type ProviderConfiguration struct {
+	AESCBC   *AESConfiguration `json:"aescbc,omitempty" yaml:"aescbc,omitempty"`
+	Identity *struct{}         `json:"identity,omitempty" yaml:"identity,omitempty"`
+}
+
+// AESConfiguration is a simplified version of the struct defined in
+// https://github.com/kubernetes/apiserver/blob/master/pkg/apis/config/types.go
+type AESConfiguration struct {
+	Keys []Key `json:"keys" yaml:"keys"`
+}
+
+// Key is a simplified version of the struct defined in
+// https://github.com/kubernetes/apiserver/blob/master/pkg/apis/config/types.go
+type Key struct {
+	Name   string `json:"name" yaml:"name"`
+	Secret string `json:"secret" yaml:"secret"`
+}

--- a/op/k8s/encryption.go
+++ b/op/k8s/encryption.go
@@ -1,0 +1,62 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/cybozu-go/cke"
+)
+
+const (
+	encryptionConfigDir  = "/etc/kubernetes/apiserver"
+	encryptionConfigFile = "/etc/kubernetes/apiserver" + "/encryption.yml"
+)
+
+func getEncryptionSecret(ctx context.Context, inf cke.Infrastructure, key string) (string, error) {
+	vc, err := inf.Vault()
+	if err != nil {
+		return "", err
+	}
+
+	secret, err := vc.Logical().Read(cke.K8sSecret)
+	if err != nil {
+		return "", err
+	}
+	if secret == nil {
+		return "", errors.New("no encryption secrets for API server")
+	}
+
+	data, ok := secret.Data[key]
+	if !ok {
+		return "", errors.New("no secret data for " + key)
+	}
+	return data.(string), nil
+}
+
+func getEncryptionConfiguration(ctx context.Context, inf cke.Infrastructure) (*EncryptionConfiguration, error) {
+	data, err := getEncryptionSecret(ctx, inf, "aescbc")
+	if err != nil {
+		return nil, err
+	}
+
+	aescfg := new(AESConfiguration)
+	err = json.Unmarshal([]byte(data), aescfg)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := newEncryptionConfiguration()
+	resources := []ResourceConfiguration{
+		{
+			Resources: []string{"secrets"},
+			Providers: []ProviderConfiguration{
+				{AESCBC: aescfg},
+				{Identity: &struct{}{}},
+			},
+		},
+	}
+	cfg.Resources = resources
+
+	return &cfg, nil
+}

--- a/op/k8s/encryption.go
+++ b/op/k8s/encryption.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	encryptionConfigDir  = "/etc/kubernetes/apiserver"
-	encryptionConfigFile = "/etc/kubernetes/apiserver" + "/encryption.yml"
+	encryptionConfigFile = encryptionConfigDir + "/encryption.yml"
 )
 
 func getEncryptionSecret(ctx context.Context, inf cke.Infrastructure, key string) (string, error) {

--- a/pkg/ckecli/cmd/vault_enckey.go
+++ b/pkg/ckecli/cmd/vault_enckey.go
@@ -21,8 +21,8 @@ var vaultEncKeyCmd = &cobra.Command{
 WARNING: Key rotation is not fully implemented in this version!!
 
 This command generates new encryption keys for Kubernetes Secrets and
-rotate old keys.  At most two keys are retained to re-ecnrypt existing
-data.`,
+rotate old keys.  The current key, if any, is retained to decrypt
+existing data.  Other old keys are removed.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vc, err := inf.Vault()

--- a/pkg/ckecli/cmd/vault_enckey.go
+++ b/pkg/ckecli/cmd/vault_enckey.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/cybozu-go/cke"
+	"github.com/cybozu-go/cke/op/k8s"
+	vault "github.com/hashicorp/vault/api"
+	"github.com/spf13/cobra"
+)
+
+var vaultEncKeyCmd = &cobra.Command{
+	Use:   "enckey",
+	Short: "generate new encryption key for Kubernetes Secrets",
+	Long: `Generate or rotate encryption keys for Kubernetes Secrets.
+
+WARNING: Key rotation is not fully implemented in this version!!
+
+This command generates new encryption keys for Kubernetes Secrets and
+rotate old keys.  At most two keys are retained to re-ecnrypt existing
+data.`,
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		vc, err := inf.Vault()
+		if err != nil {
+			return err
+		}
+		err = rotateK8sEncryptionKey(vc)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println("succeeded")
+		return nil
+	},
+}
+
+func init() {
+	vaultCmd.AddCommand(vaultEncKeyCmd)
+}
+
+func rotateK8sEncryptionKey(vc *vault.Client) error {
+	secret, err := vc.Logical().Read(cke.K8sSecret)
+	if err != nil {
+		return err
+	}
+
+	var enckeys map[string]interface{}
+	if secret != nil && secret.Data != nil {
+		enckeys = secret.Data
+	} else {
+		enckeys = make(map[string]interface{})
+	}
+
+	var cfg k8s.AESConfiguration
+	if data, ok := enckeys["aescbc"]; ok {
+		err = json.Unmarshal([]byte(data.(string)), &cfg)
+		if err != nil {
+			return err
+		}
+	}
+
+	newKey, err := generateKey()
+	if err != nil {
+		return err
+	}
+	keys := []k8s.Key{
+		{
+			Name:   time.Now().UTC().Format(time.RFC3339),
+			Secret: base64.StdEncoding.EncodeToString(newKey),
+		},
+	}
+	if len(cfg.Keys) > 0 {
+		keys = append(keys, cfg.Keys[0])
+	}
+	cfg.Keys = keys
+	cfgData, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	enckeys["aescbc"] = string(cfgData)
+
+	_, err = vc.Logical().Write(cke.K8sSecret, enckeys)
+	return err
+}
+
+// generateKey generates key for aescbc
+// ref: https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#providers
+func generateKey() ([]byte, error) {
+	key := make([]byte, 32)
+	_, err := rand.Read(key)
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
+}

--- a/pkg/ckecli/cmd/vault_init.go
+++ b/pkg/ckecli/cmd/vault_init.go
@@ -178,7 +178,7 @@ func initVault(ctx context.Context) error {
 		}
 	}
 
-	return nil
+	return rotateK8sEncryptionKey(vc2)
 }
 
 func createPKI(ctx context.Context, vc *vault.Client, ca caParams) error {
@@ -246,7 +246,8 @@ Vault will be configured to:
     * have "cke" policy that can use secrets under cke/.
     * have "ca-server", "ca-etcd-peer", "ca-etcd-client", "ca-kubernetes"
       PKI secrets under cke/.
-    * creates AppRole for CKE.
+		* creates AppRole for CKE.
+		* have initial encryption key for Kubernetes Secrets.
 
 This command will ask username and password for Vault authentication
 when VAULT_TOKEN environment variable is not set.`,

--- a/pkg/ckecli/cmd/vault_init.go
+++ b/pkg/ckecli/cmd/vault_init.go
@@ -246,8 +246,8 @@ Vault will be configured to:
     * have "cke" policy that can use secrets under cke/.
     * have "ca-server", "ca-etcd-peer", "ca-etcd-client", "ca-kubernetes"
       PKI secrets under cke/.
-		* creates AppRole for CKE.
-		* have initial encryption key for Kubernetes Secrets.
+    * creates AppRole for CKE.
+    * have initial encryption key for Kubernetes Secrets.
 
 This command will ask username and password for Vault authentication
 when VAULT_TOKEN environment variable is not set.`,

--- a/server/strategy.go
+++ b/server/strategy.go
@@ -79,7 +79,7 @@ func k8sOps(c *cke.Cluster, nf *NodeFilter) (ops []cke.Operator) {
 		ops = append(ops, k8s.APIServerBootOp(nodes, nf.ControlPlane(), c.ServiceSubnet, c.Options.Kubelet.Domain, c.Options.APIServer))
 	}
 	if nodes := nf.APIServerOutdatedNodes(); len(nodes) > 0 {
-		ops = append(ops, k8s.APIServerRestartOp(nodes, nf.ControlPlane(), c.ServiceSubnet, c.Options.APIServer))
+		ops = append(ops, k8s.APIServerRestartOp(nodes, nf.ControlPlane(), c.ServiceSubnet, c.Options.Kubelet.Domain, c.Options.APIServer))
 	}
 	if nodes := nf.ControllerManagerStoppedNodes(); len(nodes) > 0 {
 		ops = append(ops, k8s.ControllerManagerBootOp(nodes, c.Name, c.ServiceSubnet, c.Options.ControllerManager))

--- a/vault.go
+++ b/vault.go
@@ -22,6 +22,9 @@ const CKESecret = "cke/secrets"
 // SSHSecret is the path of SSH private keys in Vault.
 const SSHSecret = CKESecret + "/ssh"
 
+// K8sSecret is the path of encryption keys used for Kubernetes Secrets.
+const K8sSecret = CKESecret + "/k8s"
+
 type anyMap = map[string]interface{}
 
 // VaultConfig is data to store in etcd


### PR DESCRIPTION
This PR enhances CKE to encrypt `Secret` resources in Kubernetes at rest.

Upgrading of existing installations require `ckecli vault enckey` invocation.

Ref: https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/