### PR TITLE
Add labels and taints to control plane nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ This project employs a versioning scheme described in [RELEASE.md](RELEASE.md#ve
 
 ### Fixed
 
-- [log] be silent when checking scheduler status (#195).
-- [mtest] use docker instead of podman (#194).
+- log: be silent when checking scheduler status (#195).
+- mtest: use docker instead of podman (#194).
 
 ## [1.14.7] - 2019-06-28
 

--- a/README.md
+++ b/README.md
@@ -49,16 +49,16 @@ Features
     In addition to Docker, CRI runtimes such as [containerd][] or [cri-o][]
     can be used to run Kubernetes Pods.
 
-* Cluster features:
+* Kubernetes features:
 
     * HA control plane.
     * [RBAC][] is enabled.
     * Ready for [PodSecurityPolicy][]
+    * Ready for API [aggregation](https://kubernetes.io/docs/tasks/access-kubernetes-api/configure-aggregation-layer/).
     * `Secret` data are [encrypted at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
     * [CNI][] network plugins.
     * [CoreDNS][] add-on.
     * Node-local DNS cache services.
-    * [Aggregation layer](https://kubernetes.io/docs/tasks/access-kubernetes-api/configure-aggregation-layer/).
     * Nodes can be registered with [Taints][].
     * Preparation of [Scheduler extender](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/scheduler_extender.md).
 
@@ -109,7 +109,7 @@ Usage
 ```console
 $ docker run -d --read-only \
     --network host --name cke \
-    quay.io/cybozu/cke:1.13 [options...]
+    quay.io/cybozu/cke:1.14 [options...]
 ```
 
 ### Install `ckecli` to host file system
@@ -118,7 +118,7 @@ $ docker run -d --read-only \
 $ docker run --rm -u root:root \
     --entrypoint /usr/local/cke/install-tools \
     --mount type=bind,src=DIR,target=/host \
-    quay.io/cybozu/cke:1.13
+    quay.io/cybozu/cke:1.14
 ```
 
 License

--- a/cluster.go
+++ b/cluster.go
@@ -157,14 +157,15 @@ type Options struct {
 
 // Cluster is a set of configurations for a etcd/Kubernetes cluster.
 type Cluster struct {
-	Name          string     `json:"name"           yaml:"name"`
-	Nodes         []*Node    `json:"nodes"          yaml:"nodes"`
-	ServiceSubnet string     `json:"service_subnet" yaml:"service_subnet"`
-	PodSubnet     string     `json:"pod_subnet"     yaml:"pod_subnet"`
-	DNSServers    []string   `json:"dns_servers"    yaml:"dns_servers"`
-	DNSService    string     `json:"dns_service"    yaml:"dns_service"`
-	EtcdBackup    EtcdBackup `json:"etcd_backup"    yaml:"etcd_backup"`
-	Options       Options    `json:"options"        yaml:"options"`
+	Name          string     `json:"name"                yaml:"name"`
+	Nodes         []*Node    `json:"nodes"               yaml:"nodes"`
+	TaintCP       bool       `json:"taint_control_plane" yaml:"taint_control_plane"`
+	ServiceSubnet string     `json:"service_subnet"      yaml:"service_subnet"`
+	PodSubnet     string     `json:"pod_subnet"          yaml:"pod_subnet"`
+	DNSServers    []string   `json:"dns_servers"         yaml:"dns_servers"`
+	DNSService    string     `json:"dns_service"         yaml:"dns_service"`
+	EtcdBackup    EtcdBackup `json:"etcd_backup"         yaml:"etcd_backup"`
+	Options       Options    `json:"options"             yaml:"options"`
 }
 
 // Validate validates the cluster definition.

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -5,17 +5,17 @@ CKE deploys and maintains a Kubernetes cluster and an etcd cluster solely for
 the Kubernetes cluster.  The configurations of the clusters can be defined by
 a YAML or JSON object with these fields:
 
-| Name                  | Required | Type         | Description                                                                 |
-| --------------------- | -------- | ------------ | --------------------------------------------------------------------------- |
-| `name`                | true     | string       | The k8s cluster name.                                                       |
-| `nodes`               | true     | array        | `Node` list.                                                                |
-| `taint_control_plane` | false    | bool         | If true, taint contorl plane nodes with `cke.cybozu.com/master: NoSchedule` |
-| `service_subnet`      | true     | string       | CIDR subnet for k8s `Service`.                                              |
-| `pod_subnet`          | true     | string       | CIDR subnet for k8s `Pod`.                                                  |
-| `dns_servers`         | false    | array        | List of upstream DNS server IP addresses.                                   |
-| `dns_service`         | false    | string       | Upstream DNS service name with namespace as `namespace/service`.            |
-| `etcd_backup`         | false    | `EtcdBackup` | See EtcdBackup.                                                             |
-| `options`             | false    | `Options`    | See options.                                                                |
+| Name                  | Required | Type         | Description                                                      |
+| --------------------- | -------- | ------------ | ---------------------------------------------------------------- |
+| `name`                | true     | string       | The k8s cluster name.                                            |
+| `nodes`               | true     | array        | `Node` list.                                                     |
+| `taint_control_plane` | false    | bool         | If true, taint contorl plane nodes.                              |
+| `service_subnet`      | true     | string       | CIDR subnet for k8s `Service`.                                   |
+| `pod_subnet`          | true     | string       | CIDR subnet for k8s `Pod`.                                       |
+| `dns_servers`         | false    | array        | List of upstream DNS server IP addresses.                        |
+| `dns_service`         | false    | string       | Upstream DNS service name with namespace as `namespace/service`. |
+| `etcd_backup`         | false    | `EtcdBackup` | See EtcdBackup.                                                  |
+| `options`             | false    | `Options`    | See options.                                                     |
 
 * IP addresses in `pod_subnet` are only used for host-local communication
   as a fallback CNI plugin.  They are never seen from outside of the cluster.

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -5,16 +5,17 @@ CKE deploys and maintains a Kubernetes cluster and an etcd cluster solely for
 the Kubernetes cluster.  The configurations of the clusters can be defined by
 a YAML or JSON object with these fields:
 
-| Name             | Required | Type         | Description                                                      |
-| ---------------- | -------- | ------------ | ---------------------------------------------------------------- |
-| `name`           | true     | string       | The k8s cluster name.                                            |
-| `nodes`          | true     | array        | `Node` list.                                                     |
-| `service_subnet` | true     | string       | CIDR subnet for k8s `Service`.                                   |
-| `pod_subnet`     | true     | string       | CIDR subnet for k8s `Pod`.                                       |
-| `dns_servers`    | false    | array        | List of upstream DNS server IP addresses.                        |
-| `dns_service`    | false    | string       | Upstream DNS service name with namespace as `namespace/service`. |
-| `etcd_backup`    | false    | `EtcdBackup` | See EtcdBackup.                                                  |
-| `options`        | false    | `Options`    | See options.                                                     |
+| Name                  | Required | Type         | Description                                                                 |
+| --------------------- | -------- | ------------ | --------------------------------------------------------------------------- |
+| `name`                | true     | string       | The k8s cluster name.                                                       |
+| `nodes`               | true     | array        | `Node` list.                                                                |
+| `taint_control_plane` | false    | bool         | If true, taint contorl plane nodes with `cke.cybozu.com/master: NoSchedule` |
+| `service_subnet`      | true     | string       | CIDR subnet for k8s `Service`.                                              |
+| `pod_subnet`          | true     | string       | CIDR subnet for k8s `Pod`.                                                  |
+| `dns_servers`         | false    | array        | List of upstream DNS server IP addresses.                                   |
+| `dns_service`         | false    | string       | Upstream DNS service name with namespace as `namespace/service`.            |
+| `etcd_backup`         | false    | `EtcdBackup` | See EtcdBackup.                                                             |
+| `options`             | false    | `Options`    | See options.                                                                |
 
 * IP addresses in `pod_subnet` are only used for host-local communication
   as a fallback CNI plugin.  They are never seen from outside of the cluster.
@@ -151,12 +152,12 @@ updated later on.
 
 ### SchedulerParams
 
-| Name          | Required | Type               | Description                                     |
-| ------------- | -------- | ------------------ | ----------------------------------------------- |
-| `extenders`   | false    | `[]string`         | Extender parameters                             |
-| `extra_args`  | false    | array              | Extra command-line arguments.  List of strings. |
-| `extra_binds` | false    | array              | Extra bind mounts.  List of `Mount`.            |
-| `extra_env`   | false    | object             | Extra environment variables.                    |
+| Name          | Required | Type       | Description                                     |
+| ------------- | -------- | ---------- | ----------------------------------------------- |
+| `extenders`   | false    | `[]string` | Extender parameters                             |
+| `extra_args`  | false    | array      | Extra command-line arguments.  List of strings. |
+| `extra_binds` | false    | array      | Extra bind mounts.  List of `Mount`.            |
+| `extra_env`   | false    | object     | Extra environment variables.                    |
 
 Elements of `extenders` are contents of [`ExtenderConfig`](https://github.com/kubernetes/kubernetes/blob/release-1.14//pkg/scheduler/api/v1/types.go#L183) in JSON format.
 

--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -18,7 +18,7 @@ In CKE, the control plane of Kubernetes consists of Nodes.  To isolate
 control plane nodes from others, CKE automatically adds `cke.cybozu.com/master: "true"` label.
 
 If `taint_control_plane` is true in `cluster.yml`, CKE taints control
-plane nodes with `cke.cybozu.com/master: NoSchedule`.
+plane nodes with `cke.cybozu.com/master: PreferNoSchedule`.
 
 Node maintenance
 ----------------

--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -11,6 +11,15 @@ Every node in Kubernetes cluster runs a TCP reverse proxy called [rivers][]
 for load-balancing requests to API servers.  It will implicitly retry
 connection attempts when some API servers are down.
 
+Control plane
+-------------
+
+In CKE, the control plane of Kubernetes consists of Nodes.  To isolate
+control plane nodes from others, CKE automatically adds `cke.cybozu.com/master: "true"` label.
+
+If `taint_control_plane` is true in `cluster.yml`, CKE taints control
+plane nodes with `cke.cybozu.com/master: NoSchedule`.
+
 Node maintenance
 ----------------
 

--- a/op/constants.go
+++ b/op/constants.go
@@ -50,9 +50,9 @@ const (
 	// TimeoutDuration is default timeout duration
 	TimeoutDuration = 5 * time.Second
 
-	// Control plane node label name
+	// CKELabelMaster is the label name added to control plane nodes
 	CKELabelMaster = "cke.cybozu.com/master"
-	// Control plane node taint name
+	// CKETaintMaster is the taint name added to control plane nodes
 	CKETaintMaster = "cke.cybozu.com/master"
 
 	// CKELabelAppName is application name

--- a/op/constants.go
+++ b/op/constants.go
@@ -50,6 +50,11 @@ const (
 	// TimeoutDuration is default timeout duration
 	TimeoutDuration = 5 * time.Second
 
+	// Control plane node label name
+	CKELabelMaster = "cke.cybozu.com/master"
+	// Control plane node taint name
+	CKETaintMaster = "cke.cybozu.com/master"
+
 	// CKELabelAppName is application name
 	CKELabelAppName = "cke.cybozu.com/appname"
 	// EtcdBackupAppName is application name for etcdbackup


### PR DESCRIPTION
With this PR, CKE adds a label `cke.cybozu.com/master: "true"` to control plane nodes.

A new boolean flag `taint_control_node` is added to `cluster.yml`.
When enabled, control plane nodes are tainted with `cke.cybozu.com/master`
whose effect is `PreferNoSchedule`.