### PR TITLE
Add PodDisruptionBudget for cluster-dns

### DIFF
--- a/op/status.go
+++ b/op/status.go
@@ -474,7 +474,7 @@ func GetKubernetesClusterStatus(ctx context.Context, inf cke.Infrastructure, n *
 				return cke.KubernetesClusterStatus{}, err
 			}
 			s.SetResourceStatus(rkey, obj.Annotations)
-		case "PodDisruptionBudgets":
+		case "PodDisruptionBudget":
 			obj, err := k8s.PolicyV1beta1().PodDisruptionBudgets(parts[1]).Get(parts[2], metav1.GetOptions{})
 			if k8serr.IsNotFound(err) {
 				continue

--- a/op/status.go
+++ b/op/status.go
@@ -474,6 +474,15 @@ func GetKubernetesClusterStatus(ctx context.Context, inf cke.Infrastructure, n *
 				return cke.KubernetesClusterStatus{}, err
 			}
 			s.SetResourceStatus(rkey, obj.Annotations)
+		case "PodDisruptionBudgets":
+			obj, err := k8s.PolicyV1beta1().PodDisruptionBudgets(parts[1]).Get(parts[2], metav1.GetOptions{})
+			if k8serr.IsNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return cke.KubernetesClusterStatus{}, err
+			}
+			s.SetResourceStatus(rkey, obj.Annotations)
 		default:
 			log.Warn("unknown resource kind", map[string]interface{}{
 				"kind": parts[0],

--- a/pkg/ckecli/cmd/resource_set.go
+++ b/pkg/ckecli/cmd/resource_set.go
@@ -44,7 +44,8 @@ Only the following resource types can be used:
   * Deployment
   * DaemonSet
   * CronJob
-  * Service`,
+  * Service
+  * PodDisruptionBudget`,
 
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/sabakan/generator.go
+++ b/sabakan/generator.go
@@ -109,11 +109,11 @@ type Generator struct {
 // NewGenerator creates a new Generator.
 // current can be nil if no cluster configuration has been set.
 // template must have been validated with ValidateTemplate().
-func NewGenerator(current, template *cke.Cluster, cstr *cke.Constraints, machines []Machine) *Generator {
+func NewGenerator(current, template *cke.Cluster, cstr *cke.Constraints, machines []Machine, currentTime time.Time) *Generator {
 	g := &Generator{
 		template:    template,
 		constraints: cstr,
-		timestamp:   time.Now(),
+		timestamp:   currentTime,
 		waitSeconds: DefaultWaitRetiringSeconds,
 	}
 

--- a/sabakan/generator_test.go
+++ b/sabakan/generator_test.go
@@ -235,7 +235,7 @@ func testNewGenerator(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := NewGenerator(tt.args.current, tt.args.template, tt.args.cstr, tt.args.machines)
+			got := NewGenerator(tt.args.current, tt.args.template, tt.args.cstr, tt.args.machines, testBaseTS)
 			if !cmp.Equal(got.controlPlanes, tt.want.controlPlanes, cmpopts.IgnoreUnexported(cke.Node{}), cmpopts.EquateEmpty()) {
 				t.Errorf("!cmp.Equal(got.controlPlanes, tt.want.controlPlanes), actual: %v, want %v", got.controlPlanes, tt.want.controlPlanes)
 			}
@@ -342,8 +342,7 @@ func testGenerate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			g := NewGenerator(nil, tt.template, tt.cstr, tt.machines)
-			g.timestamp = testBaseTS
+			g := NewGenerator(nil, tt.template, tt.cstr, tt.machines, testBaseTS)
 			cluster, err := g.Generate()
 			if err != nil {
 				if !tt.expectErr {
@@ -420,8 +419,7 @@ func testRegenerate(t *testing.T) {
 	generated := *tmpl
 	generated.Nodes = nil
 
-	g := NewGenerator(cluster, tmpl, cke.DefaultConstraints(), machines)
-	g.timestamp = testBaseTS
+	g := NewGenerator(cluster, tmpl, cke.DefaultConstraints(), machines, testBaseTS)
 	regenerated, err := g.Regenerate()
 	if err != nil {
 		t.Fatal(err)
@@ -801,8 +799,7 @@ func testUpdate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			g := NewGenerator(tt.current, tmpl, tt.cstr, tt.machines)
-			g.timestamp = testBaseTS
+			g := NewGenerator(tt.current, tmpl, tt.cstr, tt.machines, testBaseTS)
 			got, err := g.Update()
 
 			if err != tt.expectErr {
@@ -1009,8 +1006,7 @@ func testWeighted(t *testing.T) {
 				Nodes: append(tt.tmplWorkers, tt.tmplCP),
 			}
 
-			g := NewGenerator(nil, tmpl, tt.cstr, machines)
-			g.timestamp = testBaseTS
+			g := NewGenerator(nil, tmpl, tt.cstr, machines, testBaseTS)
 			cluster, err := g.Generate()
 			if err != nil {
 				t.Fatal(err)

--- a/sabakan/generator_test.go
+++ b/sabakan/generator_test.go
@@ -1010,6 +1010,7 @@ func testWeighted(t *testing.T) {
 			}
 
 			g := NewGenerator(nil, tmpl, tt.cstr, machines)
+			g.timestamp = testBaseTS
 			cluster, err := g.Generate()
 			if err != nil {
 				t.Fatal(err)

--- a/sabakan/integrate.go
+++ b/sabakan/integrate.go
@@ -2,6 +2,7 @@ package sabakan
 
 import (
 	"context"
+	"time"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/cybozu-go/cke"
@@ -96,7 +97,7 @@ func (ig integrator) Do(ctx context.Context, leaderKey string) error {
 		return err
 	}
 
-	g := NewGenerator(cluster, tmpl, cstr, machines)
+	g := NewGenerator(cluster, tmpl, cstr, machines, time.Now())
 
 	val := ctx.Value(WaitSecs)
 	if val != nil {

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -749,6 +749,7 @@ func TestDecideOps(t *testing.T) {
 				"resource-apply",
 				"resource-apply",
 				"resource-apply",
+				"resource-apply",
 			},
 		},
 		{

--- a/static/cluster-dns.yml
+++ b/static/cluster-dns.yml
@@ -155,3 +155,17 @@ spec:
       port: 53
       targetPort: 1053
       protocol: TCP
+---
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: cluster-dns-pdb
+  namespace: kube-system
+  annotations:
+    cke.cybozu.com/revision: "1"
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      cke.cybozu.com/appname: cluster-dns

--- a/static/resources.go
+++ b/static/resources.go
@@ -153,4 +153,13 @@ var Resources = []cke.ResourceDefinition{
 		Image:      "",
 		Definition: []byte("{\"kind\":\"Service\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"cluster-dns\",\"namespace\":\"kube-system\",\"creationTimestamp\":null,\"labels\":{\"cke.cybozu.com/appname\":\"cluster-dns\"},\"annotations\":{\"cke.cybozu.com/revision\":\"1\"}},\"spec\":{\"ports\":[{\"name\":\"dns\",\"protocol\":\"UDP\",\"port\":53,\"targetPort\":1053},{\"name\":\"dns-tcp\",\"protocol\":\"TCP\",\"port\":53,\"targetPort\":1053}],\"selector\":{\"cke.cybozu.com/appname\":\"cluster-dns\"}},\"status\":{\"loadBalancer\":{}}}\n"),
 	},
+	{
+		Key:        "PodDisruptionBudget/kube-system/cluster-dns-pdb",
+		Kind:       "PodDisruptionBudget",
+		Namespace:  "kube-system",
+		Name:       "cluster-dns-pdb",
+		Revision:   1,
+		Image:      "",
+		Definition: []byte("{\"kind\":\"PodDisruptionBudget\",\"apiVersion\":\"policy/v1beta1\",\"metadata\":{\"name\":\"cluster-dns-pdb\",\"namespace\":\"kube-system\",\"creationTimestamp\":null,\"annotations\":{\"cke.cybozu.com/revision\":\"1\"}},\"spec\":{\"selector\":{\"matchLabels\":{\"cke.cybozu.com/appname\":\"cluster-dns\"}},\"maxUnavailable\":1},\"status\":{\"disruptionsAllowed\":0,\"currentHealthy\":0,\"desiredHealthy\":0,\"expectedPods\":0}}\n"),
+	},
 }


### PR DESCRIPTION
To ensure redundancy for `cluster-dns` in case of that more than one pod of `cluster-dns` are located in a node and the node is drained, this pull request made the following changes.

- add `PodDisruptionBudget ` resource for `cluster-dns` deployment.
- modify ops to handle `PodDisruptionBudget ` resource
- refactor unit test as it was unstable