### PR TITLE
Add affected nodes information to each `ckecli history` records

### DIFF
--- a/op/clusterdns/create_configmap.go
+++ b/op/clusterdns/create_configmap.go
@@ -37,7 +37,7 @@ func (o *createConfigMapOp) NextCommand() cke.Commander {
 	return createConfigMapCommand{o.apiserver, o.domain, o.dnsServers}
 }
 
-func (o *createConfigMapOp) Nodes() []string {
+func (o *createConfigMapOp) Targets() []string {
 	return []string{
 		o.apiserver.Address,
 	}

--- a/op/clusterdns/create_configmap.go
+++ b/op/clusterdns/create_configmap.go
@@ -39,7 +39,7 @@ func (o *createConfigMapOp) NextCommand() cke.Commander {
 
 func (o *createConfigMapOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 

--- a/op/clusterdns/create_configmap.go
+++ b/op/clusterdns/create_configmap.go
@@ -37,6 +37,12 @@ func (o *createConfigMapOp) NextCommand() cke.Commander {
 	return createConfigMapCommand{o.apiserver, o.domain, o.dnsServers}
 }
 
+func (o *createConfigMapOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
+}
+
 func (c createConfigMapCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "createConfigMapCommand",

--- a/op/clusterdns/create_configmap.go
+++ b/op/clusterdns/create_configmap.go
@@ -37,9 +37,9 @@ func (o *createConfigMapOp) NextCommand() cke.Commander {
 	return createConfigMapCommand{o.apiserver, o.domain, o.dnsServers}
 }
 
-func (o *createConfigMapOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *createConfigMapOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 

--- a/op/clusterdns/update_config_map.go
+++ b/op/clusterdns/update_config_map.go
@@ -33,7 +33,7 @@ func (o *updateConfigMapOp) NextCommand() cke.Commander {
 	return updateConfigMapCommand{o.apiserver, o.configmap}
 }
 
-func (o *updateConfigMapOp) Nodes() []string {
+func (o *updateConfigMapOp) Targets() []string {
 	return []string{
 		o.apiserver.Address,
 	}

--- a/op/clusterdns/update_config_map.go
+++ b/op/clusterdns/update_config_map.go
@@ -4,17 +4,17 @@ import (
 	"context"
 
 	"github.com/cybozu-go/cke"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type updateConfigMapOp struct {
 	apiserver *cke.Node
-	configmap *v1.ConfigMap
+	configmap *corev1.ConfigMap
 	finished  bool
 }
 
 // UpdateConfigMapOp returns an Operator to update ConfigMap for CoreDNS.
-func UpdateConfigMapOp(apiserver *cke.Node, configmap *v1.ConfigMap) cke.Operator {
+func UpdateConfigMapOp(apiserver *cke.Node, configmap *corev1.ConfigMap) cke.Operator {
 	return &updateConfigMapOp{
 		apiserver: apiserver,
 		configmap: configmap,
@@ -35,13 +35,13 @@ func (o *updateConfigMapOp) NextCommand() cke.Commander {
 
 func (o *updateConfigMapOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 
 type updateConfigMapCommand struct {
 	apiserver *cke.Node
-	configmap *v1.ConfigMap
+	configmap *corev1.ConfigMap
 }
 
 func (c updateConfigMapCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
@@ -60,5 +60,6 @@ func (c updateConfigMapCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "updateConfigMapCommand",
 		Target: "kube-system",
+		Detail: "update configmap in kube-system",
 	}
 }

--- a/op/clusterdns/update_config_map.go
+++ b/op/clusterdns/update_config_map.go
@@ -60,6 +60,5 @@ func (c updateConfigMapCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "updateConfigMapCommand",
 		Target: "kube-system",
-		Detail: "update configmap in kube-system",
 	}
 }

--- a/op/clusterdns/update_config_map.go
+++ b/op/clusterdns/update_config_map.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/cybozu-go/cke"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 type updateConfigMapOp struct {
@@ -33,9 +33,9 @@ func (o *updateConfigMapOp) NextCommand() cke.Commander {
 	return updateConfigMapCommand{o.apiserver, o.configmap}
 }
 
-func (o *updateConfigMapOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *updateConfigMapOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 

--- a/op/clusterdns/update_config_map.go
+++ b/op/clusterdns/update_config_map.go
@@ -33,6 +33,12 @@ func (o *updateConfigMapOp) NextCommand() cke.Commander {
 	return updateConfigMapCommand{o.apiserver, o.configmap}
 }
 
+func (o *updateConfigMapOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
+}
+
 type updateConfigMapCommand struct {
 	apiserver *cke.Node
 	configmap *v1.ConfigMap

--- a/op/common/container.go
+++ b/op/common/container.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/cybozu-go/cke"
@@ -103,14 +102,9 @@ func (c runContainerCommand) Run(ctx context.Context, inf cke.Infrastructure) er
 }
 
 func (c runContainerCommand) Command() cke.Command {
-	addresses := make([]string, len(c.nodes))
-	for i, n := range c.nodes {
-		addresses[i] = n.Address
-	}
 	return cke.Command{
 		Name:   "run-container",
 		Target: c.name,
-		Detail: "run " + c.name + " in " + strings.Join(addresses, ","),
 	}
 }
 
@@ -157,7 +151,6 @@ func (c stopContainerCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "stop-container",
 		Target: c.name,
-		Detail: "run " + c.name + " in " + c.node.Address,
 	}
 }
 

--- a/op/common/container.go
+++ b/op/common/container.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/cybozu-go/cke"
@@ -102,9 +103,14 @@ func (c runContainerCommand) Run(ctx context.Context, inf cke.Infrastructure) er
 }
 
 func (c runContainerCommand) Command() cke.Command {
+	addresses := make([]string, len(c.nodes))
+	for i, n := range c.nodes {
+		addresses[i] = n.Address
+	}
 	return cke.Command{
 		Name:   "run-container",
 		Target: c.name,
+		Detail: "run " + c.name + " in " + strings.Join(addresses, ","),
 	}
 }
 
@@ -151,6 +157,7 @@ func (c stopContainerCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "stop-container",
 		Target: c.name,
+		Detail: "run " + c.name + " in " + c.node.Address,
 	}
 }
 

--- a/op/common/container.go
+++ b/op/common/container.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/cybozu-go/cke"
@@ -103,14 +102,9 @@ func (c runContainerCommand) Run(ctx context.Context, inf cke.Infrastructure) er
 }
 
 func (c runContainerCommand) Command() cke.Command {
-	targets := make([]string, len(c.nodes))
-	for i, n := range c.nodes {
-		targets[i] = n.Address
-	}
 	return cke.Command{
 		Name:   "run-container",
-		Target: strings.Join(targets, ","),
-		Detail: c.name,
+		Target: c.name,
 	}
 }
 
@@ -156,8 +150,7 @@ func (c stopContainerCommand) Run(ctx context.Context, inf cke.Infrastructure) e
 func (c stopContainerCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "stop-container",
-		Target: c.node.Address,
-		Detail: c.name,
+		Target: c.name,
 	}
 }
 
@@ -207,13 +200,8 @@ func (c killContainersCommand) Run(ctx context.Context, inf cke.Infrastructure) 
 }
 
 func (c killContainersCommand) Command() cke.Command {
-	addrs := make([]string, len(c.nodes))
-	for i, n := range c.nodes {
-		addrs[i] = n.Address
-	}
 	return cke.Command{
 		Name:   "kill-containers",
-		Target: strings.Join(addrs, ","),
-		Detail: c.name,
+		Target: c.name,
 	}
 }

--- a/op/common/volume.go
+++ b/op/common/volume.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-	"strings"
 
 	"github.com/cybozu-go/cke"
 	"github.com/cybozu-go/well"
@@ -37,8 +36,7 @@ func (c volumeCreateCommand) Command() cke.Command {
 	}
 	return cke.Command{
 		Name:   "volume-create",
-		Target: strings.Join(targets, ","),
-		Detail: c.volname,
+		Target: c.volname,
 	}
 }
 
@@ -78,7 +76,6 @@ func (c volumeRemoveCommand) Command() cke.Command {
 	}
 	return cke.Command{
 		Name:   "volume-remove",
-		Target: strings.Join(targets, ","),
-		Detail: c.volname,
+		Target: c.volname,
 	}
 }

--- a/op/common/volume.go
+++ b/op/common/volume.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-	"strings"
 
 	"github.com/cybozu-go/cke"
 	"github.com/cybozu-go/well"
@@ -31,15 +30,9 @@ func (c volumeCreateCommand) Run(ctx context.Context, inf cke.Infrastructure) er
 }
 
 func (c volumeCreateCommand) Command() cke.Command {
-	addresses := make([]string, len(c.nodes))
-	for i, n := range c.nodes {
-		addresses[i] = n.Address
-	}
-	detail := "create " + c.volname + " in " + strings.Join(addresses, ",")
 	return cke.Command{
 		Name:   "volume-create",
 		Target: c.volname,
-		Detail: detail,
 	}
 }
 
@@ -73,14 +66,8 @@ func (c volumeRemoveCommand) Run(ctx context.Context, inf cke.Infrastructure) er
 }
 
 func (c volumeRemoveCommand) Command() cke.Command {
-	addresses := make([]string, len(c.nodes))
-	for i, n := range c.nodes {
-		addresses[i] = n.Address
-	}
-	detail := "remove " + c.volname + " in " + strings.Join(addresses, ",")
 	return cke.Command{
 		Name:   "volume-remove",
 		Target: c.volname,
-		Detail: detail,
 	}
 }

--- a/op/common/volume.go
+++ b/op/common/volume.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cybozu-go/cke"
 	"github.com/cybozu-go/well"
@@ -30,13 +31,15 @@ func (c volumeCreateCommand) Run(ctx context.Context, inf cke.Infrastructure) er
 }
 
 func (c volumeCreateCommand) Command() cke.Command {
-	targets := make([]string, len(c.nodes))
+	addresses := make([]string, len(c.nodes))
 	for i, n := range c.nodes {
-		targets[i] = n.Address
+		addresses[i] = n.Address
 	}
+	detail := "create " + c.volname + " in " + strings.Join(addresses, ",")
 	return cke.Command{
 		Name:   "volume-create",
 		Target: c.volname,
+		Detail: detail,
 	}
 }
 
@@ -70,12 +73,14 @@ func (c volumeRemoveCommand) Run(ctx context.Context, inf cke.Infrastructure) er
 }
 
 func (c volumeRemoveCommand) Command() cke.Command {
-	targets := make([]string, len(c.nodes))
+	addresses := make([]string, len(c.nodes))
 	for i, n := range c.nodes {
-		targets[i] = n.Address
+		addresses[i] = n.Address
 	}
+	detail := "remove " + c.volname + " in " + strings.Join(addresses, ",")
 	return cke.Command{
 		Name:   "volume-remove",
 		Target: c.volname,
+		Detail: detail,
 	}
 }

--- a/op/etcd/add.go
+++ b/op/etcd/add.go
@@ -74,7 +74,7 @@ func (o *addMemberOp) NextCommand() cke.Commander {
 
 func (o *addMemberOp) Nodes() []string {
 	return []string{
-		o.targetNode.Nodename(),
+		o.targetNode.Address,
 	}
 }
 
@@ -153,8 +153,9 @@ func (c addMemberCommand) Run(ctx context.Context, inf cke.Infrastructure) error
 }
 
 func (c addMemberCommand) Command() cke.Command {
+	detail := "add node, " + c.node.Address + ", to etcd members"
 	return cke.Command{
 		Name:   "add-etcd-member",
-		Target: c.node.Address,
+		Detail: detail,
 	}
 }

--- a/op/etcd/add.go
+++ b/op/etcd/add.go
@@ -153,9 +153,7 @@ func (c addMemberCommand) Run(ctx context.Context, inf cke.Infrastructure) error
 }
 
 func (c addMemberCommand) Command() cke.Command {
-	detail := "add node, " + c.node.Address + ", to etcd members"
 	return cke.Command{
-		Name:   "add-etcd-member",
-		Detail: detail,
+		Name: "add-etcd-member",
 	}
 }

--- a/op/etcd/add.go
+++ b/op/etcd/add.go
@@ -72,6 +72,12 @@ func (o *addMemberOp) NextCommand() cke.Commander {
 	return nil
 }
 
+func (o *addMemberOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.targetNode,
+	}
+}
+
 type addMemberCommand struct {
 	endpoints []string
 	node      *cke.Node

--- a/op/etcd/add.go
+++ b/op/etcd/add.go
@@ -72,7 +72,7 @@ func (o *addMemberOp) NextCommand() cke.Commander {
 	return nil
 }
 
-func (o *addMemberOp) Nodes() []string {
+func (o *addMemberOp) Targets() []string {
 	return []string{
 		o.targetNode.Address,
 	}

--- a/op/etcd/add.go
+++ b/op/etcd/add.go
@@ -72,9 +72,9 @@ func (o *addMemberOp) NextCommand() cke.Commander {
 	return nil
 }
 
-func (o *addMemberOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.targetNode,
+func (o *addMemberOp) Nodes() []string {
+	return []string{
+		o.targetNode.Nodename(),
 	}
 }
 

--- a/op/etcd/boot.go
+++ b/op/etcd/boot.go
@@ -79,12 +79,12 @@ func (o *bootOp) NextCommand() cke.Commander {
 	}
 }
 
-func (o *bootOp) Targets() []cke.Node {
-	nodes := []cke.Node{}
-	for _, v := range o.nodes {
-		nodes = append(nodes, *v)
+func (o *bootOp) Nodes() []string {
+	ips := []string{}
+	for _, n := range o.nodes {
+		ips = append(ips, n.Nodename())
 	}
-	return nodes
+	return ips
 }
 
 type setupEtcdAuthCommand struct {

--- a/op/etcd/boot.go
+++ b/op/etcd/boot.go
@@ -120,10 +120,8 @@ func (c setupEtcdAuthCommand) Run(ctx context.Context, inf cke.Infrastructure) e
 }
 
 func (c setupEtcdAuthCommand) Command() cke.Command {
-	detail := "Add etcd auth setup to the endpoints, " + strings.Join(c.endpoints, ",")
 	return cke.Command{
 		Name:   "setup-etcd-auth",
 		Target: strings.Join(c.endpoints, ","),
-		Detail: detail,
 	}
 }

--- a/op/etcd/boot.go
+++ b/op/etcd/boot.go
@@ -80,9 +80,9 @@ func (o *bootOp) NextCommand() cke.Commander {
 }
 
 func (o *bootOp) Nodes() []string {
-	ips := []string{}
-	for _, n := range o.nodes {
-		ips = append(ips, n.Nodename())
+	ips := make([]string, len(o.nodes))
+	for i, n := range o.nodes {
+		ips[i] = n.Address
 	}
 	return ips
 }
@@ -120,8 +120,10 @@ func (c setupEtcdAuthCommand) Run(ctx context.Context, inf cke.Infrastructure) e
 }
 
 func (c setupEtcdAuthCommand) Command() cke.Command {
+	detail := "Add etcd auth setup to the endpoints, " + strings.Join(c.endpoints, ",")
 	return cke.Command{
 		Name:   "setup-etcd-auth",
 		Target: strings.Join(c.endpoints, ","),
+		Detail: detail,
 	}
 }

--- a/op/etcd/boot.go
+++ b/op/etcd/boot.go
@@ -79,6 +79,14 @@ func (o *bootOp) NextCommand() cke.Commander {
 	}
 }
 
+func (o *bootOp) Targets() []cke.Node {
+	nodes := []cke.Node{}
+	for _, v := range o.nodes {
+		nodes = append(nodes, *v)
+	}
+	return nodes
+}
+
 type setupEtcdAuthCommand struct {
 	endpoints []string
 }

--- a/op/etcd/boot.go
+++ b/op/etcd/boot.go
@@ -79,7 +79,7 @@ func (o *bootOp) NextCommand() cke.Commander {
 	}
 }
 
-func (o *bootOp) Nodes() []string {
+func (o *bootOp) Targets() []string {
 	ips := make([]string, len(o.nodes))
 	for i, n := range o.nodes {
 		ips[i] = n.Address

--- a/op/etcd/destroy.go
+++ b/op/etcd/destroy.go
@@ -44,3 +44,11 @@ func (o *destroyMemberOp) NextCommand() cke.Commander {
 	}
 	return nil
 }
+
+func (o *destroyMemberOp) Targets() []cke.Node {
+	nodes := []cke.Node{}
+	for _, v := range o.targets {
+		nodes = append(nodes, *v)
+	}
+	return nodes
+}

--- a/op/etcd/destroy.go
+++ b/op/etcd/destroy.go
@@ -45,10 +45,10 @@ func (o *destroyMemberOp) NextCommand() cke.Commander {
 	return nil
 }
 
-func (o *destroyMemberOp) Targets() []cke.Node {
-	nodes := []cke.Node{}
-	for _, v := range o.targets {
-		nodes = append(nodes, *v)
+func (o *destroyMemberOp) Nodes() []string {
+	ips := []string{}
+	for _, n := range o.targets {
+		ips = append(ips, n.Nodename())
 	}
-	return nodes
+	return ips
 }

--- a/op/etcd/destroy.go
+++ b/op/etcd/destroy.go
@@ -45,10 +45,10 @@ func (o *destroyMemberOp) NextCommand() cke.Commander {
 	return nil
 }
 
-func (o *destroyMemberOp) Nodes() []string {
+func (o *destroyMemberOp) Targets() []string {
 	ips := make([]string, len(o.targets))
-	for _, n := range o.targets {
-		ips = append(ips, n.Nodename())
+	for i, n := range o.targets {
+		ips[i] = n.Address
 	}
 	return ips
 }

--- a/op/etcd/destroy.go
+++ b/op/etcd/destroy.go
@@ -46,7 +46,7 @@ func (o *destroyMemberOp) NextCommand() cke.Commander {
 }
 
 func (o *destroyMemberOp) Nodes() []string {
-	ips := []string{}
+	ips := make([]string, len(o.targets))
 	for _, n := range o.targets {
 		ips = append(ips, n.Nodename())
 	}

--- a/op/etcd/remove.go
+++ b/op/etcd/remove.go
@@ -44,11 +44,7 @@ func (o *removeMemberOp) NextCommand() cke.Commander {
 }
 
 func (o *removeMemberOp) Nodes() []string {
-	ips := []string{}
-	for _, m := range o.members {
-		ips = append(ips, m.Name)
-	}
-	return ips
+	return []string{}
 }
 
 type removeMemberCommand struct {

--- a/op/etcd/remove.go
+++ b/op/etcd/remove.go
@@ -36,6 +36,10 @@ func (o *removeMemberOp) NextCommand() cke.Commander {
 	return removeMemberCommand{o.endpoints, o.ids}
 }
 
+func (o *removeMemberOp) Targets() []cke.Node {
+	return []cke.Node{}
+}
+
 type removeMemberCommand struct {
 	endpoints []string
 	ids       []uint64

--- a/op/etcd/restart.go
+++ b/op/etcd/restart.go
@@ -57,6 +57,6 @@ func (o *etcdRestartOp) NextCommand() cke.Commander {
 
 func (o *etcdRestartOp) Nodes() []string {
 	return []string{
-		o.target.Nodename(),
+		o.target.Address,
 	}
 }

--- a/op/etcd/restart.go
+++ b/op/etcd/restart.go
@@ -55,7 +55,7 @@ func (o *etcdRestartOp) NextCommand() cke.Commander {
 	return nil
 }
 
-func (o *etcdRestartOp) Nodes() []string {
+func (o *etcdRestartOp) Targets() []string {
 	return []string{
 		o.target.Address,
 	}

--- a/op/etcd/restart.go
+++ b/op/etcd/restart.go
@@ -54,3 +54,9 @@ func (o *etcdRestartOp) NextCommand() cke.Commander {
 	}
 	return nil
 }
+
+func (o *etcdRestartOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.target,
+	}
+}

--- a/op/etcd/restart.go
+++ b/op/etcd/restart.go
@@ -55,8 +55,8 @@ func (o *etcdRestartOp) NextCommand() cke.Commander {
 	return nil
 }
 
-func (o *etcdRestartOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.target,
+func (o *etcdRestartOp) Nodes() []string {
+	return []string{
+		o.target.Nodename(),
 	}
 }

--- a/op/etcd/start.go
+++ b/op/etcd/start.go
@@ -59,9 +59,9 @@ func (o *etcdStartOp) NextCommand() cke.Commander {
 }
 
 func (o *etcdStartOp) Nodes() []string {
-	ips := []string{}
+	ips := make([]string, len(o.nodes))
 	for _, n := range o.nodes {
-		ips = append(ips, n.Nodename())
+		ips = append(ips, n.Address)
 	}
 	return ips
 }

--- a/op/etcd/start.go
+++ b/op/etcd/start.go
@@ -58,10 +58,10 @@ func (o *etcdStartOp) NextCommand() cke.Commander {
 	}
 }
 
-func (o *etcdStartOp) Nodes() []string {
+func (o *etcdStartOp) Targets() []string {
 	ips := make([]string, len(o.nodes))
-	for _, n := range o.nodes {
-		ips = append(ips, n.Address)
+	for i, n := range o.nodes {
+		ips[i] = n.Address
 	}
 	return ips
 }

--- a/op/etcd/start.go
+++ b/op/etcd/start.go
@@ -57,3 +57,11 @@ func (o *etcdStartOp) NextCommand() cke.Commander {
 		return nil
 	}
 }
+
+func (o *etcdStartOp) Targets() []cke.Node {
+	nodes := []cke.Node{}
+	for _, v := range o.nodes {
+		nodes = append(nodes, *v)
+	}
+	return nodes
+}

--- a/op/etcd/start.go
+++ b/op/etcd/start.go
@@ -58,10 +58,10 @@ func (o *etcdStartOp) NextCommand() cke.Commander {
 	}
 }
 
-func (o *etcdStartOp) Targets() []cke.Node {
-	nodes := []cke.Node{}
-	for _, v := range o.nodes {
-		nodes = append(nodes, *v)
+func (o *etcdStartOp) Nodes() []string {
+	ips := []string{}
+	for _, n := range o.nodes {
+		ips = append(ips, n.Nodename())
 	}
-	return nodes
+	return ips
 }

--- a/op/etcd/wait.go
+++ b/op/etcd/wait.go
@@ -27,6 +27,6 @@ func (o *etcdWaitClusterOp) NextCommand() cke.Commander {
 	return waitEtcdSyncCommand{o.endpoints, false}
 }
 
-func (o *etcdWaitClusterOp) Nodes() []string {
-	return []string{}
+func (o *etcdWaitClusterOp) Targets() []string {
+	return o.endpoints
 }

--- a/op/etcd/wait.go
+++ b/op/etcd/wait.go
@@ -27,6 +27,6 @@ func (o *etcdWaitClusterOp) NextCommand() cke.Commander {
 	return waitEtcdSyncCommand{o.endpoints, false}
 }
 
-func (o *etcdWaitClusterOp) Targets() []cke.Node {
-	return []cke.Node{}
+func (o *etcdWaitClusterOp) Nodes() []string {
+	return []string{}
 }

--- a/op/etcd/wait.go
+++ b/op/etcd/wait.go
@@ -26,3 +26,7 @@ func (o *etcdWaitClusterOp) NextCommand() cke.Commander {
 
 	return waitEtcdSyncCommand{o.endpoints, false}
 }
+
+func (o *etcdWaitClusterOp) Targets() []cke.Node {
+	return []cke.Node{}
+}

--- a/op/etcdbackup/craete_configmap.go
+++ b/op/etcdbackup/craete_configmap.go
@@ -38,7 +38,7 @@ func (o *etcdBackupConfigMapCreateOp) NextCommand() cke.Commander {
 	return createEtcdBackupConfigMapCommand{o.apiserver, o.rotate}
 }
 
-func (o *etcdBackupConfigMapCreateOp) Nodes() []string {
+func (o *etcdBackupConfigMapCreateOp) Targets() []string {
 	return []string{
 		o.apiserver.Address,
 	}

--- a/op/etcdbackup/craete_configmap.go
+++ b/op/etcdbackup/craete_configmap.go
@@ -38,9 +38,9 @@ func (o *etcdBackupConfigMapCreateOp) NextCommand() cke.Commander {
 	return createEtcdBackupConfigMapCommand{o.apiserver, o.rotate}
 }
 
-func (o *etcdBackupConfigMapCreateOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *etcdBackupConfigMapCreateOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 

--- a/op/etcdbackup/craete_configmap.go
+++ b/op/etcdbackup/craete_configmap.go
@@ -38,6 +38,12 @@ func (o *etcdBackupConfigMapCreateOp) NextCommand() cke.Commander {
 	return createEtcdBackupConfigMapCommand{o.apiserver, o.rotate}
 }
 
+func (o *etcdBackupConfigMapCreateOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
+}
+
 type createEtcdBackupConfigMapCommand struct {
 	apiserver *cke.Node
 	rotate    int

--- a/op/etcdbackup/craete_configmap.go
+++ b/op/etcdbackup/craete_configmap.go
@@ -93,6 +93,5 @@ func (c createEtcdBackupConfigMapCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "create-etcdbackup-configmap",
 		Target: "etcdbackup",
-		Detail: "create etcdbackup configmap in kube-system",
 	}
 }

--- a/op/etcdbackup/craete_configmap.go
+++ b/op/etcdbackup/craete_configmap.go
@@ -40,7 +40,7 @@ func (o *etcdBackupConfigMapCreateOp) NextCommand() cke.Commander {
 
 func (o *etcdBackupConfigMapCreateOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 
@@ -93,5 +93,6 @@ func (c createEtcdBackupConfigMapCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "create-etcdbackup-configmap",
 		Target: "etcdbackup",
+		Detail: "create etcdbackup configmap in kube-system",
 	}
 }

--- a/op/etcdbackup/create_cronjob.go
+++ b/op/etcdbackup/create_cronjob.go
@@ -38,9 +38,9 @@ func (o *etcdBackupCronJobCreateOp) NextCommand() cke.Commander {
 	return createEtcdBackupCronJobCommand{o.apiserver, o.schedule}
 }
 
-func (o *etcdBackupCronJobCreateOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *etcdBackupCronJobCreateOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 

--- a/op/etcdbackup/create_cronjob.go
+++ b/op/etcdbackup/create_cronjob.go
@@ -38,7 +38,7 @@ func (o *etcdBackupCronJobCreateOp) NextCommand() cke.Commander {
 	return createEtcdBackupCronJobCommand{o.apiserver, o.schedule}
 }
 
-func (o *etcdBackupCronJobCreateOp) Nodes() []string {
+func (o *etcdBackupCronJobCreateOp) Targets() []string {
 	return []string{
 		o.apiserver.Address,
 	}

--- a/op/etcdbackup/create_cronjob.go
+++ b/op/etcdbackup/create_cronjob.go
@@ -40,7 +40,7 @@ func (o *etcdBackupCronJobCreateOp) NextCommand() cke.Commander {
 
 func (o *etcdBackupCronJobCreateOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 
@@ -89,5 +89,6 @@ func (c createEtcdBackupCronJobCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "create-etcdbackup-job",
 		Target: "etcdbackup",
+		Detail: "create etcdbackup cronjob in kube-system",
 	}
 }

--- a/op/etcdbackup/create_cronjob.go
+++ b/op/etcdbackup/create_cronjob.go
@@ -89,6 +89,5 @@ func (c createEtcdBackupCronJobCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "create-etcdbackup-job",
 		Target: "etcdbackup",
-		Detail: "create etcdbackup cronjob in kube-system",
 	}
 }

--- a/op/etcdbackup/create_cronjob.go
+++ b/op/etcdbackup/create_cronjob.go
@@ -38,6 +38,12 @@ func (o *etcdBackupCronJobCreateOp) NextCommand() cke.Commander {
 	return createEtcdBackupCronJobCommand{o.apiserver, o.schedule}
 }
 
+func (o *etcdBackupCronJobCreateOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
+}
+
 type createEtcdBackupCronJobCommand struct {
 	apiserver *cke.Node
 	schedule  string

--- a/op/etcdbackup/create_pod.go
+++ b/op/etcdbackup/create_pod.go
@@ -38,6 +38,12 @@ func (o *etcdBackupPodCreateOp) NextCommand() cke.Commander {
 	return createEtcdBackupPodCommand{o.apiserver, o.pvcname}
 }
 
+func (o *etcdBackupPodCreateOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
+}
+
 type createEtcdBackupPodCommand struct {
 	apiserver *cke.Node
 	pvcname   string

--- a/op/etcdbackup/create_pod.go
+++ b/op/etcdbackup/create_pod.go
@@ -95,6 +95,5 @@ func (c createEtcdBackupPodCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "create-etcdbackup-pod",
 		Target: "etcdbackup",
-		Detail: "create pods for etcdbackup in kube-system",
 	}
 }

--- a/op/etcdbackup/create_pod.go
+++ b/op/etcdbackup/create_pod.go
@@ -38,7 +38,7 @@ func (o *etcdBackupPodCreateOp) NextCommand() cke.Commander {
 	return createEtcdBackupPodCommand{o.apiserver, o.pvcname}
 }
 
-func (o *etcdBackupPodCreateOp) Nodes() []string {
+func (o *etcdBackupPodCreateOp) Targets() []string {
 	return []string{
 		o.apiserver.Address,
 	}

--- a/op/etcdbackup/create_pod.go
+++ b/op/etcdbackup/create_pod.go
@@ -38,9 +38,9 @@ func (o *etcdBackupPodCreateOp) NextCommand() cke.Commander {
 	return createEtcdBackupPodCommand{o.apiserver, o.pvcname}
 }
 
-func (o *etcdBackupPodCreateOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *etcdBackupPodCreateOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 

--- a/op/etcdbackup/create_pod.go
+++ b/op/etcdbackup/create_pod.go
@@ -40,7 +40,7 @@ func (o *etcdBackupPodCreateOp) NextCommand() cke.Commander {
 
 func (o *etcdBackupPodCreateOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 
@@ -95,5 +95,6 @@ func (c createEtcdBackupPodCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "create-etcdbackup-pod",
 		Target: "etcdbackup",
+		Detail: "create pods for etcdbackup in kube-system",
 	}
 }

--- a/op/etcdbackup/create_secret.go
+++ b/op/etcdbackup/create_secret.go
@@ -39,7 +39,7 @@ func (o *etcdBackupSecretCreateOp) NextCommand() cke.Commander {
 
 func (o *etcdBackupSecretCreateOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 
@@ -100,5 +100,6 @@ func (c createEtcdBackupSecretCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "create-etcdbackup-secret",
 		Target: "etcdbackup",
+		Detail: "create etcdbackup secret in kube-system",
 	}
 }

--- a/op/etcdbackup/create_secret.go
+++ b/op/etcdbackup/create_secret.go
@@ -100,6 +100,5 @@ func (c createEtcdBackupSecretCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "create-etcdbackup-secret",
 		Target: "etcdbackup",
-		Detail: "create etcdbackup secret in kube-system",
 	}
 }

--- a/op/etcdbackup/create_secret.go
+++ b/op/etcdbackup/create_secret.go
@@ -37,6 +37,12 @@ func (o *etcdBackupSecretCreateOp) NextCommand() cke.Commander {
 	return createEtcdBackupSecretCommand{o.apiserver}
 }
 
+func (o *etcdBackupSecretCreateOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
+}
+
 type createEtcdBackupSecretCommand struct {
 	apiserver *cke.Node
 }

--- a/op/etcdbackup/create_secret.go
+++ b/op/etcdbackup/create_secret.go
@@ -37,7 +37,7 @@ func (o *etcdBackupSecretCreateOp) NextCommand() cke.Commander {
 	return createEtcdBackupSecretCommand{o.apiserver}
 }
 
-func (o *etcdBackupSecretCreateOp) Nodes() []string {
+func (o *etcdBackupSecretCreateOp) Targets() []string {
 	return []string{
 		o.apiserver.Address,
 	}

--- a/op/etcdbackup/create_secret.go
+++ b/op/etcdbackup/create_secret.go
@@ -37,9 +37,9 @@ func (o *etcdBackupSecretCreateOp) NextCommand() cke.Commander {
 	return createEtcdBackupSecretCommand{o.apiserver}
 }
 
-func (o *etcdBackupSecretCreateOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *etcdBackupSecretCreateOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 

--- a/op/etcdbackup/create_service.go
+++ b/op/etcdbackup/create_service.go
@@ -76,6 +76,5 @@ func (c createEtcdBackupServiceCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "create-etcdbackup-service",
 		Target: "etcdbackup",
-		Detail: "create etcdbackup service in kube-system",
 	}
 }

--- a/op/etcdbackup/create_service.go
+++ b/op/etcdbackup/create_service.go
@@ -36,9 +36,9 @@ func (o *etcdBackupServiceCreateOp) NextCommand() cke.Commander {
 	return createEtcdBackupServiceCommand{o.apiserver}
 }
 
-func (o *etcdBackupServiceCreateOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *etcdBackupServiceCreateOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 

--- a/op/etcdbackup/create_service.go
+++ b/op/etcdbackup/create_service.go
@@ -38,7 +38,7 @@ func (o *etcdBackupServiceCreateOp) NextCommand() cke.Commander {
 
 func (o *etcdBackupServiceCreateOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 
@@ -76,5 +76,6 @@ func (c createEtcdBackupServiceCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "create-etcdbackup-service",
 		Target: "etcdbackup",
+		Detail: "create etcdbackup service in kube-system",
 	}
 }

--- a/op/etcdbackup/create_service.go
+++ b/op/etcdbackup/create_service.go
@@ -36,7 +36,7 @@ func (o *etcdBackupServiceCreateOp) NextCommand() cke.Commander {
 	return createEtcdBackupServiceCommand{o.apiserver}
 }
 
-func (o *etcdBackupServiceCreateOp) Nodes() []string {
+func (o *etcdBackupServiceCreateOp) Targets() []string {
 	return []string{
 		o.apiserver.Address,
 	}

--- a/op/etcdbackup/create_service.go
+++ b/op/etcdbackup/create_service.go
@@ -36,6 +36,12 @@ func (o *etcdBackupServiceCreateOp) NextCommand() cke.Commander {
 	return createEtcdBackupServiceCommand{o.apiserver}
 }
 
+func (o *etcdBackupServiceCreateOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
+}
+
 type createEtcdBackupServiceCommand struct {
 	apiserver *cke.Node
 }

--- a/op/etcdbackup/remove_configmap.go
+++ b/op/etcdbackup/remove_configmap.go
@@ -54,6 +54,5 @@ func (c removeEtcdBackupConfigMapCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "remove-etcdbackup-configmap",
 		Target: "etcdbackup-configmap",
-		Detail: "remove etcdbackup configmap in kube-system",
 	}
 }

--- a/op/etcdbackup/remove_configmap.go
+++ b/op/etcdbackup/remove_configmap.go
@@ -32,9 +32,9 @@ func (o *etcdBackupConfigMapRemoveOp) NextCommand() cke.Commander {
 	return removeEtcdBackupConfigMapCommand{o.apiserver}
 }
 
-func (o *etcdBackupConfigMapRemoveOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *etcdBackupConfigMapRemoveOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 

--- a/op/etcdbackup/remove_configmap.go
+++ b/op/etcdbackup/remove_configmap.go
@@ -32,6 +32,12 @@ func (o *etcdBackupConfigMapRemoveOp) NextCommand() cke.Commander {
 	return removeEtcdBackupConfigMapCommand{o.apiserver}
 }
 
+func (o *etcdBackupConfigMapRemoveOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
+}
+
 type removeEtcdBackupConfigMapCommand struct {
 	apiserver *cke.Node
 }

--- a/op/etcdbackup/remove_configmap.go
+++ b/op/etcdbackup/remove_configmap.go
@@ -34,7 +34,7 @@ func (o *etcdBackupConfigMapRemoveOp) NextCommand() cke.Commander {
 
 func (o *etcdBackupConfigMapRemoveOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 
@@ -54,5 +54,6 @@ func (c removeEtcdBackupConfigMapCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "remove-etcdbackup-configmap",
 		Target: "etcdbackup-configmap",
+		Detail: "remove etcdbackup configmap in kube-system",
 	}
 }

--- a/op/etcdbackup/remove_configmap.go
+++ b/op/etcdbackup/remove_configmap.go
@@ -32,7 +32,7 @@ func (o *etcdBackupConfigMapRemoveOp) NextCommand() cke.Commander {
 	return removeEtcdBackupConfigMapCommand{o.apiserver}
 }
 
-func (o *etcdBackupConfigMapRemoveOp) Nodes() []string {
+func (o *etcdBackupConfigMapRemoveOp) Targets() []string {
 	return []string{
 		o.apiserver.Address,
 	}

--- a/op/etcdbackup/remove_cronjob.go
+++ b/op/etcdbackup/remove_cronjob.go
@@ -32,9 +32,9 @@ func (o *etcdBackupCronJobRemoveOp) NextCommand() cke.Commander {
 	return removeEtcdBackupCronJobCommand{o.apiserver}
 }
 
-func (o *etcdBackupCronJobRemoveOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *etcdBackupCronJobRemoveOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 

--- a/op/etcdbackup/remove_cronjob.go
+++ b/op/etcdbackup/remove_cronjob.go
@@ -32,7 +32,7 @@ func (o *etcdBackupCronJobRemoveOp) NextCommand() cke.Commander {
 	return removeEtcdBackupCronJobCommand{o.apiserver}
 }
 
-func (o *etcdBackupCronJobRemoveOp) Nodes() []string {
+func (o *etcdBackupCronJobRemoveOp) Targets() []string {
 	return []string{
 		o.apiserver.Address,
 	}

--- a/op/etcdbackup/remove_cronjob.go
+++ b/op/etcdbackup/remove_cronjob.go
@@ -34,7 +34,7 @@ func (o *etcdBackupCronJobRemoveOp) NextCommand() cke.Commander {
 
 func (o *etcdBackupCronJobRemoveOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 
@@ -54,5 +54,6 @@ func (c removeEtcdBackupCronJobCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "remove-etcdbackup-job",
 		Target: "etcdbackup",
+		Detail: "remove etcdbackup cronjob in kube-system",
 	}
 }

--- a/op/etcdbackup/remove_cronjob.go
+++ b/op/etcdbackup/remove_cronjob.go
@@ -32,6 +32,12 @@ func (o *etcdBackupCronJobRemoveOp) NextCommand() cke.Commander {
 	return removeEtcdBackupCronJobCommand{o.apiserver}
 }
 
+func (o *etcdBackupCronJobRemoveOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
+}
+
 type removeEtcdBackupCronJobCommand struct {
 	apiserver *cke.Node
 }

--- a/op/etcdbackup/remove_cronjob.go
+++ b/op/etcdbackup/remove_cronjob.go
@@ -54,6 +54,5 @@ func (c removeEtcdBackupCronJobCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "remove-etcdbackup-job",
 		Target: "etcdbackup",
-		Detail: "remove etcdbackup cronjob in kube-system",
 	}
 }

--- a/op/etcdbackup/remove_pod.go
+++ b/op/etcdbackup/remove_pod.go
@@ -32,7 +32,7 @@ func (o *etcdBackupPodRemoveOp) NextCommand() cke.Commander {
 	return removeEtcdBackupPodCommand{o.apiserver}
 }
 
-func (o *etcdBackupPodRemoveOp) Nodes() []string {
+func (o *etcdBackupPodRemoveOp) Targets() []string {
 	return []string{
 		o.apiserver.Address,
 	}

--- a/op/etcdbackup/remove_pod.go
+++ b/op/etcdbackup/remove_pod.go
@@ -34,7 +34,7 @@ func (o *etcdBackupPodRemoveOp) NextCommand() cke.Commander {
 
 func (o *etcdBackupPodRemoveOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 
@@ -54,5 +54,6 @@ func (c removeEtcdBackupPodCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "remove-etcdbackup-pod",
 		Target: "etcdbackup",
+		Detail: "remove etcdbackup pods in kube-system",
 	}
 }

--- a/op/etcdbackup/remove_pod.go
+++ b/op/etcdbackup/remove_pod.go
@@ -32,6 +32,12 @@ func (o *etcdBackupPodRemoveOp) NextCommand() cke.Commander {
 	return removeEtcdBackupPodCommand{o.apiserver}
 }
 
+func (o *etcdBackupPodRemoveOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
+}
+
 type removeEtcdBackupPodCommand struct {
 	apiserver *cke.Node
 }

--- a/op/etcdbackup/remove_pod.go
+++ b/op/etcdbackup/remove_pod.go
@@ -54,6 +54,5 @@ func (c removeEtcdBackupPodCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "remove-etcdbackup-pod",
 		Target: "etcdbackup",
-		Detail: "remove etcdbackup pods in kube-system",
 	}
 }

--- a/op/etcdbackup/remove_pod.go
+++ b/op/etcdbackup/remove_pod.go
@@ -32,9 +32,9 @@ func (o *etcdBackupPodRemoveOp) NextCommand() cke.Commander {
 	return removeEtcdBackupPodCommand{o.apiserver}
 }
 
-func (o *etcdBackupPodRemoveOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *etcdBackupPodRemoveOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 

--- a/op/etcdbackup/remove_secret.go
+++ b/op/etcdbackup/remove_secret.go
@@ -32,9 +32,9 @@ func (o *etcdBackupSecretRemoveOp) NextCommand() cke.Commander {
 	return removeEtcdBackupSecretCommand{o.apiserver}
 }
 
-func (o *etcdBackupSecretRemoveOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *etcdBackupSecretRemoveOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 

--- a/op/etcdbackup/remove_secret.go
+++ b/op/etcdbackup/remove_secret.go
@@ -54,6 +54,5 @@ func (c removeEtcdBackupSecretCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "remove-etcdbackup-secret",
 		Target: "etcdbackup-secret",
-		Detail: "remove etcdbackup secret in kube-system",
 	}
 }

--- a/op/etcdbackup/remove_secret.go
+++ b/op/etcdbackup/remove_secret.go
@@ -32,6 +32,12 @@ func (o *etcdBackupSecretRemoveOp) NextCommand() cke.Commander {
 	return removeEtcdBackupSecretCommand{o.apiserver}
 }
 
+func (o *etcdBackupSecretRemoveOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
+}
+
 type removeEtcdBackupSecretCommand struct {
 	apiserver *cke.Node
 }

--- a/op/etcdbackup/remove_secret.go
+++ b/op/etcdbackup/remove_secret.go
@@ -34,7 +34,7 @@ func (o *etcdBackupSecretRemoveOp) NextCommand() cke.Commander {
 
 func (o *etcdBackupSecretRemoveOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 
@@ -54,5 +54,6 @@ func (c removeEtcdBackupSecretCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "remove-etcdbackup-secret",
 		Target: "etcdbackup-secret",
+		Detail: "remove etcdbackup secret in kube-system",
 	}
 }

--- a/op/etcdbackup/remove_secret.go
+++ b/op/etcdbackup/remove_secret.go
@@ -32,7 +32,7 @@ func (o *etcdBackupSecretRemoveOp) NextCommand() cke.Commander {
 	return removeEtcdBackupSecretCommand{o.apiserver}
 }
 
-func (o *etcdBackupSecretRemoveOp) Nodes() []string {
+func (o *etcdBackupSecretRemoveOp) Targets() []string {
 	return []string{
 		o.apiserver.Address,
 	}

--- a/op/etcdbackup/remove_service.go
+++ b/op/etcdbackup/remove_service.go
@@ -32,6 +32,12 @@ func (o *etcdBackupServiceRemoveOp) NextCommand() cke.Commander {
 	return removeEtcdBackupServiceCommand{o.apiserver}
 }
 
+func (o *etcdBackupServiceRemoveOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
+}
+
 type removeEtcdBackupServiceCommand struct {
 	apiserver *cke.Node
 }

--- a/op/etcdbackup/remove_service.go
+++ b/op/etcdbackup/remove_service.go
@@ -54,6 +54,5 @@ func (c removeEtcdBackupServiceCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "remove-etcdbackup-service",
 		Target: "etcdbackup-service",
-		Detail: "remove etcdbackup service in kube-system",
 	}
 }

--- a/op/etcdbackup/remove_service.go
+++ b/op/etcdbackup/remove_service.go
@@ -32,9 +32,9 @@ func (o *etcdBackupServiceRemoveOp) NextCommand() cke.Commander {
 	return removeEtcdBackupServiceCommand{o.apiserver}
 }
 
-func (o *etcdBackupServiceRemoveOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *etcdBackupServiceRemoveOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 

--- a/op/etcdbackup/remove_service.go
+++ b/op/etcdbackup/remove_service.go
@@ -34,7 +34,7 @@ func (o *etcdBackupServiceRemoveOp) NextCommand() cke.Commander {
 
 func (o *etcdBackupServiceRemoveOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 
@@ -54,5 +54,6 @@ func (c removeEtcdBackupServiceCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "remove-etcdbackup-service",
 		Target: "etcdbackup-service",
+		Detail: "remove etcdbackup service in kube-system",
 	}
 }

--- a/op/etcdbackup/remove_service.go
+++ b/op/etcdbackup/remove_service.go
@@ -32,7 +32,7 @@ func (o *etcdBackupServiceRemoveOp) NextCommand() cke.Commander {
 	return removeEtcdBackupServiceCommand{o.apiserver}
 }
 
-func (o *etcdBackupServiceRemoveOp) Nodes() []string {
+func (o *etcdBackupServiceRemoveOp) Targets() []string {
 	return []string{
 		o.apiserver.Address,
 	}

--- a/op/etcdbackup/update_configmap.go
+++ b/op/etcdbackup/update_configmap.go
@@ -4,9 +4,8 @@ import (
 	"bytes"
 	"context"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"github.com/cybozu-go/cke"
+	corev1 "k8s.io/api/core/v1"
 	k8sYaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 

--- a/op/etcdbackup/update_configmap.go
+++ b/op/etcdbackup/update_configmap.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/cybozu-go/cke"
 	k8sYaml "k8s.io/apimachinery/pkg/util/yaml"
@@ -38,7 +38,7 @@ func (o *etcdBackupConfigMapUpdateOp) NextCommand() cke.Commander {
 
 func (o *etcdBackupConfigMapUpdateOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 
@@ -63,7 +63,7 @@ func (c updateEtcdBackupConfigMapCommand) Run(ctx context.Context, inf cke.Infra
 		return err
 	}
 
-	ConfigMap := new(v1.ConfigMap)
+	ConfigMap := new(corev1.ConfigMap)
 	err = k8sYaml.NewYAMLToJSONDecoder(buf).Decode(ConfigMap)
 	if err != nil {
 		return err

--- a/op/etcdbackup/update_configmap.go
+++ b/op/etcdbackup/update_configmap.go
@@ -36,7 +36,7 @@ func (o *etcdBackupConfigMapUpdateOp) NextCommand() cke.Commander {
 	return updateEtcdBackupConfigMapCommand{o.apiserver, o.rotate}
 }
 
-func (o *etcdBackupConfigMapUpdateOp) Nodes() []string {
+func (o *etcdBackupConfigMapUpdateOp) Targets() []string {
 	return []string{
 		o.apiserver.Address,
 	}

--- a/op/etcdbackup/update_configmap.go
+++ b/op/etcdbackup/update_configmap.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/cybozu-go/cke"
 	k8sYaml "k8s.io/apimachinery/pkg/util/yaml"
@@ -36,9 +36,9 @@ func (o *etcdBackupConfigMapUpdateOp) NextCommand() cke.Commander {
 	return updateEtcdBackupConfigMapCommand{o.apiserver, o.rotate}
 }
 
-func (o *etcdBackupConfigMapUpdateOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *etcdBackupConfigMapUpdateOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 

--- a/op/etcdbackup/update_configmap.go
+++ b/op/etcdbackup/update_configmap.go
@@ -36,6 +36,12 @@ func (o *etcdBackupConfigMapUpdateOp) NextCommand() cke.Commander {
 	return updateEtcdBackupConfigMapCommand{o.apiserver, o.rotate}
 }
 
+func (o *etcdBackupConfigMapUpdateOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
+}
+
 type updateEtcdBackupConfigMapCommand struct {
 	apiserver *cke.Node
 	rotate    int

--- a/op/etcdbackup/update_cronjob.go
+++ b/op/etcdbackup/update_cronjob.go
@@ -35,6 +35,12 @@ func (o *etcdBackupCronJobUpdateOp) NextCommand() cke.Commander {
 	return updateEtcdBackupCronJobCommand{o.apiserver, o.schedule}
 }
 
+func (o *etcdBackupCronJobUpdateOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
+}
+
 type updateEtcdBackupCronJobCommand struct {
 	apiserver *cke.Node
 	schedule  string

--- a/op/etcdbackup/update_cronjob.go
+++ b/op/etcdbackup/update_cronjob.go
@@ -37,7 +37,7 @@ func (o *etcdBackupCronJobUpdateOp) NextCommand() cke.Commander {
 
 func (o *etcdBackupCronJobUpdateOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 
@@ -77,5 +77,6 @@ func (c updateEtcdBackupCronJobCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "update-etcdbackup-job",
 		Target: "etcdbackup",
+		Detail: "update etcdbackup cronjob in kube-system",
 	}
 }

--- a/op/etcdbackup/update_cronjob.go
+++ b/op/etcdbackup/update_cronjob.go
@@ -77,6 +77,5 @@ func (c updateEtcdBackupCronJobCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "update-etcdbackup-job",
 		Target: "etcdbackup",
-		Detail: "update etcdbackup cronjob in kube-system",
 	}
 }

--- a/op/etcdbackup/update_cronjob.go
+++ b/op/etcdbackup/update_cronjob.go
@@ -35,9 +35,9 @@ func (o *etcdBackupCronJobUpdateOp) NextCommand() cke.Commander {
 	return updateEtcdBackupCronJobCommand{o.apiserver, o.schedule}
 }
 
-func (o *etcdBackupCronJobUpdateOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *etcdBackupCronJobUpdateOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 

--- a/op/etcdbackup/update_cronjob.go
+++ b/op/etcdbackup/update_cronjob.go
@@ -35,7 +35,7 @@ func (o *etcdBackupCronJobUpdateOp) NextCommand() cke.Commander {
 	return updateEtcdBackupCronJobCommand{o.apiserver, o.schedule}
 }
 
-func (o *etcdBackupCronJobUpdateOp) Nodes() []string {
+func (o *etcdBackupCronJobUpdateOp) Targets() []string {
 	return []string{
 		o.apiserver.Address,
 	}

--- a/op/etcdbackup/update_pod.go
+++ b/op/etcdbackup/update_pod.go
@@ -36,9 +36,9 @@ func (o *etcdBackupPodUpdateOp) NextCommand() cke.Commander {
 	return updateEtcdBackupPodCommand{o.apiserver, o.pvcname}
 }
 
-func (o *etcdBackupPodUpdateOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *etcdBackupPodUpdateOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 

--- a/op/etcdbackup/update_pod.go
+++ b/op/etcdbackup/update_pod.go
@@ -84,6 +84,5 @@ func (c updateEtcdBackupPodCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "update-etcdbackup-pod",
 		Target: "etcdbackup",
-		Detail: "update etcdbackup pods in kube-system",
 	}
 }

--- a/op/etcdbackup/update_pod.go
+++ b/op/etcdbackup/update_pod.go
@@ -36,7 +36,7 @@ func (o *etcdBackupPodUpdateOp) NextCommand() cke.Commander {
 	return updateEtcdBackupPodCommand{o.apiserver, o.pvcname}
 }
 
-func (o *etcdBackupPodUpdateOp) Nodes() []string {
+func (o *etcdBackupPodUpdateOp) Targets() []string {
 	return []string{
 		o.apiserver.Address,
 	}

--- a/op/etcdbackup/update_pod.go
+++ b/op/etcdbackup/update_pod.go
@@ -38,7 +38,7 @@ func (o *etcdBackupPodUpdateOp) NextCommand() cke.Commander {
 
 func (o *etcdBackupPodUpdateOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 
@@ -84,5 +84,6 @@ func (c updateEtcdBackupPodCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "update-etcdbackup-pod",
 		Target: "etcdbackup",
+		Detail: "update etcdbackup pods in kube-system",
 	}
 }

--- a/op/etcdbackup/update_pod.go
+++ b/op/etcdbackup/update_pod.go
@@ -36,6 +36,12 @@ func (o *etcdBackupPodUpdateOp) NextCommand() cke.Commander {
 	return updateEtcdBackupPodCommand{o.apiserver, o.pvcname}
 }
 
+func (o *etcdBackupPodUpdateOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
+}
+
 type updateEtcdBackupPodCommand struct {
 	apiserver *cke.Node
 	pvcname   string

--- a/op/k8s/apiserver_boot.go
+++ b/op/k8s/apiserver_boot.go
@@ -94,12 +94,12 @@ func (o *apiServerBootOp) NextCommand() cke.Commander {
 	}
 }
 
-func (o *apiServerBootOp) Targets() []cke.Node {
-	nodes := []cke.Node{}
-	for _, p := range o.nodes {
-		nodes = append(nodes, *p)
+func (o *apiServerBootOp) Nodes() []string {
+	ips := []string{}
+	for _, n := range o.nodes {
+		ips = append(ips, n.Nodename())
 	}
-	return nodes
+	return ips
 }
 
 type prepareAPIServerFilesCommand struct {

--- a/op/k8s/apiserver_boot.go
+++ b/op/k8s/apiserver_boot.go
@@ -94,7 +94,7 @@ func (o *apiServerBootOp) NextCommand() cke.Commander {
 	}
 }
 
-func (o *apiServerBootOp) Nodes() []string {
+func (o *apiServerBootOp) Targets() []string {
 	ips := make([]string, len(o.nodes))
 	for i, n := range o.nodes {
 		ips[i] = n.Address

--- a/op/k8s/apiserver_boot.go
+++ b/op/k8s/apiserver_boot.go
@@ -94,6 +94,14 @@ func (o *apiServerBootOp) NextCommand() cke.Commander {
 	}
 }
 
+func (o *apiServerBootOp) Targets() []cke.Node {
+	nodes := []cke.Node{}
+	for _, p := range o.nodes {
+		nodes = append(nodes, *p)
+	}
+	return nodes
+}
+
 type prepareAPIServerFilesCommand struct {
 	files         *common.FilesBuilder
 	serviceSubnet string

--- a/op/k8s/apiserver_boot.go
+++ b/op/k8s/apiserver_boot.go
@@ -95,9 +95,9 @@ func (o *apiServerBootOp) NextCommand() cke.Commander {
 }
 
 func (o *apiServerBootOp) Nodes() []string {
-	ips := []string{}
-	for _, n := range o.nodes {
-		ips = append(ips, n.Nodename())
+	ips := make([]string, len(o.nodes))
+	for i, n := range o.nodes {
+		ips[i] = n.Address
 	}
 	return ips
 }

--- a/op/k8s/apiserver_restart.go
+++ b/op/k8s/apiserver_restart.go
@@ -66,3 +66,11 @@ func (o *apiServerRestartOp) NextCommand() cke.Commander {
 
 	panic("unreachable")
 }
+
+func (o *apiServerRestartOp) Targets() []cke.Node {
+	nodes := []cke.Node{}
+	for _, v := range o.nodes {
+		nodes = append(nodes, *v)
+	}
+	return nodes
+}

--- a/op/k8s/apiserver_restart.go
+++ b/op/k8s/apiserver_restart.go
@@ -68,9 +68,9 @@ func (o *apiServerRestartOp) NextCommand() cke.Commander {
 }
 
 func (o *apiServerRestartOp) Nodes() []string {
-	ips := []string{}
-	for _, n := range o.nodes {
-		ips = append(ips, n.Nodename())
+	ips := make([]string, len(o.nodes))
+	for i, n := range o.nodes {
+		ips[i] = n.Address
 	}
 	return ips
 }

--- a/op/k8s/apiserver_restart.go
+++ b/op/k8s/apiserver_restart.go
@@ -67,10 +67,10 @@ func (o *apiServerRestartOp) NextCommand() cke.Commander {
 	panic("unreachable")
 }
 
-func (o *apiServerRestartOp) Targets() []cke.Node {
-	nodes := []cke.Node{}
-	for _, v := range o.nodes {
-		nodes = append(nodes, *v)
+func (o *apiServerRestartOp) Nodes() []string {
+	ips := []string{}
+	for _, n := range o.nodes {
+		ips = append(ips, n.Nodename())
 	}
-	return nodes
+	return ips
 }

--- a/op/k8s/apiserver_restart.go
+++ b/op/k8s/apiserver_restart.go
@@ -67,7 +67,7 @@ func (o *apiServerRestartOp) NextCommand() cke.Commander {
 	panic("unreachable")
 }
 
-func (o *apiServerRestartOp) Nodes() []string {
+func (o *apiServerRestartOp) Targets() []string {
 	ips := make([]string, len(o.nodes))
 	for i, n := range o.nodes {
 		ips[i] = n.Address

--- a/op/k8s/controller_manager_boot.go
+++ b/op/k8s/controller_manager_boot.go
@@ -58,9 +58,9 @@ func (o *controllerManagerBootOp) NextCommand() cke.Commander {
 }
 
 func (o *controllerManagerBootOp) Nodes() []string {
-	ips := []string{}
-	for _, n := range o.nodes {
-		ips = append(ips, n.Nodename())
+	ips := make([]string, len(o.nodes))
+	for i, n := range o.nodes {
+		ips[i] = n.Address
 	}
 	return ips
 }

--- a/op/k8s/controller_manager_boot.go
+++ b/op/k8s/controller_manager_boot.go
@@ -57,12 +57,12 @@ func (o *controllerManagerBootOp) NextCommand() cke.Commander {
 	}
 }
 
-func (o *controllerManagerBootOp) Targets() []cke.Node {
-	nodes := []cke.Node{}
-	for _, v := range o.nodes {
-		nodes = append(nodes, *v)
+func (o *controllerManagerBootOp) Nodes() []string {
+	ips := []string{}
+	for _, n := range o.nodes {
+		ips = append(ips, n.Nodename())
 	}
-	return nodes
+	return ips
 }
 
 type prepareControllerManagerFilesCommand struct {

--- a/op/k8s/controller_manager_boot.go
+++ b/op/k8s/controller_manager_boot.go
@@ -57,7 +57,7 @@ func (o *controllerManagerBootOp) NextCommand() cke.Commander {
 	}
 }
 
-func (o *controllerManagerBootOp) Nodes() []string {
+func (o *controllerManagerBootOp) Targets() []string {
 	ips := make([]string, len(o.nodes))
 	for i, n := range o.nodes {
 		ips[i] = n.Address

--- a/op/k8s/controller_manager_boot.go
+++ b/op/k8s/controller_manager_boot.go
@@ -57,6 +57,14 @@ func (o *controllerManagerBootOp) NextCommand() cke.Commander {
 	}
 }
 
+func (o *controllerManagerBootOp) Targets() []cke.Node {
+	nodes := []cke.Node{}
+	for _, v := range o.nodes {
+		nodes = append(nodes, *v)
+	}
+	return nodes
+}
+
 type prepareControllerManagerFilesCommand struct {
 	cluster string
 	files   *common.FilesBuilder

--- a/op/k8s/controller_manager_restart.go
+++ b/op/k8s/controller_manager_restart.go
@@ -48,9 +48,9 @@ func (o *controllerManagerRestartOp) NextCommand() cke.Commander {
 }
 
 func (o *controllerManagerRestartOp) Nodes() []string {
-	ips := []string{}
-	for _, n := range o.nodes {
-		ips = append(ips, n.Nodename())
+	ips := make([]string, len(o.nodes))
+	for i, n := range o.nodes {
+		ips[i] = n.Address
 	}
 	return ips
 }

--- a/op/k8s/controller_manager_restart.go
+++ b/op/k8s/controller_manager_restart.go
@@ -47,7 +47,7 @@ func (o *controllerManagerRestartOp) NextCommand() cke.Commander {
 	return nil
 }
 
-func (o *controllerManagerRestartOp) Nodes() []string {
+func (o *controllerManagerRestartOp) Targets() []string {
 	ips := make([]string, len(o.nodes))
 	for i, n := range o.nodes {
 		ips[i] = n.Address

--- a/op/k8s/controller_manager_restart.go
+++ b/op/k8s/controller_manager_restart.go
@@ -46,3 +46,11 @@ func (o *controllerManagerRestartOp) NextCommand() cke.Commander {
 	}
 	return nil
 }
+
+func (o *controllerManagerRestartOp) Targets() []cke.Node {
+	nodes := []cke.Node{}
+	for _, v := range o.nodes {
+		nodes = append(nodes, *v)
+	}
+	return nodes
+}

--- a/op/k8s/controller_manager_restart.go
+++ b/op/k8s/controller_manager_restart.go
@@ -47,10 +47,10 @@ func (o *controllerManagerRestartOp) NextCommand() cke.Commander {
 	return nil
 }
 
-func (o *controllerManagerRestartOp) Targets() []cke.Node {
-	nodes := []cke.Node{}
-	for _, v := range o.nodes {
-		nodes = append(nodes, *v)
+func (o *controllerManagerRestartOp) Nodes() []string {
+	ips := []string{}
+	for _, n := range o.nodes {
+		ips = append(ips, n.Nodename())
 	}
-	return nodes
+	return ips
 }

--- a/op/k8s/kubelet_boot.go
+++ b/op/k8s/kubelet_boot.go
@@ -116,9 +116,9 @@ func (o *kubeletBootOp) NextCommand() cke.Commander {
 }
 
 func (o *kubeletBootOp) Nodes() []string {
-	ips := []string{}
-	for _, n := range o.nodes {
-		ips = append(ips, n.Nodename())
+	ips := make([]string, len(o.nodes))
+	for i, n := range o.nodes {
+		ips[i] = n.Address
 	}
 	return ips
 }
@@ -150,9 +150,15 @@ func (c emptyDirCommand) Run(ctx context.Context, inf cke.Infrastructure) error 
 }
 
 func (c emptyDirCommand) Command() cke.Command {
+	addresses := make([]string, len(c.nodes))
+	for i, n := range c.nodes {
+		addresses[i] = n.Address
+	}
+	detail := "empty dir, " + c.dir + ", in " + strings.Join(addresses, ",")
 	return cke.Command{
 		Name:   "empty-dir",
 		Target: c.dir,
+		Detail: detail,
 	}
 }
 
@@ -253,8 +259,14 @@ func (c installCNICommand) Run(ctx context.Context, inf cke.Infrastructure) erro
 }
 
 func (c installCNICommand) Command() cke.Command {
+	addresses := make([]string, len(c.nodes))
+	for i, n := range c.nodes {
+		addresses[i] = n.Address
+	}
+	detail := "install cni plugin in " + strings.Join(addresses, ",")
 	return cke.Command{
-		Name: "install-cni",
+		Name:   "install-cni",
+		Detail: detail,
 	}
 }
 
@@ -311,8 +323,14 @@ func (c retaintBeforeKubeletBootCommand) Run(ctx context.Context, inf cke.Infras
 }
 
 func (c retaintBeforeKubeletBootCommand) Command() cke.Command {
+	addresses := make([]string, len(c.nodes))
+	for i, n := range c.nodes {
+		addresses[i] = n.Address
+	}
+	detail := "retaint node before kubelet boot in " + strings.Join(addresses, ",")
 	return cke.Command{
 		Name: "retaint-before-kubelet-boot",
+		Detail: detail,
 	}
 }
 

--- a/op/k8s/kubelet_boot.go
+++ b/op/k8s/kubelet_boot.go
@@ -115,6 +115,14 @@ func (o *kubeletBootOp) NextCommand() cke.Commander {
 	}
 }
 
+func (o *kubeletBootOp) Targets() []cke.Node {
+	nodes := []cke.Node{}
+	for _, v := range o.nodes {
+		nodes = append(nodes, *v)
+	}
+	return nodes
+}
+
 type emptyDirCommand struct {
 	nodes []*cke.Node
 	dir   string

--- a/op/k8s/kubelet_boot.go
+++ b/op/k8s/kubelet_boot.go
@@ -115,12 +115,12 @@ func (o *kubeletBootOp) NextCommand() cke.Commander {
 	}
 }
 
-func (o *kubeletBootOp) Targets() []cke.Node {
-	nodes := []cke.Node{}
-	for _, v := range o.nodes {
-		nodes = append(nodes, *v)
+func (o *kubeletBootOp) Nodes() []string {
+	ips := []string{}
+	for _, n := range o.nodes {
+		ips = append(ips, n.Nodename())
 	}
-	return nodes
+	return ips
 }
 
 type emptyDirCommand struct {
@@ -150,14 +150,9 @@ func (c emptyDirCommand) Run(ctx context.Context, inf cke.Infrastructure) error 
 }
 
 func (c emptyDirCommand) Command() cke.Command {
-	targets := make([]string, len(c.nodes))
-	for i, n := range c.nodes {
-		targets[i] = n.Address
-	}
 	return cke.Command{
 		Name:   "empty-dir",
-		Target: strings.Join(targets, ","),
-		Detail: c.dir,
+		Target: c.dir,
 	}
 }
 
@@ -258,13 +253,8 @@ func (c installCNICommand) Run(ctx context.Context, inf cke.Infrastructure) erro
 }
 
 func (c installCNICommand) Command() cke.Command {
-	targets := make([]string, len(c.nodes))
-	for i, n := range c.nodes {
-		targets[i] = n.Address
-	}
 	return cke.Command{
-		Name:   "install-cni",
-		Target: strings.Join(targets, ","),
+		Name: "install-cni",
 	}
 }
 
@@ -321,13 +311,8 @@ func (c retaintBeforeKubeletBootCommand) Run(ctx context.Context, inf cke.Infras
 }
 
 func (c retaintBeforeKubeletBootCommand) Command() cke.Command {
-	targets := make([]string, len(c.nodes))
-	for i, n := range c.nodes {
-		targets[i] = n.Address
-	}
 	return cke.Command{
-		Name:   "retaint-before-kubelet-boot",
-		Target: strings.Join(targets, ","),
+		Name: "retaint-before-kubelet-boot",
 	}
 }
 

--- a/op/k8s/kubelet_boot.go
+++ b/op/k8s/kubelet_boot.go
@@ -115,7 +115,7 @@ func (o *kubeletBootOp) NextCommand() cke.Commander {
 	}
 }
 
-func (o *kubeletBootOp) Nodes() []string {
+func (o *kubeletBootOp) Targets() []string {
 	ips := make([]string, len(o.nodes))
 	for i, n := range o.nodes {
 		ips[i] = n.Address
@@ -329,7 +329,7 @@ func (c retaintBeforeKubeletBootCommand) Command() cke.Command {
 	}
 	detail := "retaint node before kubelet boot in " + strings.Join(addresses, ",")
 	return cke.Command{
-		Name: "retaint-before-kubelet-boot",
+		Name:   "retaint-before-kubelet-boot",
 		Detail: detail,
 	}
 }

--- a/op/k8s/kubelet_boot.go
+++ b/op/k8s/kubelet_boot.go
@@ -150,15 +150,9 @@ func (c emptyDirCommand) Run(ctx context.Context, inf cke.Infrastructure) error 
 }
 
 func (c emptyDirCommand) Command() cke.Command {
-	addresses := make([]string, len(c.nodes))
-	for i, n := range c.nodes {
-		addresses[i] = n.Address
-	}
-	detail := "empty dir, " + c.dir + ", in " + strings.Join(addresses, ",")
 	return cke.Command{
 		Name:   "empty-dir",
 		Target: c.dir,
-		Detail: detail,
 	}
 }
 
@@ -259,14 +253,8 @@ func (c installCNICommand) Run(ctx context.Context, inf cke.Infrastructure) erro
 }
 
 func (c installCNICommand) Command() cke.Command {
-	addresses := make([]string, len(c.nodes))
-	for i, n := range c.nodes {
-		addresses[i] = n.Address
-	}
-	detail := "install cni plugin in " + strings.Join(addresses, ",")
 	return cke.Command{
-		Name:   "install-cni",
-		Detail: detail,
+		Name: "install-cni",
 	}
 }
 
@@ -323,14 +311,8 @@ func (c retaintBeforeKubeletBootCommand) Run(ctx context.Context, inf cke.Infras
 }
 
 func (c retaintBeforeKubeletBootCommand) Command() cke.Command {
-	addresses := make([]string, len(c.nodes))
-	for i, n := range c.nodes {
-		addresses[i] = n.Address
-	}
-	detail := "retaint node before kubelet boot in " + strings.Join(addresses, ",")
 	return cke.Command{
-		Name:   "retaint-before-kubelet-boot",
-		Detail: detail,
+		Name: "retaint-before-kubelet-boot",
 	}
 }
 

--- a/op/k8s/kubelet_restart.go
+++ b/op/k8s/kubelet_restart.go
@@ -68,9 +68,9 @@ func (o *kubeletRestartOp) NextCommand() cke.Commander {
 }
 
 func (o *kubeletRestartOp) Nodes() []string {
-	ips := []string{}
-	for _, n := range o.nodes {
-		ips = append(ips, n.Nodename())
+	ips := make([]string, len(o.nodes))
+	for i, n := range o.nodes {
+		ips[i] = n.Address
 	}
 	return ips
 }

--- a/op/k8s/kubelet_restart.go
+++ b/op/k8s/kubelet_restart.go
@@ -67,12 +67,12 @@ func (o *kubeletRestartOp) NextCommand() cke.Commander {
 	}
 }
 
-func (o *kubeletRestartOp) Targets() []cke.Node {
-	nodes := []cke.Node{}
-	for _, v := range o.nodes {
-		nodes = append(nodes, *v)
+func (o *kubeletRestartOp) Nodes() []string {
+	ips := []string{}
+	for _, n := range o.nodes {
+		ips = append(ips, n.Nodename())
 	}
-	return nodes
+	return ips
 }
 
 type prepareKubeletConfigCommand struct {

--- a/op/k8s/kubelet_restart.go
+++ b/op/k8s/kubelet_restart.go
@@ -67,6 +67,14 @@ func (o *kubeletRestartOp) NextCommand() cke.Commander {
 	}
 }
 
+func (o *kubeletRestartOp) Targets() []cke.Node {
+	nodes := []cke.Node{}
+	for _, v := range o.nodes {
+		nodes = append(nodes, *v)
+	}
+	return nodes
+}
+
 type prepareKubeletConfigCommand struct {
 	cluster string
 	params  cke.KubeletParams

--- a/op/k8s/kubelet_restart.go
+++ b/op/k8s/kubelet_restart.go
@@ -67,7 +67,7 @@ func (o *kubeletRestartOp) NextCommand() cke.Commander {
 	}
 }
 
-func (o *kubeletRestartOp) Nodes() []string {
+func (o *kubeletRestartOp) Targets() []string {
 	ips := make([]string, len(o.nodes))
 	for i, n := range o.nodes {
 		ips[i] = n.Address

--- a/op/k8s/proxy_boot.go
+++ b/op/k8s/proxy_boot.go
@@ -64,7 +64,7 @@ func (o *kubeProxyBootOp) NextCommand() cke.Commander {
 	}
 }
 
-func (o *kubeProxyBootOp) Nodes() []string {
+func (o *kubeProxyBootOp) Targets() []string {
 	ips := make([]string, len(o.nodes))
 	for i, n := range o.nodes {
 		ips[i] = n.Address

--- a/op/k8s/proxy_boot.go
+++ b/op/k8s/proxy_boot.go
@@ -64,12 +64,12 @@ func (o *kubeProxyBootOp) NextCommand() cke.Commander {
 	}
 }
 
-func (o *kubeProxyBootOp) Targets() []cke.Node {
-	nodes := []cke.Node{}
-	for _, v := range o.nodes {
-		nodes = append(nodes, *v)
+func (o *kubeProxyBootOp) Nodes() []string {
+	ips := []string{}
+	for _, n := range o.nodes {
+		ips = append(ips, n.Nodename())
 	}
-	return nodes
+	return ips
 }
 
 type prepareProxyFilesCommand struct {

--- a/op/k8s/proxy_boot.go
+++ b/op/k8s/proxy_boot.go
@@ -64,6 +64,14 @@ func (o *kubeProxyBootOp) NextCommand() cke.Commander {
 	}
 }
 
+func (o *kubeProxyBootOp) Targets() []cke.Node {
+	nodes := []cke.Node{}
+	for _, v := range o.nodes {
+		nodes = append(nodes, *v)
+	}
+	return nodes
+}
+
 type prepareProxyFilesCommand struct {
 	cluster string
 	files   *common.FilesBuilder

--- a/op/k8s/proxy_boot.go
+++ b/op/k8s/proxy_boot.go
@@ -65,9 +65,9 @@ func (o *kubeProxyBootOp) NextCommand() cke.Commander {
 }
 
 func (o *kubeProxyBootOp) Nodes() []string {
-	ips := []string{}
-	for _, n := range o.nodes {
-		ips = append(ips, n.Nodename())
+	ips := make([]string, len(o.nodes))
+	for i, n := range o.nodes {
+		ips[i] = n.Address
 	}
 	return ips
 }

--- a/op/k8s/proxy_restart.go
+++ b/op/k8s/proxy_restart.go
@@ -62,10 +62,10 @@ func (o *kubeProxyRestartOp) NextCommand() cke.Commander {
 	}
 }
 
-func (o *kubeProxyRestartOp) Targets() []cke.Node {
-	nodes := []cke.Node{}
-	for _, v := range o.nodes {
-		nodes = append(nodes, *v)
+func (o *kubeProxyRestartOp) Nodes() []string {
+	ips := []string{}
+	for _, n := range o.nodes {
+		ips = append(ips, n.Nodename())
 	}
-	return nodes
+	return ips
 }

--- a/op/k8s/proxy_restart.go
+++ b/op/k8s/proxy_restart.go
@@ -63,9 +63,9 @@ func (o *kubeProxyRestartOp) NextCommand() cke.Commander {
 }
 
 func (o *kubeProxyRestartOp) Nodes() []string {
-	ips := []string{}
-	for _, n := range o.nodes {
-		ips = append(ips, n.Nodename())
+	ips := make([]string, len(o.nodes))
+	for i, n := range o.nodes {
+		ips[i] = n.Address
 	}
 	return ips
 }

--- a/op/k8s/proxy_restart.go
+++ b/op/k8s/proxy_restart.go
@@ -61,3 +61,11 @@ func (o *kubeProxyRestartOp) NextCommand() cke.Commander {
 		return nil
 	}
 }
+
+func (o *kubeProxyRestartOp) Targets() []cke.Node {
+	nodes := []cke.Node{}
+	for _, v := range o.nodes {
+		nodes = append(nodes, *v)
+	}
+	return nodes
+}

--- a/op/k8s/proxy_restart.go
+++ b/op/k8s/proxy_restart.go
@@ -62,7 +62,7 @@ func (o *kubeProxyRestartOp) NextCommand() cke.Commander {
 	}
 }
 
-func (o *kubeProxyRestartOp) Nodes() []string {
+func (o *kubeProxyRestartOp) Targets() []string {
 	ips := make([]string, len(o.nodes))
 	for i, n := range o.nodes {
 		ips[i] = n.Address

--- a/op/k8s/rivers_boot.go
+++ b/op/k8s/rivers_boot.go
@@ -57,7 +57,7 @@ func RiversParams(upstreams []*cke.Node) cke.ServiceParams {
 	return cke.ServiceParams{ExtraArguments: args}
 }
 
-func (o *riversBootOp) Nodes() []string {
+func (o *riversBootOp) Targets() []string {
 	ips := make([]string, len(o.nodes))
 	for i, n := range o.nodes {
 		ips[i] = n.Address

--- a/op/k8s/rivers_boot.go
+++ b/op/k8s/rivers_boot.go
@@ -58,9 +58,9 @@ func RiversParams(upstreams []*cke.Node) cke.ServiceParams {
 }
 
 func (o *riversBootOp) Nodes() []string {
-	ips := []string{}
-	for _, n := range o.nodes {
-		ips = append(ips, n.Nodename())
+	ips := make([]string, len(o.nodes))
+	for i, n := range o.nodes {
+		ips[i] = n.Address
 	}
 	return ips
 }

--- a/op/k8s/rivers_boot.go
+++ b/op/k8s/rivers_boot.go
@@ -57,10 +57,10 @@ func RiversParams(upstreams []*cke.Node) cke.ServiceParams {
 	return cke.ServiceParams{ExtraArguments: args}
 }
 
-func (o *riversBootOp) Targets() []cke.Node {
-	nodes := []cke.Node{}
-	for _, v := range o.nodes {
-		nodes = append(nodes, *v)
+func (o *riversBootOp) Nodes() []string {
+	ips := []string{}
+	for _, n := range o.nodes {
+		ips = append(ips, n.Nodename())
 	}
-	return nodes
+	return ips
 }

--- a/op/k8s/rivers_boot.go
+++ b/op/k8s/rivers_boot.go
@@ -56,3 +56,11 @@ func RiversParams(upstreams []*cke.Node) cke.ServiceParams {
 	}
 	return cke.ServiceParams{ExtraArguments: args}
 }
+
+func (o *riversBootOp) Targets() []cke.Node {
+	nodes := []cke.Node{}
+	for _, v := range o.nodes {
+		nodes = append(nodes, *v)
+	}
+	return nodes
+}

--- a/op/k8s/rivers_restart.go
+++ b/op/k8s/rivers_restart.go
@@ -44,7 +44,7 @@ func (o *riversRestartOp) NextCommand() cke.Commander {
 	return nil
 }
 
-func (o *riversRestartOp) Nodes() []string {
+func (o *riversRestartOp) Targets() []string {
 	ips := make([]string, len(o.nodes))
 	for i, n := range o.nodes {
 		ips[i] = n.Address

--- a/op/k8s/rivers_restart.go
+++ b/op/k8s/rivers_restart.go
@@ -44,10 +44,10 @@ func (o *riversRestartOp) NextCommand() cke.Commander {
 	return nil
 }
 
-func (o *riversRestartOp) Targets() []cke.Node {
-	nodes := []cke.Node{}
-	for _, v := range o.nodes {
-		nodes = append(nodes, *v)
+func (o *riversRestartOp) Nodes() []string {
+	ips := []string{}
+	for _, n := range o.nodes {
+		ips = append(ips, n.Nodename())
 	}
-	return nodes
+	return ips
 }

--- a/op/k8s/rivers_restart.go
+++ b/op/k8s/rivers_restart.go
@@ -43,3 +43,11 @@ func (o *riversRestartOp) NextCommand() cke.Commander {
 	}
 	return nil
 }
+
+func (o *riversRestartOp) Targets() []cke.Node {
+	nodes := []cke.Node{}
+	for _, v := range o.nodes {
+		nodes = append(nodes, *v)
+	}
+	return nodes
+}

--- a/op/k8s/rivers_restart.go
+++ b/op/k8s/rivers_restart.go
@@ -45,9 +45,9 @@ func (o *riversRestartOp) NextCommand() cke.Commander {
 }
 
 func (o *riversRestartOp) Nodes() []string {
-	ips := []string{}
-	for _, n := range o.nodes {
-		ips = append(ips, n.Nodename())
+	ips := make([]string, len(o.nodes))
+	for i, n := range o.nodes {
+		ips[i] = n.Address
 	}
 	return ips
 }

--- a/op/k8s/scheduler_boot.go
+++ b/op/k8s/scheduler_boot.go
@@ -54,6 +54,14 @@ func (o *schedulerBootOp) NextCommand() cke.Commander {
 	}
 }
 
+func (o *schedulerBootOp) Targets() []cke.Node {
+	nodes := []cke.Node{}
+	for _, v := range o.nodes {
+		nodes = append(nodes, *v)
+	}
+	return nodes
+}
+
 type prepareSchedulerFilesCommand struct {
 	cluster string
 	files   *common.FilesBuilder

--- a/op/k8s/scheduler_boot.go
+++ b/op/k8s/scheduler_boot.go
@@ -54,12 +54,12 @@ func (o *schedulerBootOp) NextCommand() cke.Commander {
 	}
 }
 
-func (o *schedulerBootOp) Targets() []cke.Node {
-	nodes := []cke.Node{}
-	for _, v := range o.nodes {
-		nodes = append(nodes, *v)
+func (o *schedulerBootOp) Nodes() []string {
+	ips := []string{}
+	for _, n := range o.nodes {
+		ips = append(ips, n.Nodename())
 	}
-	return nodes
+	return ips
 }
 
 type prepareSchedulerFilesCommand struct {

--- a/op/k8s/scheduler_boot.go
+++ b/op/k8s/scheduler_boot.go
@@ -54,7 +54,7 @@ func (o *schedulerBootOp) NextCommand() cke.Commander {
 	}
 }
 
-func (o *schedulerBootOp) Nodes() []string {
+func (o *schedulerBootOp) Targets() []string {
 	ips := make([]string, len(o.nodes))
 	for i, n := range o.nodes {
 		ips[i] = n.Address

--- a/op/k8s/scheduler_boot.go
+++ b/op/k8s/scheduler_boot.go
@@ -55,9 +55,9 @@ func (o *schedulerBootOp) NextCommand() cke.Commander {
 }
 
 func (o *schedulerBootOp) Nodes() []string {
-	ips := []string{}
-	for _, n := range o.nodes {
-		ips = append(ips, n.Nodename())
+	ips := make([]string, len(o.nodes))
+	for i, n := range o.nodes {
+		ips[i] = n.Address
 	}
 	return ips
 }

--- a/op/k8s/scheduler_restart.go
+++ b/op/k8s/scheduler_restart.go
@@ -45,7 +45,7 @@ func (o *schedulerRestartOp) NextCommand() cke.Commander {
 	return nil
 }
 
-func (o *schedulerRestartOp) Nodes() []string {
+func (o *schedulerRestartOp) Targets() []string {
 	ips := make([]string, len(o.nodes))
 	for i, n := range o.nodes {
 		ips[i] = n.Address

--- a/op/k8s/scheduler_restart.go
+++ b/op/k8s/scheduler_restart.go
@@ -46,9 +46,9 @@ func (o *schedulerRestartOp) NextCommand() cke.Commander {
 }
 
 func (o *schedulerRestartOp) Nodes() []string {
-	ips := []string{}
-	for _, n := range o.nodes {
-		ips = append(ips, n.Nodename())
+	ips := make([]string, len(o.nodes))
+	for i, n := range o.nodes {
+		ips[i] = n.Address
 	}
 	return ips
 }

--- a/op/k8s/scheduler_restart.go
+++ b/op/k8s/scheduler_restart.go
@@ -45,10 +45,10 @@ func (o *schedulerRestartOp) NextCommand() cke.Commander {
 	return nil
 }
 
-func (o *schedulerRestartOp) Targets() []cke.Node {
-	nodes := []cke.Node{}
-	for _, v := range o.nodes {
-		nodes = append(nodes, *v)
+func (o *schedulerRestartOp) Nodes() []string {
+	ips := []string{}
+	for _, n := range o.nodes {
+		ips = append(ips, n.Nodename())
 	}
-	return nodes
+	return ips
 }

--- a/op/k8s/scheduler_restart.go
+++ b/op/k8s/scheduler_restart.go
@@ -44,3 +44,11 @@ func (o *schedulerRestartOp) NextCommand() cke.Commander {
 	}
 	return nil
 }
+
+func (o *schedulerRestartOp) Targets() []cke.Node {
+	nodes := []cke.Node{}
+	for _, v := range o.nodes {
+		nodes = append(nodes, *v)
+	}
+	return nodes
+}

--- a/op/kube_etcd_endpoints.go
+++ b/op/kube_etcd_endpoints.go
@@ -37,10 +37,13 @@ func (o *kubeEtcdEndpointsCreateOp) NextCommand() cke.Commander {
 	return createEtcdEndpointsCommand{o.apiserver, o.endpoints}
 }
 
-func (o *kubeEtcdEndpointsCreateOp) Nodes() []string {
-	return []string{
-		o.apiserver.Address,
+func (o *kubeEtcdEndpointsCreateOp) Targets() []string {
+	ips := make([]string, len(o.endpoints)+1)
+	ips[0] = o.apiserver.Address
+	for i, e := range o.endpoints {
+		ips[i+1] = e.Address
 	}
+	return ips
 }
 
 type kubeEtcdEndpointsUpdateOp struct {
@@ -70,10 +73,13 @@ func (o *kubeEtcdEndpointsUpdateOp) NextCommand() cke.Commander {
 	return updateEtcdEndpointsCommand{o.apiserver, o.endpoints}
 }
 
-func (o *kubeEtcdEndpointsUpdateOp) Nodes() []string {
-	return []string{
-		o.apiserver.Address,
+func (o *kubeEtcdEndpointsUpdateOp) Targets() []string {
+	ips := make([]string, len(o.endpoints)+1)
+	ips[0] = o.apiserver.Address
+	for i, e := range o.endpoints {
+		ips[i+1] = e.Address
 	}
+	return ips
 }
 
 type createEtcdEndpointsCommand struct {

--- a/op/kube_etcd_endpoints.go
+++ b/op/kube_etcd_endpoints.go
@@ -37,12 +37,9 @@ func (o *kubeEtcdEndpointsCreateOp) NextCommand() cke.Commander {
 }
 
 func (o *kubeEtcdEndpointsCreateOp) Targets() []string {
-	ips := make([]string, len(o.endpoints)+1)
-	ips[0] = o.apiserver.Address
-	for i, e := range o.endpoints {
-		ips[i+1] = e.Address
+	return []string{
+		o.apiserver.Address,
 	}
-	return ips
 }
 
 type kubeEtcdEndpointsUpdateOp struct {
@@ -73,12 +70,9 @@ func (o *kubeEtcdEndpointsUpdateOp) NextCommand() cke.Commander {
 }
 
 func (o *kubeEtcdEndpointsUpdateOp) Targets() []string {
-	ips := make([]string, len(o.endpoints)+1)
-	ips[0] = o.apiserver.Address
-	for i, e := range o.endpoints {
-		ips[i+1] = e.Address
+	return []string{
+		o.apiserver.Address,
 	}
-	return ips
 }
 
 type createEtcdEndpointsCommand struct {

--- a/op/kube_etcd_endpoints.go
+++ b/op/kube_etcd_endpoints.go
@@ -2,6 +2,7 @@ package op
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cybozu-go/cke"
 	corev1 "k8s.io/api/core/v1"
@@ -129,9 +130,13 @@ func (c createEtcdEndpointsCommand) Run(ctx context.Context, inf cke.Infrastruct
 }
 
 func (c createEtcdEndpointsCommand) Command() cke.Command {
+	endpoints := make([]string, len(c.endpoints))
+	for i, e := range c.endpoints {
+		endpoints[i] = e.Address
+	}
 	return cke.Command{
 		Name:   "createEtcdEndpointsCommand",
-		Target: "kube-system/" + etcdEndpointsName,
+		Target: strings.Join(endpoints, ","),
 	}
 }
 
@@ -165,8 +170,12 @@ func (c updateEtcdEndpointsCommand) Run(ctx context.Context, inf cke.Infrastruct
 }
 
 func (c updateEtcdEndpointsCommand) Command() cke.Command {
+	endpoints := make([]string, len(c.endpoints))
+	for i, e := range c.endpoints {
+		endpoints[i] = e.Address
+	}
 	return cke.Command{
 		Name:   "updateEtcdEndpointsCommand",
-		Target: "kube-system/" + etcdEndpointsName,
+		Target: strings.Join(endpoints, ","),
 	}
 }

--- a/op/kube_etcd_endpoints.go
+++ b/op/kube_etcd_endpoints.go
@@ -2,7 +2,6 @@ package op
 
 import (
 	"context"
-	"strings"
 
 	"github.com/cybozu-go/cke"
 	corev1 "k8s.io/api/core/v1"
@@ -37,9 +36,9 @@ func (o *kubeEtcdEndpointsCreateOp) NextCommand() cke.Commander {
 	return createEtcdEndpointsCommand{o.apiserver, o.endpoints}
 }
 
-func (o *kubeEtcdEndpointsCreateOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *kubeEtcdEndpointsCreateOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 
@@ -70,9 +69,9 @@ func (o *kubeEtcdEndpointsUpdateOp) NextCommand() cke.Commander {
 	return updateEtcdEndpointsCommand{o.apiserver, o.endpoints}
 }
 
-func (o *kubeEtcdEndpointsUpdateOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *kubeEtcdEndpointsUpdateOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 
@@ -130,14 +129,9 @@ func (c createEtcdEndpointsCommand) Run(ctx context.Context, inf cke.Infrastruct
 }
 
 func (c createEtcdEndpointsCommand) Command() cke.Command {
-	targets := make([]string, len(c.endpoints))
-	for i, n := range c.endpoints {
-		targets[i] = n.Address
-	}
 	return cke.Command{
 		Name:   "createEtcdEndpointsCommand",
-		Target: strings.Join(targets, ","),
-		Detail: "kube-system/" + etcdEndpointsName,
+		Target: "kube-system/" + etcdEndpointsName,
 	}
 }
 
@@ -171,13 +165,8 @@ func (c updateEtcdEndpointsCommand) Run(ctx context.Context, inf cke.Infrastruct
 }
 
 func (c updateEtcdEndpointsCommand) Command() cke.Command {
-	targets := make([]string, len(c.endpoints))
-	for i, n := range c.endpoints {
-		targets[i] = n.Address
-	}
 	return cke.Command{
 		Name:   "updateEtcdEndpointsCommand",
-		Target: strings.Join(targets, ","),
-		Detail: "kube-system/" + etcdEndpointsName,
+		Target: "kube-system/" + etcdEndpointsName,
 	}
 }

--- a/op/kube_etcd_endpoints.go
+++ b/op/kube_etcd_endpoints.go
@@ -2,6 +2,7 @@ package op
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cybozu-go/cke"
 	corev1 "k8s.io/api/core/v1"
@@ -38,7 +39,7 @@ func (o *kubeEtcdEndpointsCreateOp) NextCommand() cke.Commander {
 
 func (o *kubeEtcdEndpointsCreateOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 
@@ -71,7 +72,7 @@ func (o *kubeEtcdEndpointsUpdateOp) NextCommand() cke.Commander {
 
 func (o *kubeEtcdEndpointsUpdateOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 
@@ -129,9 +130,15 @@ func (c createEtcdEndpointsCommand) Run(ctx context.Context, inf cke.Infrastruct
 }
 
 func (c createEtcdEndpointsCommand) Command() cke.Command {
+	addresses := make([]string, len(c.endpoints))
+	for i, n := range c.endpoints {
+		addresses[i] = n.Address
+	}
+	detail := "update etcd endpoints, " + "kube-system/" + etcdEndpointsName + " in " + strings.Join(addresses, ",")
 	return cke.Command{
 		Name:   "createEtcdEndpointsCommand",
 		Target: "kube-system/" + etcdEndpointsName,
+		Detail: detail,
 	}
 }
 

--- a/op/kube_etcd_endpoints.go
+++ b/op/kube_etcd_endpoints.go
@@ -37,6 +37,12 @@ func (o *kubeEtcdEndpointsCreateOp) NextCommand() cke.Commander {
 	return createEtcdEndpointsCommand{o.apiserver, o.endpoints}
 }
 
+func (o *kubeEtcdEndpointsCreateOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
+}
+
 type kubeEtcdEndpointsUpdateOp struct {
 	apiserver *cke.Node
 	endpoints []*cke.Node
@@ -62,6 +68,12 @@ func (o *kubeEtcdEndpointsUpdateOp) NextCommand() cke.Commander {
 
 	o.finished = true
 	return updateEtcdEndpointsCommand{o.apiserver, o.endpoints}
+}
+
+func (o *kubeEtcdEndpointsUpdateOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
 }
 
 type createEtcdEndpointsCommand struct {

--- a/op/kube_etcd_endpoints.go
+++ b/op/kube_etcd_endpoints.go
@@ -2,7 +2,6 @@ package op
 
 import (
 	"context"
-	"strings"
 
 	"github.com/cybozu-go/cke"
 	corev1 "k8s.io/api/core/v1"
@@ -136,15 +135,9 @@ func (c createEtcdEndpointsCommand) Run(ctx context.Context, inf cke.Infrastruct
 }
 
 func (c createEtcdEndpointsCommand) Command() cke.Command {
-	addresses := make([]string, len(c.endpoints))
-	for i, n := range c.endpoints {
-		addresses[i] = n.Address
-	}
-	detail := "update etcd endpoints, " + "kube-system/" + etcdEndpointsName + " in " + strings.Join(addresses, ",")
 	return cke.Command{
 		Name:   "createEtcdEndpointsCommand",
 		Target: "kube-system/" + etcdEndpointsName,
-		Detail: detail,
 	}
 }
 

--- a/op/kube_node_remove.go
+++ b/op/kube_node_remove.go
@@ -32,10 +32,11 @@ func (o *kubeNodeRemove) NextCommand() cke.Commander {
 	return nodeRemoveCommand{o.apiserver, o.nodes}
 }
 
-func (o *kubeNodeRemove) Nodes() []string {
-	ips := make([]string, len(o.nodes))
+func (o *kubeNodeRemove) Targets() []string {
+	ips := make([]string, len(o.nodes)+1)
+	ips[0] = o.apiserver.Address
 	for i, n := range o.nodes {
-		ips[i] = n.Name
+		ips[i+1] = n.GetName()
 	}
 	return ips
 }

--- a/op/kube_node_remove.go
+++ b/op/kube_node_remove.go
@@ -2,7 +2,6 @@ package op
 
 import (
 	"context"
-	"strings"
 
 	"github.com/cybozu-go/cke"
 	corev1 "k8s.io/api/core/v1"
@@ -36,7 +35,7 @@ func (o *kubeNodeRemove) Targets() []string {
 	ips := make([]string, len(o.nodes)+1)
 	ips[0] = o.apiserver.Address
 	for i, n := range o.nodes {
-		ips[i+1] = n.GetName()
+		ips[i+1] = n.Name
 	}
 	return ips
 }
@@ -68,9 +67,7 @@ func (c nodeRemoveCommand) Command() cke.Command {
 	for i, n := range c.nodes {
 		names[i] = n.Name
 	}
-	detail := "remove nodes, " + strings.Join(names, ",")
 	return cke.Command{
-		Name:   "removeNode",
-		Detail: detail,
+		Name: "removeNode",
 	}
 }

--- a/op/kube_node_remove.go
+++ b/op/kube_node_remove.go
@@ -2,6 +2,7 @@ package op
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cybozu-go/cke"
 	corev1 "k8s.io/api/core/v1"
@@ -32,12 +33,9 @@ func (o *kubeNodeRemove) NextCommand() cke.Commander {
 }
 
 func (o *kubeNodeRemove) Targets() []string {
-	names := make([]string, len(o.nodes)+1)
-	names[0] = o.apiserver.Address
-	for i, n := range o.nodes {
-		names[i+1] = n.Name
+	return []string{
+		o.apiserver.Address,
 	}
-	return names
 }
 
 type nodeRemoveCommand struct {
@@ -68,6 +66,7 @@ func (c nodeRemoveCommand) Command() cke.Command {
 		names[i] = n.Name
 	}
 	return cke.Command{
-		Name: "removeNode",
+		Name:   "removeNode",
+		Target: strings.Join(names, ","),
 	}
 }

--- a/op/kube_node_remove.go
+++ b/op/kube_node_remove.go
@@ -2,7 +2,6 @@ package op
 
 import (
 	"context"
-	"strings"
 
 	"github.com/cybozu-go/cke"
 	corev1 "k8s.io/api/core/v1"
@@ -32,8 +31,12 @@ func (o *kubeNodeRemove) NextCommand() cke.Commander {
 	return nodeRemoveCommand{o.apiserver, o.nodes}
 }
 
-func (o *kubeNodeRemove) Targets() []cke.Node {
-	return []cke.Node{}
+func (o *kubeNodeRemove) Nodes() []string {
+	ips := []string{}
+	for _, n := range o.nodes {
+		ips = append(ips, n.Name)
+	}
+	return ips
 }
 
 type nodeRemoveCommand struct {
@@ -59,12 +62,7 @@ func (c nodeRemoveCommand) Run(ctx context.Context, inf cke.Infrastructure) erro
 }
 
 func (c nodeRemoveCommand) Command() cke.Command {
-	names := make([]string, len(c.nodes))
-	for i, n := range c.nodes {
-		names[i] = n.Name
-	}
 	return cke.Command{
-		Name:   "removeNode",
-		Target: strings.Join(names, ","),
+		Name: "removeNode",
 	}
 }

--- a/op/kube_node_remove.go
+++ b/op/kube_node_remove.go
@@ -32,12 +32,12 @@ func (o *kubeNodeRemove) NextCommand() cke.Commander {
 }
 
 func (o *kubeNodeRemove) Targets() []string {
-	ips := make([]string, len(o.nodes)+1)
-	ips[0] = o.apiserver.Address
+	names := make([]string, len(o.nodes)+1)
+	names[0] = o.apiserver.Address
 	for i, n := range o.nodes {
-		ips[i+1] = n.Name
+		names[i+1] = n.Name
 	}
-	return ips
+	return names
 }
 
 type nodeRemoveCommand struct {

--- a/op/kube_node_remove.go
+++ b/op/kube_node_remove.go
@@ -32,6 +32,10 @@ func (o *kubeNodeRemove) NextCommand() cke.Commander {
 	return nodeRemoveCommand{o.apiserver, o.nodes}
 }
 
+func (o *kubeNodeRemove) Targets() []cke.Node {
+	return []cke.Node{}
+}
+
 type nodeRemoveCommand struct {
 	apiserver *cke.Node
 	nodes     []*corev1.Node

--- a/op/kube_node_remove.go
+++ b/op/kube_node_remove.go
@@ -2,6 +2,7 @@ package op
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cybozu-go/cke"
 	corev1 "k8s.io/api/core/v1"
@@ -32,9 +33,9 @@ func (o *kubeNodeRemove) NextCommand() cke.Commander {
 }
 
 func (o *kubeNodeRemove) Nodes() []string {
-	ips := []string{}
-	for _, n := range o.nodes {
-		ips = append(ips, n.Name)
+	ips := make([]string, len(o.nodes))
+	for i, n := range o.nodes {
+		ips[i] = n.Name
 	}
 	return ips
 }
@@ -62,7 +63,13 @@ func (c nodeRemoveCommand) Run(ctx context.Context, inf cke.Infrastructure) erro
 }
 
 func (c nodeRemoveCommand) Command() cke.Command {
+	names := make([]string, len(c.nodes))
+	for i, n := range c.nodes {
+		names[i] = n.Name
+	}
+	detail := "remove nodes, " + strings.Join(names, ",")
 	return cke.Command{
-		Name: "removeNode",
+		Name:   "removeNode",
+		Detail: detail,
 	}
 }

--- a/op/kube_node_update.go
+++ b/op/kube_node_update.go
@@ -32,6 +32,10 @@ func (o *kubeNodeUpdate) NextCommand() cke.Commander {
 	return nodeUpdateCommand{o.apiserver, o.nodes}
 }
 
+func (o *kubeNodeUpdate) Targets() []cke.Node {
+	return []cke.Node{}
+}
+
 type nodeUpdateCommand struct {
 	apiserver *cke.Node
 	nodes     []*corev1.Node

--- a/op/kube_node_update.go
+++ b/op/kube_node_update.go
@@ -32,7 +32,7 @@ func (o *kubeNodeUpdate) NextCommand() cke.Commander {
 	return nodeUpdateCommand{o.apiserver, o.nodes}
 }
 
-func (o *kubeNodeUpdate) Nodes() []string {
+func (o *kubeNodeUpdate) Targets() []string {
 	ips := make([]string, len(o.nodes))
 	for i, n := range o.nodes {
 		ips[i] = n.Name

--- a/op/kube_node_update.go
+++ b/op/kube_node_update.go
@@ -2,7 +2,6 @@ package op
 
 import (
 	"context"
-	"strings"
 
 	"github.com/cybozu-go/cke"
 	corev1 "k8s.io/api/core/v1"
@@ -32,8 +31,12 @@ func (o *kubeNodeUpdate) NextCommand() cke.Commander {
 	return nodeUpdateCommand{o.apiserver, o.nodes}
 }
 
-func (o *kubeNodeUpdate) Targets() []cke.Node {
-	return []cke.Node{}
+func (o *kubeNodeUpdate) Nodes() []string {
+	ips := []string{}
+	for _, n := range o.nodes {
+		ips = append(ips, n.Name)
+	}
+	return ips
 }
 
 type nodeUpdateCommand struct {
@@ -59,12 +62,7 @@ func (c nodeUpdateCommand) Run(ctx context.Context, inf cke.Infrastructure) erro
 }
 
 func (c nodeUpdateCommand) Command() cke.Command {
-	names := make([]string, len(c.nodes))
-	for i, n := range c.nodes {
-		names[i] = n.Name
-	}
 	return cke.Command{
-		Name:   "updateNode",
-		Target: strings.Join(names, ","),
+		Name: "updateNode",
 	}
 }

--- a/op/kube_node_update.go
+++ b/op/kube_node_update.go
@@ -2,6 +2,7 @@ package op
 
 import (
 	"context"
+	"strings"
 
 	"github.com/cybozu-go/cke"
 	corev1 "k8s.io/api/core/v1"
@@ -32,9 +33,9 @@ func (o *kubeNodeUpdate) NextCommand() cke.Commander {
 }
 
 func (o *kubeNodeUpdate) Nodes() []string {
-	ips := []string{}
-	for _, n := range o.nodes {
-		ips = append(ips, n.Name)
+	ips := make([]string, len(o.nodes))
+	for i, n := range o.nodes {
+		ips[i] = n.Name
 	}
 	return ips
 }
@@ -62,7 +63,13 @@ func (c nodeUpdateCommand) Run(ctx context.Context, inf cke.Infrastructure) erro
 }
 
 func (c nodeUpdateCommand) Command() cke.Command {
+	names := make([]string, len(c.nodes))
+	for i, n := range c.nodes {
+		names[i] = n.Name
+	}
+	detail := "update nodes, " + strings.Join(names, ",")
 	return cke.Command{
-		Name: "updateNode",
+		Name:   "updateNode",
+		Detail: detail,
 	}
 }

--- a/op/kube_node_update.go
+++ b/op/kube_node_update.go
@@ -2,7 +2,6 @@ package op
 
 import (
 	"context"
-	"strings"
 
 	"github.com/cybozu-go/cke"
 	corev1 "k8s.io/api/core/v1"
@@ -67,9 +66,7 @@ func (c nodeUpdateCommand) Command() cke.Command {
 	for i, n := range c.nodes {
 		names[i] = n.Name
 	}
-	detail := "update nodes, " + strings.Join(names, ",")
 	return cke.Command{
-		Name:   "updateNode",
-		Detail: detail,
+		Name: "updateNode",
 	}
 }

--- a/op/kube_wait.go
+++ b/op/kube_wait.go
@@ -35,7 +35,7 @@ func (o *kubeWaitOp) NextCommand() cke.Commander {
 
 func (o *kubeWaitOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 

--- a/op/kube_wait.go
+++ b/op/kube_wait.go
@@ -33,6 +33,12 @@ func (o *kubeWaitOp) NextCommand() cke.Commander {
 	return waitKubeCommand{o.apiserver}
 }
 
+func (o *kubeWaitOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
+}
+
 type waitKubeCommand struct {
 	apiserver *cke.Node
 }

--- a/op/kube_wait.go
+++ b/op/kube_wait.go
@@ -33,7 +33,7 @@ func (o *kubeWaitOp) NextCommand() cke.Commander {
 	return waitKubeCommand{o.apiserver}
 }
 
-func (o *kubeWaitOp) Nodes() []string {
+func (o *kubeWaitOp) Targets() []string {
 	return []string{
 		o.apiserver.Address,
 	}

--- a/op/kube_wait.go
+++ b/op/kube_wait.go
@@ -33,9 +33,9 @@ func (o *kubeWaitOp) NextCommand() cke.Commander {
 	return waitKubeCommand{o.apiserver}
 }
 
-func (o *kubeWaitOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *kubeWaitOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 

--- a/op/nodedns/create_configmap.go
+++ b/op/nodedns/create_configmap.go
@@ -39,7 +39,7 @@ func (o *createConfigMapOp) NextCommand() cke.Commander {
 	return createConfigMapCommand{o.apiserver, o.clusterIP, o.domain, o.dnsServers}
 }
 
-func (o *createConfigMapOp) Nodes() []string {
+func (o *createConfigMapOp) Targets() []string {
 	return []string{
 		o.apiserver.Address,
 	}

--- a/op/nodedns/create_configmap.go
+++ b/op/nodedns/create_configmap.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cybozu-go/cke"
 	"github.com/cybozu-go/cke/op"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type createConfigMapOp struct {
@@ -60,7 +60,7 @@ func (c createConfigMapCommand) Run(ctx context.Context, inf cke.Infrastructure)
 
 	// ConfigMap
 	configs := cs.CoreV1().ConfigMaps("kube-system")
-	_, err = configs.Get(op.NodeDNSAppName, v1.GetOptions{})
+	_, err = configs.Get(op.NodeDNSAppName, metav1.GetOptions{})
 	switch {
 	case err == nil:
 	case errors.IsNotFound(err):

--- a/op/nodedns/create_configmap.go
+++ b/op/nodedns/create_configmap.go
@@ -6,7 +6,7 @@ import (
 	"github.com/cybozu-go/cke"
 	"github.com/cybozu-go/cke/op"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type createConfigMapOp struct {
@@ -39,9 +39,9 @@ func (o *createConfigMapOp) NextCommand() cke.Commander {
 	return createConfigMapCommand{o.apiserver, o.clusterIP, o.domain, o.dnsServers}
 }
 
-func (o *createConfigMapOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *createConfigMapOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 

--- a/op/nodedns/create_configmap.go
+++ b/op/nodedns/create_configmap.go
@@ -80,6 +80,5 @@ func (c createConfigMapCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "createConfigMapCommand",
 		Target: "kube-system",
-		Detail: "create configmap in kube-system",
 	}
 }

--- a/op/nodedns/create_configmap.go
+++ b/op/nodedns/create_configmap.go
@@ -39,6 +39,12 @@ func (o *createConfigMapOp) NextCommand() cke.Commander {
 	return createConfigMapCommand{o.apiserver, o.clusterIP, o.domain, o.dnsServers}
 }
 
+func (o *createConfigMapOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
+}
+
 type createConfigMapCommand struct {
 	apiserver  *cke.Node
 	clusterIP  string

--- a/op/nodedns/create_configmap.go
+++ b/op/nodedns/create_configmap.go
@@ -41,7 +41,7 @@ func (o *createConfigMapOp) NextCommand() cke.Commander {
 
 func (o *createConfigMapOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 
@@ -80,5 +80,6 @@ func (c createConfigMapCommand) Command() cke.Command {
 	return cke.Command{
 		Name:   "createConfigMapCommand",
 		Target: "kube-system",
+		Detail: "create configmap in kube-system",
 	}
 }

--- a/op/nodedns/update_configmap.go
+++ b/op/nodedns/update_configmap.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/cybozu-go/cke"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 type updateConfigMapOp struct {
@@ -33,9 +33,9 @@ func (o *updateConfigMapOp) NextCommand() cke.Commander {
 	return updateConfigMapCommand{o.apiserver, o.configMap}
 }
 
-func (o *updateConfigMapOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *updateConfigMapOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 

--- a/op/nodedns/update_configmap.go
+++ b/op/nodedns/update_configmap.go
@@ -33,7 +33,7 @@ func (o *updateConfigMapOp) NextCommand() cke.Commander {
 	return updateConfigMapCommand{o.apiserver, o.configMap}
 }
 
-func (o *updateConfigMapOp) Nodes() []string {
+func (o *updateConfigMapOp) Targets() []string {
 	return []string{
 		o.apiserver.Address,
 	}

--- a/op/nodedns/update_configmap.go
+++ b/op/nodedns/update_configmap.go
@@ -4,17 +4,17 @@ import (
 	"context"
 
 	"github.com/cybozu-go/cke"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type updateConfigMapOp struct {
 	apiserver *cke.Node
-	configMap *v1.ConfigMap
+	configMap *corev1.ConfigMap
 	finished  bool
 }
 
 // UpdateConfigMapOp returns an Operator to update unbound as Node local resolver.
-func UpdateConfigMapOp(apiserver *cke.Node, configMap *v1.ConfigMap) cke.Operator {
+func UpdateConfigMapOp(apiserver *cke.Node, configMap *corev1.ConfigMap) cke.Operator {
 	return &updateConfigMapOp{
 		apiserver: apiserver,
 		configMap: configMap,
@@ -35,13 +35,13 @@ func (o *updateConfigMapOp) NextCommand() cke.Commander {
 
 func (o *updateConfigMapOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 
 type updateConfigMapCommand struct {
 	apiserver *cke.Node
-	configMap *v1.ConfigMap
+	configMap *corev1.ConfigMap
 }
 
 func (c updateConfigMapCommand) Run(ctx context.Context, inf cke.Infrastructure) error {

--- a/op/nodedns/update_configmap.go
+++ b/op/nodedns/update_configmap.go
@@ -33,6 +33,12 @@ func (o *updateConfigMapOp) NextCommand() cke.Commander {
 	return updateConfigMapCommand{o.apiserver, o.configMap}
 }
 
+func (o *updateConfigMapOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
+}
+
 type updateConfigMapCommand struct {
 	apiserver *cke.Node
 	configMap *v1.ConfigMap

--- a/op/resource.go
+++ b/op/resource.go
@@ -34,7 +34,7 @@ func (o *resourceApplyOp) NextCommand() cke.Commander {
 
 func (o *resourceApplyOp) Nodes() []string {
 	return []string{
-		o.apiserver.Nodename(),
+		o.apiserver.Address,
 	}
 }
 

--- a/op/resource.go
+++ b/op/resource.go
@@ -32,7 +32,7 @@ func (o *resourceApplyOp) NextCommand() cke.Commander {
 	return o
 }
 
-func (o *resourceApplyOp) Nodes() []string {
+func (o *resourceApplyOp) Targets() []string {
 	return []string{
 		o.apiserver.Address,
 	}

--- a/op/resource.go
+++ b/op/resource.go
@@ -32,9 +32,9 @@ func (o *resourceApplyOp) NextCommand() cke.Commander {
 	return o
 }
 
-func (o *resourceApplyOp) Targets() []cke.Node {
-	return []cke.Node{
-		*o.apiserver,
+func (o *resourceApplyOp) Nodes() []string {
+	return []string{
+		o.apiserver.Nodename(),
 	}
 }
 

--- a/op/resource.go
+++ b/op/resource.go
@@ -32,6 +32,12 @@ func (o *resourceApplyOp) NextCommand() cke.Commander {
 	return o
 }
 
+func (o *resourceApplyOp) Targets() []cke.Node {
+	return []cke.Node{
+		*o.apiserver,
+	}
+}
+
 func (o *resourceApplyOp) Run(ctx context.Context, inf cke.Infrastructure) error {
 	cs, err := inf.K8sClient(ctx, o.apiserver)
 	if err != nil {

--- a/op/status.go
+++ b/op/status.go
@@ -194,7 +194,7 @@ func getEtcdMembers(ctx context.Context, inf cke.Infrastructure, cli *clientv3.C
 	return members, nil
 }
 
-// GuessMemberName returns member name
+// GuessMemberName returns etcd member's ip address
 func GuessMemberName(m *etcdserverpb.Member) (string, error) {
 	if len(m.Name) > 0 {
 		return m.Name, nil

--- a/op/status.go
+++ b/op/status.go
@@ -185,7 +185,7 @@ func getEtcdMembers(ctx context.Context, inf cke.Infrastructure, cli *clientv3.C
 	}
 	members := make(map[string]*etcdserverpb.Member)
 	for _, m := range resp.Members {
-		name, err := guessMemberName(m)
+		name, err := GuessMemberName(m)
 		if err != nil {
 			return nil, err
 		}
@@ -194,7 +194,8 @@ func getEtcdMembers(ctx context.Context, inf cke.Infrastructure, cli *clientv3.C
 	return members, nil
 }
 
-func guessMemberName(m *etcdserverpb.Member) (string, error) {
+// GuessMemberName returns member name
+func GuessMemberName(m *etcdserverpb.Member) (string, error) {
 	if len(m.Name) > 0 {
 		return m.Name, nil
 	}

--- a/op/stop.go
+++ b/op/stop.go
@@ -23,6 +23,14 @@ func (o *containerStopOp) NextCommand() cke.Commander {
 	return common.KillContainersCommand(o.nodes, o.name)
 }
 
+func (o *containerStopOp) Targets() []cke.Node {
+	nodes := []cke.Node{}
+	for _, v := range o.nodes {
+		nodes = append(nodes, *v)
+	}
+	return nodes
+}
+
 // APIServerStopOp returns an Operator to stop API server
 func APIServerStopOp(nodes []*cke.Node) cke.Operator {
 	return &containerStopOp{

--- a/op/stop.go
+++ b/op/stop.go
@@ -23,12 +23,12 @@ func (o *containerStopOp) NextCommand() cke.Commander {
 	return common.KillContainersCommand(o.nodes, o.name)
 }
 
-func (o *containerStopOp) Targets() []cke.Node {
-	nodes := []cke.Node{}
-	for _, v := range o.nodes {
-		nodes = append(nodes, *v)
+func (o *containerStopOp) Nodes() []string {
+	ips := []string{}
+	for _, n := range o.nodes {
+		ips = append(ips, n.Nodename())
 	}
-	return nodes
+	return ips
 }
 
 // APIServerStopOp returns an Operator to stop API server

--- a/op/stop.go
+++ b/op/stop.go
@@ -23,7 +23,7 @@ func (o *containerStopOp) NextCommand() cke.Commander {
 	return common.KillContainersCommand(o.nodes, o.name)
 }
 
-func (o *containerStopOp) Nodes() []string {
+func (o *containerStopOp) Targets() []string {
 	ips := make([]string, len(o.nodes))
 	for i, n := range o.nodes {
 		ips[i] = n.Address

--- a/op/stop.go
+++ b/op/stop.go
@@ -24,9 +24,9 @@ func (o *containerStopOp) NextCommand() cke.Commander {
 }
 
 func (o *containerStopOp) Nodes() []string {
-	ips := []string{}
-	for _, n := range o.nodes {
-		ips = append(ips, n.Nodename())
+	ips := make([]string, len(o.nodes))
+	for i, n := range o.nodes {
+		ips[i] = n.Address
 	}
 	return ips
 }

--- a/operation.go
+++ b/operation.go
@@ -11,7 +11,7 @@ type Operator interface {
 	Name() string
 	// NextCommand returns the next command or nil if completed.
 	NextCommand() Commander
-	// Targets returns the nodes ip addresses which will be affected by the operation
+	// Targets returns the ip which will be affected by the operation
 	Targets() []string
 }
 
@@ -27,13 +27,9 @@ type Commander interface {
 type Command struct {
 	Name   string `json:"name"`
 	Target string `json:"target"`
-	Detail string `json:"detail"`
 }
 
 // String implements fmt.Stringer
 func (c Command) String() string {
-	if len(c.Detail) > 0 {
-		return fmt.Sprintf("%s %s: %s", c.Name, c.Target, c.Detail)
-	}
 	return fmt.Sprintf("%s %s", c.Name, c.Target)
 }

--- a/operation.go
+++ b/operation.go
@@ -11,8 +11,8 @@ type Operator interface {
 	Name() string
 	// NextCommand returns the next command or nil if completed.
 	NextCommand() Commander
-	// Nodes returns the nodes ip addresses which will be affected by the operation
-	Nodes() []string
+	// Targets returns the nodes ip addresses which will be affected by the operation
+	Targets() []string
 }
 
 // Commander is a single step to proceed an operation

--- a/operation.go
+++ b/operation.go
@@ -11,8 +11,8 @@ type Operator interface {
 	Name() string
 	// NextCommand returns the next command or nil if completed.
 	NextCommand() Commander
-	// Targets returns the nodes which will be affected by the operation
-	Targets() []Node
+	// Nodes returns the nodes ip addresses which will be affected by the operation
+	Nodes() []string
 }
 
 // Commander is a single step to proceed an operation

--- a/operation.go
+++ b/operation.go
@@ -11,6 +11,8 @@ type Operator interface {
 	Name() string
 	// NextCommand returns the next command or nil if completed.
 	NextCommand() Commander
+	// Targets returns the nodes which will be affected by the operation
+	Targets() []Node
 }
 
 // Commander is a single step to proceed an operation

--- a/record.go
+++ b/record.go
@@ -21,6 +21,7 @@ type Record struct {
 	Status    RecordStatus `json:"status"`
 	Operation string       `json:"operation"`
 	Command   Command      `json:"command"`
+	Nodes     []Node       `json:"nodes"`
 	Error     string       `json:"error"`
 	StartAt   time.Time    `json:"start-at"`
 	EndAt     time.Time    `json:"end-at"`
@@ -52,6 +53,11 @@ func (r *Record) Complete() {
 func (r *Record) SetCommand(c Command) {
 	r.Status = StatusRunning
 	r.Command = c
+}
+
+// SetTargets updates the record for the targets
+func (r *Record) SetTargets(n []Node) {
+	r.Nodes = n
 }
 
 // SetError cancels the operation with error information

--- a/record.go
+++ b/record.go
@@ -21,7 +21,7 @@ type Record struct {
 	Status    RecordStatus `json:"status"`
 	Operation string       `json:"operation"`
 	Command   Command      `json:"command"`
-	Nodes     []Node       `json:"nodes"`
+	Nodes     []string     `json:"nodes"`
 	Error     string       `json:"error"`
 	StartAt   time.Time    `json:"start-at"`
 	EndAt     time.Time    `json:"end-at"`
@@ -55,8 +55,8 @@ func (r *Record) SetCommand(c Command) {
 	r.Command = c
 }
 
-// SetTargets updates the record for the targets
-func (r *Record) SetTargets(n []Node) {
+// SetNodes updates the record for the targets
+func (r *Record) SetNodes(n []string) {
 	r.Nodes = n
 }
 

--- a/record.go
+++ b/record.go
@@ -21,18 +21,19 @@ type Record struct {
 	Status    RecordStatus `json:"status"`
 	Operation string       `json:"operation"`
 	Command   Command      `json:"command"`
-	Nodes     []string     `json:"nodes"`
+	Targets   []string     `json:"targets"`
 	Error     string       `json:"error"`
 	StartAt   time.Time    `json:"start-at"`
 	EndAt     time.Time    `json:"end-at"`
 }
 
 // NewRecord creates new `Record`
-func NewRecord(id int64, op string) *Record {
+func NewRecord(id int64, op string, targets []string) *Record {
 	return &Record{
 		ID:        id,
 		Status:    StatusNew,
 		Operation: op,
+		Targets:   targets,
 		StartAt:   time.Now().UTC(),
 	}
 }
@@ -53,11 +54,6 @@ func (r *Record) Complete() {
 func (r *Record) SetCommand(c Command) {
 	r.Status = StatusRunning
 	r.Command = c
-}
-
-// SetNodes updates the record for the targets
-func (r *Record) SetNodes(n []string) {
-	r.Nodes = n
 }
 
 // SetError cancels the operation with error information

--- a/server/control.go
+++ b/server/control.go
@@ -250,7 +250,7 @@ func runOp(ctx context.Context, op cke.Operator, leaderKey string, storage cke.S
 	if err != nil {
 		return err
 	}
-	record := cke.NewRecord(id, op.Name())
+	record := cke.NewRecord(id, op.Name(), op.Targets())
 	err = storage.RegisterRecord(ctx, leaderKey, record)
 	if err != nil {
 		return err
@@ -280,14 +280,13 @@ func runOp(ctx context.Context, op cke.Operator, leaderKey string, storage cke.S
 		default:
 		}
 
-		record.SetNodes(op.Nodes())
 		err = storage.UpdateRecord(ctx, leaderKey, record)
 		if err != nil {
 			return err
 		}
 		log.Info("record targerts", map[string]interface{}{
 			"op":      op.Name(),
-			"targets": strings.Join(op.Nodes(), " "),
+			"targets": strings.Join(op.Targets(), " "),
 		})
 
 		record.SetCommand(commander.Command())

--- a/server/control.go
+++ b/server/control.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"time"
@@ -279,6 +280,20 @@ func runOp(ctx context.Context, op cke.Operator, leaderKey string, storage cke.S
 		default:
 		}
 
+		record.SetTargets(op.Targets())
+		err = storage.UpdateRecord(ctx, leaderKey, record)
+		if err != nil {
+			return err
+		}
+		nodes, err := json.Marshal(op.Targets())
+		if err != nil {
+			return err
+		}
+		log.Info("record targerts", map[string]interface{}{
+			"op":      op.Name(),
+			"targets": string(nodes),
+		})
+
 		record.SetCommand(commander.Command())
 		err = storage.UpdateRecord(ctx, leaderKey, record)
 		if err != nil {
@@ -292,7 +307,6 @@ func runOp(ctx context.Context, op cke.Operator, leaderKey string, storage cke.S
 		if err == nil {
 			continue
 		}
-
 		log.Error("command failed", map[string]interface{}{
 			log.FnError: err,
 			"op":        op.Name(),

--- a/server/control.go
+++ b/server/control.go
@@ -280,7 +280,6 @@ func runOp(ctx context.Context, op cke.Operator, leaderKey string, storage cke.S
 		default:
 		}
 
-		err = storage.UpdateRecord(ctx, leaderKey, record)
 		if err != nil {
 			return err
 		}

--- a/server/control.go
+++ b/server/control.go
@@ -280,9 +280,6 @@ func runOp(ctx context.Context, op cke.Operator, leaderKey string, storage cke.S
 		default:
 		}
 
-		if err != nil {
-			return err
-		}
 		log.Info("record targerts", map[string]interface{}{
 			"op":      op.Name(),
 			"targets": strings.Join(op.Targets(), " "),

--- a/server/control.go
+++ b/server/control.go
@@ -2,9 +2,9 @@ package server
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/coreos/etcd/clientv3/concurrency"
@@ -280,18 +280,14 @@ func runOp(ctx context.Context, op cke.Operator, leaderKey string, storage cke.S
 		default:
 		}
 
-		record.SetTargets(op.Targets())
+		record.SetNodes(op.Nodes())
 		err = storage.UpdateRecord(ctx, leaderKey, record)
-		if err != nil {
-			return err
-		}
-		nodes, err := json.Marshal(op.Targets())
 		if err != nil {
 			return err
 		}
 		log.Info("record targerts", map[string]interface{}{
 			"op":      op.Name(),
-			"targets": string(nodes),
+			"targets": strings.Join(op.Nodes(), " "),
 		})
 
 		record.SetCommand(commander.Command())

--- a/server/node_filter.go
+++ b/server/node_filter.go
@@ -3,6 +3,7 @@ package server
 import (
 	"strings"
 
+	"github.com/coreos/etcd/etcdserver/etcdserverpb"
 	"github.com/cybozu-go/cke"
 	"github.com/cybozu-go/cke/op/etcd"
 	"github.com/cybozu-go/cke/op/k8s"
@@ -128,8 +129,8 @@ func (nf *NodeFilter) EtcdStoppedMembers() (nodes []*cke.Node) {
 	return nodes
 }
 
-// EtcdNonClusterMemberIDs returns IDs of etcd members not defined in cluster YAML.
-func (nf *NodeFilter) EtcdNonClusterMemberIDs(healthy bool) (ids []uint64) {
+// EtcdNonClusterMembers returns etcd members whose IDs are not defined in cluster YAML.
+func (nf *NodeFilter) EtcdNonClusterMembers(healthy bool) (members []*etcdserverpb.Member) {
 	st := nf.status.Etcd
 	for k, v := range st.Members {
 		if nf.InCluster(k) {
@@ -138,9 +139,9 @@ func (nf *NodeFilter) EtcdNonClusterMemberIDs(healthy bool) (ids []uint64) {
 		if st.InSyncMembers[k] != healthy {
 			continue
 		}
-		ids = append(ids, v.ID)
+		members = append(members, v)
 	}
-	return ids
+	return members
 }
 
 // EtcdNonCPMembers returns nodes and IDs of etcd members running on

--- a/server/strategy.go
+++ b/server/strategy.go
@@ -109,8 +109,8 @@ func k8sOps(c *cke.Cluster, nf *NodeFilter) (ops []cke.Operator) {
 }
 
 func etcdMaintOp(c *cke.Cluster, nf *NodeFilter) cke.Operator {
-	if ids := nf.EtcdNonClusterMemberIDs(false); len(ids) > 0 {
-		return etcd.RemoveMemberOp(nf.ControlPlane(), ids)
+	if members := nf.EtcdNonClusterMembers(false); len(members) > 0 {
+		return etcd.RemoveMemberOp(nf.ControlPlane(), members)
 	}
 	if nodes, ids := nf.EtcdNonCPMembers(false); len(nodes) > 0 {
 		return etcd.DestroyMemberOp(nf.ControlPlane(), nodes, ids)
@@ -131,8 +131,8 @@ func etcdMaintOp(c *cke.Cluster, nf *NodeFilter) cke.Operator {
 	if nodes := nf.EtcdNewMembers(); len(nodes) > 0 {
 		return etcd.AddMemberOp(nf.ControlPlane(), nodes[0], c.Options.Etcd, c.Options.Kubelet.Domain)
 	}
-	if ids := nf.EtcdNonClusterMemberIDs(true); len(ids) > 0 {
-		return etcd.RemoveMemberOp(nf.ControlPlane(), ids)
+	if members := nf.EtcdNonClusterMembers(true); len(members) > 0 {
+		return etcd.RemoveMemberOp(nf.ControlPlane(), members)
 	}
 	if nodes, ids := nf.EtcdNonCPMembers(true); len(ids) > 0 {
 		return etcd.DestroyMemberOp(nf.ControlPlane(), nodes, ids)

--- a/storage_test.go
+++ b/storage_test.go
@@ -110,7 +110,7 @@ func testStorageRecord(t *testing.T) {
 	}
 
 	leaderKey := e.Key()
-	r := NewRecord(1, "my-operation")
+	r := NewRecord(1, "my-operation", []string{})
 	err = storage.RegisterRecord(ctx, leaderKey, r)
 	if err != nil {
 		t.Fatal(err)
@@ -189,7 +189,7 @@ func testStorageMaint(t *testing.T) {
 
 	leaderKey := e.Key()
 	for i := int64(1); i < 11; i++ {
-		r := NewRecord(i, "my-operation")
+		r := NewRecord(i, "my-operation", []string{})
 		err = storage.RegisterRecord(ctx, leaderKey, r)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
The output of `ckecli history` does not always contain affected nodes' information.
Also, the information is in the `Target` field of the `Command` field, if it exists.  
As a result, the `Target` field was somehow messed up.

This pull request made four changes.
1. Remove nodes' ip addresses in  the `Target` field of the `Command` field.
2. Add another `Target` to the `Record` field and put ip addresses in the field.
3. Remove the `Detail` field of the `Command` field as it was not used anywhere. 