### PR TITLE
fix Dockerfile to copy binaries correctly

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
 # CKE container
 FROM quay.io/cybozu/ubuntu:18.04
 
-COPY cke /usr/local/cke/bin
-COPY ckecli /usr/local/cke/bin
+COPY cke /usr/local/cke/bin/
+COPY ckecli /usr/local/cke/bin/
 COPY install-tools /usr/local/cke/install-tools
 
 ENV PATH=/usr/local/cke/bin:"$PATH"


### PR DESCRIPTION
We expect to copy CKE binaries to /usr/local/cke/bin/.
However, `docker build` regards /usr/local/cke/bin as a regular file
by definition.