### PR TITLE
Run Sonobuoy in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,47 @@ jobs:
       - run:
           name: docker-compose down
           command: docker-compose down
+  sonobuoy:
+    docker:
+      - image: google/cloud-sdk
+    steps:
+      - checkout
+      - run:
+          name: Store Service Account
+          command: |
+            echo $GCLOUD_SERVICE_ACCOUNT > account.json
+            gcloud auth activate-service-account --key-file=account.json
+      - run:
+          name: Run Sonobuoy
+          command: ./bin/run-sonobuoy.sh
+          no_output_timeout: 200m
+      - persist_to_workspace:
+         root: /tmp
+         paths:
+          - sonobuoy.tar.gz
+  github-release:
+    docker:
+      - image: quay.io/cybozu/golang:1.12-bionic
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Prepare files
+          command: |
+            mkdir /tmp/upload
+            cp /tmp/workspace/sonobuoy.tar.gz /tmp/upload
+            tar xzf /tmp/workspace/sonobuoy.tar.gz -C /tmp/upload --strip-components=4 plugins/e2e/results/global/e2e.log plugins/e2e/results/global/junit_01.xml
+            sed "s/vX\.Y\.Z/${CIRCLE_TAG}/" sonobuoy/README.md > /tmp/upload/README.md
+            sed "s/vX\.Y\.Z/${CIRCLE_TAG}/" sonobuoy/PRODUCT.yaml > /tmp/upload/PRODUCT.yaml
+      - run:
+          name: Release to GitHub
+          command: |
+            prrelease=
+            if echo ${CIRCLE_TAG} | grep -q -e -; then
+              prerelease="-prerelease"
+            fi
+            ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -n ${CIRCLE_TAG} $prerelease ${CIRCLE_TAG} /tmp/upload
 
 workflows:
   version: 2
@@ -142,7 +183,14 @@ workflows:
       - mtest-containerd-functions
       - mtest-containerd-operators
       - compose
-  release:
+  conformance:
+    jobs:
+      - hold:
+          type: approval
+      - sonobuoy:
+          requires:
+            - hold
+  release-image:
     jobs:
       - build:
           filters:
@@ -161,6 +209,22 @@ workflows:
       - push-image:
           requires:
             - build-image
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+  release-github:
+    jobs:
+      - sonobuoy:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - github-release:
+          requires:
+            - sonobuoy
           filters:
             branches:
               ignore: /.*/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -60,29 +60,27 @@ Bump version
 3. Make a branch to release, for example by `git neco dev "$VERSION"`
 4. Update `version.go`.
 5. Edit `CHANGELOG.md` for the new version ([example][]).
-6. Commit the change and push it.
+6. Commit the change and create a pull request.
 
     ```console
     $ git commit -a -m "Bump version to $VERSION"
     $ git neco review
     ```
-7. Merge this branch.
-8. Checkout `master` branch.
-9. Add a git tag, then push it.
+7. Make sure that Sonobuoy test has been passed.
+8. Merge the pull request.
+9. Make a tag and push it.
 
     ```console
+    $ git checkout master
+    $ git pull
     $ git tag "v$VERSION"
     $ git push origin "v$VERSION"
     ```
 
 Now the version is bumped up and the latest container image is uploaded to [quay.io](https://quay.io/cybozu/cke).
 
-Publish GitHub release page
----------------------------
-
-Go to https://github.com/cybozu-go/cke/releases and edit the tag.
-Finally, press `Publish release` button.
-
+CircleCI also creates a GitHub release automatically after running [sonobuoy](./sonobuoy) tests.
+So, **DO NOT MANUALLY CREATE GITHUB RELEASES**.  The test results will be attached to the GitHub
+release that can be submitted to [cncf/k8s-conformance](https://github.com/cncf/k8s-conformance).
 
 [example]: https://github.com/cybozu-go/etcdpasswd/commit/77d95384ac6c97e7f48281eaf23cb94f68867f79
-[CircleCI]: https://circleci.com/gh/cybozu-go/etcdpasswd

--- a/bin/env-sonobuoy
+++ b/bin/env-sonobuoy
@@ -1,0 +1,8 @@
+PROJECT=neco-test
+ZONE=asia-northeast1-c
+SERVICE_ACCOUNT=neco-test@neco-test.iam.gserviceaccount.com
+INSTANCE_NAME=${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}
+MACHINE_TYPE=n1-standard-16
+DISK_TYPE=pd-ssd
+BOOT_DISK_SIZE=40GB
+GCLOUD="gcloud --quiet --account ${SERVICE_ACCOUNT} --project ${PROJECT}"

--- a/bin/run-sonobuoy.sh
+++ b/bin/run-sonobuoy.sh
@@ -1,0 +1,63 @@
+#!/bin/sh -ex
+
+. $(dirname $0)/env-sonobuoy
+
+delete_instance() {
+  if [ $RET -ne 0 ]; then
+    # do not delete GCP instance upon test failure to help debugging.
+    return
+  fi
+  $GCLOUD compute instances delete ${INSTANCE_NAME} --zone ${ZONE} || true
+}
+
+# Create GCE instance
+$GCLOUD compute instances delete ${INSTANCE_NAME} --zone ${ZONE} || true
+$GCLOUD compute instances create ${INSTANCE_NAME} \
+  --zone ${ZONE} \
+  --machine-type ${MACHINE_TYPE} \
+  --image vmx-enabled \
+  --boot-disk-type ${DISK_TYPE} \
+  --boot-disk-size ${BOOT_DISK_SIZE}
+
+RET=0
+trap delete_instance INT QUIT TERM 0
+
+for i in $(seq 300); do
+  if $GCLOUD compute ssh --zone=${ZONE} cybozu@${INSTANCE_NAME} --command=date 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+cat >run.sh <<EOF
+#!/bin/sh -e
+
+# Run mtest
+GOPATH=\$HOME/go
+export GOPATH
+GO111MODULE=on
+export GO111MODULE
+PATH=/usr/local/go/bin:\$GOPATH/bin:\$PATH
+export PATH
+
+git clone https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} \
+    \$HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
+cd \$HOME/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
+git checkout -qf ${CIRCLE_SHA1}
+
+cd sonobuoy
+make setup
+make run
+exec make sonobuoy
+EOF
+chmod +x run.sh
+
+$GCLOUD compute scp --zone=${ZONE} run.sh cybozu@${INSTANCE_NAME}:
+set +e
+$GCLOUD compute ssh --zone=${ZONE} cybozu@${INSTANCE_NAME} --command='sudo -H /home/cybozu/run.sh'
+RET=$?
+if [ "$RET" -eq 0 ]; then
+  $GCLOUD compute scp --zone=${ZONE} cybozu@${INSTANCE_NAME}:/home/cybozu/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/sonobuoy/sonobuoy.tar.gz /tmp/sonobuoy.tar.gz
+fi
+
+exit $RET

--- a/bin/run-sonobuoy.sh
+++ b/bin/run-sonobuoy.sh
@@ -17,7 +17,8 @@ $GCLOUD compute instances create ${INSTANCE_NAME} \
   --machine-type ${MACHINE_TYPE} \
   --image vmx-enabled \
   --boot-disk-type ${DISK_TYPE} \
-  --boot-disk-size ${BOOT_DISK_SIZE}
+  --boot-disk-size ${BOOT_DISK_SIZE} \
+  --local-ssd interface=scsi
 
 RET=0
 trap delete_instance INT QUIT TERM 0
@@ -29,8 +30,18 @@ for i in $(seq 300); do
   sleep 1
 done
 
+# Extend instance life to complete sonobuoy test
+$GCLOUD compute instances add-metadata ${INSTANCE_NAME} --zone ${ZONE} \
+  --metadata extended=$(date -Iseconds -d+3hours)
+
 cat >run.sh <<EOF
 #!/bin/sh -e
+
+# mkfs and mount local SSD on \$HOME/.vagrant.d
+mkfs -t ext4 -F /dev/disk/by-id/google-local-ssd-0
+mkdir -p \$HOME/.vagrant.d
+mount -t ext4 /dev/disk/by-id/google-local-ssd-0 \$HOME/.vagrant.d
+chmod 755 \$HOME/.vagrant.d
 
 # Run mtest
 GOPATH=\$HOME/go

--- a/bin/run-sonobuoy.sh
+++ b/bin/run-sonobuoy.sh
@@ -48,7 +48,8 @@ git checkout -qf ${CIRCLE_SHA1}
 cd sonobuoy
 make setup
 make run
-exec make sonobuoy
+make sonobuoy
+mv sonobuoy.tar.gz /tmp
 EOF
 chmod +x run.sh
 
@@ -57,7 +58,7 @@ set +e
 $GCLOUD compute ssh --zone=${ZONE} cybozu@${INSTANCE_NAME} --command='sudo -H /home/cybozu/run.sh'
 RET=$?
 if [ "$RET" -eq 0 ]; then
-  $GCLOUD compute scp --zone=${ZONE} cybozu@${INSTANCE_NAME}:/home/cybozu/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/sonobuoy/sonobuoy.tar.gz /tmp/sonobuoy.tar.gz
+  $GCLOUD compute scp --zone=${ZONE} cybozu@${INSTANCE_NAME}:/tmp/sonobuoy.tar.gz /tmp/sonobuoy.tar.gz
 fi
 
 exit $RET

--- a/example/README.md
+++ b/example/README.md
@@ -2,10 +2,10 @@
 
 ## Overview
 
-This demonstration gets you a single host CKE and Kubernetes cluster.
+This demonstration gets you a three-node Kubernetes cluster installed by CKE.
 
-Be warned that `etcd` and `vault` deployed by this example is not durable nor secure.
-You can use this CKE for testing and development.
+**Be warned that `etcd` and `vault` deployed by this example is not durable nor secure.**
+Use this only for testing and development.
 
 ## Requirements
 
@@ -26,7 +26,7 @@ $ git clone https://github.com/cybozu-go/cke.git
 $ cd ./cke/example/
 $ mkdir bin
 $ mkdir etcd-data
-$ docker-compose up
+$ docker-compose up -d
 ```
 
 `bin` is the directory where the cli tools are installed.
@@ -65,7 +65,7 @@ $ vagrant ssh worker-1
 Register SSH private-key to log in to the VMs.
 
 ```console
-$ ./bin/ckecli --config ./cke.config vault ssh-privkey ~/.vagrant.d/insecure_private_key
+$ ./bin/ckecli --config=./cke.config vault ssh-privkey ~/.vagrant.d/insecure_private_key
 ```
 
 ## Declare Kubernetes Cluster Configuration
@@ -73,8 +73,8 @@ $ ./bin/ckecli --config ./cke.config vault ssh-privkey ~/.vagrant.d/insecure_pri
 Declares the number of control planes and workers of Kubernetes cluster and configuration.
 
 ```console
-$ ./bin/ckecli --config ./cke.config constraints set minimum-workers 2
-$ ./bin/ckecli --config ./cke.config constraints set control-plane-count 1
+$ ./bin/ckecli --config=./cke.config constraints set minimum-workers 2
+$ ./bin/ckecli --config=./cke.config constraints set control-plane-count 1
 $ ./bin/ckecli --config=./cke.config cluster set ./cke-cluster.yml
 ```
 
@@ -85,7 +85,7 @@ Once the cluster configuration is set, CKE will soon install Kubernetes.
 You can see the operation history with the following command.
 
 ```console
-$ ./bin/ckecli --config ./cke.config history -f
+$ ./bin/ckecli --config=./cke.config history -f
 ```
 
 You can also see the logs of CKE.

--- a/example/Vagrantfile
+++ b/example/Vagrantfile
@@ -11,15 +11,15 @@ Vagrant.configure("2") do |config|
   config.vm.define "worker-1" do |machine|
     machine.vm.network "private_network", ip: "192.168.1.101"
     machine.vm.provider "virtualbox" do |vb|
-      vb.memory = "14336"
-      vb.cpus = 6
+      vb.memory = "4096"
+      vb.cpus = 4
     end
   end
 
   config.vm.define "worker-2" do |machine|
     machine.vm.network "private_network", ip: "192.168.1.102"
     machine.vm.provider "virtualbox" do |vb|
-      vb.memory = "14336"
+      vb.memory = "4096"
       vb.cpus = 4
     end
   end
@@ -27,7 +27,7 @@ Vagrant.configure("2") do |config|
   config.vm.define "worker-3" do |machine|
     machine.vm.network "private_network", ip: "192.168.1.103"
     machine.vm.provider "virtualbox" do |vb|
-      vb.memory = "14336"
+      vb.memory = "4096"
       vb.cpus = 4
     end
   end

--- a/example/Vagrantfile
+++ b/example/Vagrantfile
@@ -11,24 +11,24 @@ Vagrant.configure("2") do |config|
   config.vm.define "worker-1" do |machine|
     machine.vm.network "private_network", ip: "192.168.1.101"
     machine.vm.provider "virtualbox" do |vb|
-      vb.memory = "4096"
-      vb.cpus = 4
+      vb.memory = "14336"
+      vb.cpus = 6
     end
   end
 
   config.vm.define "worker-2" do |machine|
     machine.vm.network "private_network", ip: "192.168.1.102"
     machine.vm.provider "virtualbox" do |vb|
-      vb.memory = "2048"
-      vb.cpus = 2
+      vb.memory = "14336"
+      vb.cpus = 4
     end
   end
 
   config.vm.define "worker-3" do |machine|
     machine.vm.network "private_network", ip: "192.168.1.103"
     machine.vm.provider "virtualbox" do |vb|
-      vb.memory = "2048"
-      vb.cpus = 2
+      vb.memory = "14336"
+      vb.cpus = 4
     end
   end
 end

--- a/sonobuoy/.gitignore
+++ b/sonobuoy/.gitignore
@@ -1,0 +1,5 @@
+/bin
+/etcd-data
+/.vagrant
+/.kubeconfig
+/sonobuoy.tar.gz

--- a/sonobuoy/Makefile
+++ b/sonobuoy/Makefile
@@ -1,0 +1,75 @@
+### Configurable variables
+SONOBUOY_VERSION = 0.15.3
+KUBECTL_VERSION = 1.15.3
+DOCKER_COMPOSE_VERSION = 1.24.1
+
+### Unconfigurable
+CURL = curl -fsL
+ifeq ($(shell id -u),0)
+SUDO =
+else
+SUDO = sudo
+endif
+GO111MODULE = on
+GOFLAGS = -mod=vendor
+export GO111MODULE GOFLAGS
+SONOBUOY_URL =  https://github.com/heptio/sonobuoy/releases/download/v$(SONOBUOY_VERSION)/sonobuoy_$(SONOBUOY_VERSION)_linux_amd64.tar.gz
+KUBECTL_URL = https://storage.googleapis.com/kubernetes-release/release/v$(KUBECTL_VERSION)/bin/linux/amd64/kubectl
+DOCKER_COMPOSE_URL = https://github.com/docker/compose/releases/download/$(DOCKER_COMPOSE_VERSION)/docker-compose-Linux-x86_64
+PACKAGES = virtualbox vagrant
+CKECLI = ./bin/ckecli --config=./cke.config
+KUBECONFIG := $(shell pwd)/.kubeconfig
+export KUBECONFIG
+
+all:
+	@echo "Available targets:"
+	@echo "    run        Run CKE and install Kubernetes into Vagrant VMs."
+	@echo "    sonobuoy   Run sonobuoy."
+	@echo "    clean      Stop VMs and clean files."
+	@echo "    setup      Onetime setup.  Need root privilege."
+
+bin/cke bin/ckecli:
+	mkdir -p bin
+	GOBIN=$(shell pwd)/bin go install ../pkg/$(notdir $@)
+
+bin/kubectl:
+	mkdir -p bin
+	$(CURL) -o bin/kubectl $(KUBECTL_URL)
+	chmod +x ./bin/kubectl
+
+bin/sonobuoy:
+	mkdir -p bin
+	$(CURL) $(SONOBUOY_URL) | tar xzf - -C bin sonobuoy
+
+run: bin/cke bin/ckecli
+	mkdir -p etcd-data
+	/usr/local/bin/docker-compose up -d
+	vagrant up
+	for i in $$(seq 180); do sleep 1; vagrant ssh worker-1 -c date && break; done
+	$(CKECLI) vault ssh-privkey $$HOME/.vagrant.d/insecure_private_key
+	$(CKECLI) constraints set minimum-workers 2
+	$(CKECLI) constraints set control-plane-count 1
+	$(CKECLI) cluster set ./cke-cluster.yml
+
+sonobuoy: bin/kubectl bin/sonobuoy
+	$(CKECLI) kubernetes issue --ttl=10h > .kubeconfig
+	for i in $$(seq 300); do sleep 1; if [ "$$(./bin/kubectl get -n kube-system ds/node-dns -o json | jq .status.numberReady)" = 3 ]; then break; fi; done
+	for i in $$(seq 300); do sleep 1; if [ "$$(./bin/kubectl get -n kube-system deployments/cluster-dns -o json | jq .status.readyReplicas)" = 2 ]; then break; fi; done
+	./bin/kubectl apply -f ../example/calico.yaml
+	for i in $$(seq 300); do sleep 1; if [ "$$(./bin/kubectl get nodes --no-headers | grep Ready | wc -l)" = 3 ]; then break; fi; done
+	time ./bin/sonobuoy run --wait
+	outfile=$$(./bin/sonobuoy retrieve) && mv $$outfile sonobuoy.tar.gz
+	./bin/sonobuoy delete
+
+clean:
+	-vagrant destroy -f
+	-/usr/local/bin/docker-compose down
+	$(SUDO) rm -rf bin etcd-data
+
+setup:
+	$(SUDO) $(CURL) -o /usr/local/bin/docker-compose $(DOCKER_COMPOSE_URL)
+	$(SUDO) chmod +x /usr/local/bin/docker-compose
+	$(SUDO) apt-get update
+	$(SUDO) apt-get install -y $(PACKAGES)
+
+.PHONY: all run sonobuoy clean setup

--- a/sonobuoy/Makefile
+++ b/sonobuoy/Makefile
@@ -54,9 +54,9 @@ run: bin/cke bin/ckecli
 sonobuoy: bin/kubectl bin/sonobuoy
 	$(CKECLI) kubernetes issue --ttl=10h > .kubeconfig
 	for i in $$(seq 300); do sleep 1; if [ "$$(./bin/kubectl get -n kube-system ds/node-dns -o json | jq .status.numberReady)" = 3 ]; then break; fi; done
-	for i in $$(seq 300); do sleep 1; if [ "$$(./bin/kubectl get -n kube-system deployments/cluster-dns -o json | jq .status.readyReplicas)" = 2 ]; then break; fi; done
 	./bin/kubectl apply -f ../example/calico.yaml
 	for i in $$(seq 300); do sleep 1; if [ "$$(./bin/kubectl get nodes --no-headers | grep Ready | wc -l)" = 3 ]; then break; fi; done
+	for i in $$(seq 300); do sleep 1; if [ "$$(./bin/kubectl get -n kube-system deployments/cluster-dns -o json | jq .status.readyReplicas)" = 2 ]; then break; fi; done
 	time ./bin/sonobuoy run --wait
 	outfile=$$(./bin/sonobuoy retrieve) && mv $$outfile sonobuoy.tar.gz
 	./bin/sonobuoy delete

--- a/sonobuoy/PRODUCT.yaml
+++ b/sonobuoy/PRODUCT.yaml
@@ -1,0 +1,9 @@
+vendor: Cybozu
+name: CKE - Cybozu Kubernetes Engine
+version: vX.Y.Z
+website_url: https://github.com/cybozu-go/cke/
+repo_url: https://github.com/cybozu-go/cke/
+documentation_url: https://github.com/cybozu-go/cke/tree/master/docs
+product_logo_url: https://github.com/cybozu-go/cke/blob/master/logo/cybozu_logo.svg
+type: Installer
+description: Cybozu Kubernetes Engine, a distributed service that automates Kubernetes cluster management.

--- a/sonobuoy/README.md
+++ b/sonobuoy/README.md
@@ -1,0 +1,45 @@
+Conformance test for CKE
+========================
+
+Follow the instructions to run [Sonobuoy][] for conformance test of certified Kubernetes.
+
+## Prepare environment
+
+1. Prepare Ubuntu or Debian machine that can run KVM virtual machines.
+2. Install [Docker CE][].
+3. Install [Go][].
+
+## Checkout CKE source code
+
+To test a certain CKE version, checkout the version tag:
+
+```console
+$ git clone https://github.com/cybozu-go/cke
+$ cd cke/sonobuoy
+$ git checkout vX.Y.Z
+```
+
+## Run Sonobuoy
+
+Setup `docker-compose` and Vagrant, use them to setup CKE and its Kubernetes, then run Sonobuoy
+with the following commands.
+
+```console
+$ sudo make setup
+$ make run
+$ make sonobuoy
+```
+
+When Sonobuoy finishes successfully, it leaves `sonobuoy.tar.gz` file that contains test results.
+
+## Cleanup
+
+Stop and clean Vagrant VMs and Docker containers as follows:
+
+```console
+$ make clean
+```
+
+[Sonobuoy]: https://github.com/heptio/sonobuoy
+[Docker]: https://docs.docker.com/install/linux/docker-ce/ubuntu/
+[Go]: https://golang.org/doc/install#install

--- a/sonobuoy/Vagrantfile
+++ b/sonobuoy/Vagrantfile
@@ -1,0 +1,1 @@
+../example/Vagrantfile

--- a/sonobuoy/cke-cluster.yml
+++ b/sonobuoy/cke-cluster.yml
@@ -1,0 +1,1 @@
+../example/cke-cluster.yml

--- a/sonobuoy/cke.config
+++ b/sonobuoy/cke.config
@@ -1,0 +1,1 @@
+../example/cke.config

--- a/sonobuoy/cke.config.yml
+++ b/sonobuoy/cke.config.yml
@@ -1,0 +1,1 @@
+../example/cke.config.yml

--- a/sonobuoy/docker-compose.yml
+++ b/sonobuoy/docker-compose.yml
@@ -1,0 +1,80 @@
+version: '2'
+services:
+  cke:
+    container_name: cke
+    image: quay.io/cybozu/ubuntu:18.04
+    networks:
+      app_net:
+        ipv4_address: 172.30.0.11
+    user: "${UID}:${GID}"
+    volumes:
+      - ./cke.config.yml:/etc/cke/config.yml
+      - ./bin:/usr/local/bin
+    depends_on:
+      - etcd
+      - vault
+    restart: always
+    entrypoint:
+      - /usr/local/bin/cke
+  setup:
+    container_name: setup
+    image: quay.io/cybozu/ubuntu-debug:18.04
+    networks:
+      app_net:
+        ipv4_address: 172.30.0.12
+    user: "${UID}:${GID}"
+    volumes:
+      - ./bin:/usr/local/bin
+      - ./setup:/opt/setup
+      - ./cke.config.yml:/etc/cke/config.yml
+    depends_on:
+      - vault
+      - etcd
+      - cke
+    command: /opt/setup/setup.sh
+  vault:
+    container_name: vault
+    image: quay.io/cybozu/vault:1.1
+    networks:
+      app_net:
+        ipv4_address: 172.30.0.13
+    user: "${UID}:${GID}"
+    cap_add:
+      - IPC_LOCK
+    depends_on:
+      - etcd
+    volumes:
+      - ./vault.hcl:/etc/vault/config.hcl
+      - ./bin:/host
+      - ./vault-entrypoint.sh:/entrypoint.sh
+    ports:
+      - "8200:8200"
+      - "8201:8201"
+    restart: always
+    entrypoint:
+      - /entrypoint.sh
+  etcd:
+    container_name: etcd
+    image: quay.io/cybozu/etcd:3.3
+    networks:
+      app_net:
+        ipv4_address: 172.30.0.14
+    user: "${UID}:${GID}"
+    volumes:
+      - ./etcd-data:/data/etcd
+      - ./etcd.conf.yml:/etc/etcd/etcd.conf.yml
+      - ./bin:/host
+      - ./etcd-entrypoint.sh:/entrypoint.sh
+    ports:
+      - "2379:2379"
+      - "2380:2380"
+    restart: always
+    entrypoint:
+      - /entrypoint.sh
+networks:
+  app_net:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.30.0.0/24

--- a/sonobuoy/etcd-entrypoint.sh
+++ b/sonobuoy/etcd-entrypoint.sh
@@ -1,0 +1,1 @@
+../example/etcd-entrypoint.sh

--- a/sonobuoy/etcd.conf.yml
+++ b/sonobuoy/etcd.conf.yml
@@ -1,0 +1,1 @@
+../example/etcd.conf.yml

--- a/sonobuoy/setup
+++ b/sonobuoy/setup
@@ -1,0 +1,1 @@
+../example/setup

--- a/sonobuoy/vault-entrypoint.sh
+++ b/sonobuoy/vault-entrypoint.sh
@@ -1,0 +1,1 @@
+../example/vault-entrypoint.sh

--- a/sonobuoy/vault.hcl
+++ b/sonobuoy/vault.hcl
@@ -1,0 +1,1 @@
+../example/vault.hcl


### PR DESCRIPTION
This PR adds [certified Kubernetes](https://github.com/cncf/k8s-conformance) conformance test to CI.

- `sonobuoy/` directory contains files to run the conformance tests by [heptio/sonobuoy](https://github.com/heptio/sonobuoy).
- Pushes to branches triggers a CircleCI workflow `conformance`.
    The workflow holds the test until a human approves to run it.
- Pushing a git tag triggers `release-github` workflow that runs the conformance tests.
    If the test succeeds, the workflow creates a GitHub release and attaches the test results to it.