### PR TITLE
[ckecli] add options to `ckecli kubernetes issue` command

### DIFF
--- a/docs/ckecli.md
+++ b/docs/ckecli.md
@@ -156,15 +156,17 @@ BACKUP_NAME is the name of backup file.
 
 Control CKE managed kubernetes.
 
-### `ckecli kubernetes issue [--ttl=TTL]`
+### `ckecli kubernetes issue [--ttl=TTL] [--group=GROUPNAME] [--user=USERNAME]`
 
 Write kubeconfig to stdout.
 
 This config file embeds client certificate and can be used with `kubectl` to connect Kubernetes cluster.
 
-| Option  | Default value | Description                   |
-| ------- | ------------- | ----------------------------- |
-| `--ttl` | `2h`          | TTL of the client certificate |
+| Option    | Default value    | Description                                 |
+| --------- | ---------------- | ------------------------------------------- |
+| `--ttl`   | `2h`             | TTL of the client certificate               |
+| `--group` | `system:masters` | organization name of the client certificate |
+| `--user`  | `admin`          | user name of the client certificate         |
 
 `ckecli resource`
 -----------------

--- a/infrastructure.go
+++ b/infrastructure.go
@@ -133,7 +133,7 @@ func (i *ckeInfrastructure) init(ctx context.Context) error {
 
 	i.once.Do(func() {
 		issue := func() (cert, key []byte, err error) {
-			c, k, e := KubernetesCA{}.IssueUserCert(ctx, i, "admin", "system:masters", "25h")
+			c, k, e := KubernetesCA{}.IssueUserCert(ctx, i, RoleAdmin, AdminGroup, "25h")
 			if e != nil {
 				return nil, nil, e
 			}

--- a/infrastructure.go
+++ b/infrastructure.go
@@ -133,7 +133,7 @@ func (i *ckeInfrastructure) init(ctx context.Context) error {
 
 	i.once.Do(func() {
 		issue := func() (cert, key []byte, err error) {
-			c, k, e := KubernetesCA{}.IssueAdminCert(ctx, i, "25h")
+			c, k, e := KubernetesCA{}.IssueUserCert(ctx, i, "admin", "system:masters", "25h")
 			if e != nil {
 				return nil, nil, e
 			}

--- a/kubeconfig.go
+++ b/kubeconfig.go
@@ -26,9 +26,8 @@ func Kubeconfig(cluster, user, ca, clientCrt, clientKey string) *api.Config {
 	return cfg
 }
 
-// AdminKubeconfig makes kubeconfig for admin user
-func AdminKubeconfig(cluster, ca, clientCrt, clientKey, server string) *api.Config {
-	user := "admin"
+// UserKubeconfig makes kubeconfig for users
+func UserKubeconfig(cluster, userName, ca, clientCrt, clientKey, server string) *api.Config {
 	cfg := api.NewConfig()
 	c := api.NewCluster()
 	c.Server = server
@@ -38,10 +37,10 @@ func AdminKubeconfig(cluster, ca, clientCrt, clientKey, server string) *api.Conf
 	auth := api.NewAuthInfo()
 	auth.ClientCertificateData = []byte(clientCrt)
 	auth.ClientKeyData = []byte(clientKey)
-	cfg.AuthInfos[user] = auth
+	cfg.AuthInfos[userName] = auth
 
 	ctx := api.NewContext()
-	ctx.AuthInfo = user
+	ctx.AuthInfo = userName
 	ctx.Cluster = cluster
 	cfg.Contexts["default"] = ctx
 	cfg.CurrentContext = "default"

--- a/pkg/ckecli/cmd/infrastructure.go
+++ b/pkg/ckecli/cmd/infrastructure.go
@@ -102,7 +102,7 @@ func (i *cliInfrastructure) NewEtcdClient(ctx context.Context, endpoints []strin
 }
 
 func (i *cliInfrastructure) K8sClient(ctx context.Context, n *cke.Node) (*kubernetes.Clientset, error) {
-	c, k, err := cke.KubernetesCA{}.IssueUserCert(ctx, i, "admin", "system:masters", "1h")
+	c, k, err := cke.KubernetesCA{}.IssueUserCert(ctx, i, cke.RoleAdmin, cke.AdminGroup, "1h")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ckecli/cmd/infrastructure.go
+++ b/pkg/ckecli/cmd/infrastructure.go
@@ -102,7 +102,7 @@ func (i *cliInfrastructure) NewEtcdClient(ctx context.Context, endpoints []strin
 }
 
 func (i *cliInfrastructure) K8sClient(ctx context.Context, n *cke.Node) (*kubernetes.Clientset, error) {
-	c, k, err := cke.KubernetesCA{}.IssueAdminCert(ctx, i, "1h")
+	c, k, err := cke.KubernetesCA{}.IssueUserCert(ctx, i, "admin", "system:masters", "1h")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ckecli/cmd/kubernetes_issue.go
+++ b/pkg/ckecli/cmd/kubernetes_issue.go
@@ -61,7 +61,7 @@ var kubernetesIssueCmd = &cobra.Command{
 func init() {
 	fs := kubernetesIssueCmd.Flags()
 	fs.StringVar(&kubernetesIssueOpts.TTL, "ttl", "2h", "TTL of the certificate")
-	fs.StringVarP(&kubernetesIssueOpts.GroupName, "group", "g", "system:masters", "Group name of the issuing config")
-	fs.StringVarP(&kubernetesIssueOpts.UserName, "user", "u", "admin", "User name of the issuing config")
+	fs.StringVarP(&kubernetesIssueOpts.GroupName, "group", "g", cke.AdminGroup, "Group name of the issuing config")
+	fs.StringVarP(&kubernetesIssueOpts.UserName, "user", "u", cke.RoleAdmin, "User name of the issuing config")
 	kubernetesCmd.AddCommand(kubernetesIssueCmd)
 }

--- a/pki.go
+++ b/pki.go
@@ -183,19 +183,19 @@ func IssueEtcdClientCertificate(inf Infrastructure, username, ttl string) (cert,
 // KubernetesCA is a certificate authority for k8s cluster.
 type KubernetesCA struct{}
 
-// IssueAdminCert issues client certificate for cluster admin user.
-func (k KubernetesCA) IssueAdminCert(ctx context.Context, inf Infrastructure, ttl string) (crt, key string, err error) {
-	return issueCertificate(inf, CAKubernetes, RoleAdmin,
+// IssueUserCert issues client certificate for user.
+func (k KubernetesCA) IssueUserCert(ctx context.Context, inf Infrastructure, userName, groupName string, ttl string) (crt, key string, err error) {
+	return issueCertificate(inf, CAKubernetes, userName,
 		map[string]interface{}{
 			"ttl":               "2h",
 			"max_ttl":           "48h",
 			"enforce_hostnames": "false",
 			"allow_any_name":    "true",
-			"organization":      "system:masters",
+			"organization":      groupName,
 		},
 		map[string]interface{}{
 			"ttl":                  ttl,
-			"common_name":          "admin",
+			"common_name":          userName,
 			"exclude_cn_from_sans": "true",
 		})
 }


### PR DESCRIPTION
Issuing for non-admin users' certificates by `ckecli kubernetes issue` command is quite useful for debugging purposes.
Thus, this pull request made the following changes. 
- add options `--group` and `--user` to `ckecli kubernetes issue` command in order to create non-admin users' certificates
- reflect the changes to the documents. 
