### PR TITLE
Remove code to handle unreachable

### DIFF
--- a/docs/cluster_overview.md
+++ b/docs/cluster_overview.md
@@ -49,7 +49,7 @@ CKE deploys following components to control plane nodes:
 - kube-apiserver
 - kube-scheduler
 - kube-controller-manager
-- revers (works as a load balancer to kube-apiserver)
+- rivers (works as a load balancer to kube-apiserver)
 
 CKE constructs etcd cluster before it construct Kubernetes cluster.  Then CKE
 deploys Kubernetes components with rivers.

--- a/docs/cluster_overview.md
+++ b/docs/cluster_overview.md
@@ -45,14 +45,16 @@ Control Plane Nodes
 CKE deploys following components to control plane nodes:
 
 - etcd
+- etcd-rivers (works as a load balancer to etcd)
 - kube-apiserver
 - kube-scheduler
 - kube-controller-manager
+- revers (works as a load balancer to kube-apiserver)
 
 CKE constructs etcd cluster before it construct Kubernetes cluster.  Then CKE
 deploys Kubernetes components with rivers.
 
-![Control Plane Nodes](http://www.plantuml.com/plantuml/svg/dPF1ReCm44Jl_eeLf_P09E_UgqZz4Ci5Aura2B9DBrN_lTIccA0r8hbvPyQpyLCu-w1T63ihd6c2xY_MGFL-wuExMHYixaq5saEJ51KL2Ty2eDL1VsW_nKresfZwEyZ9MbNfuUgD-p8k1fPfa_BDfsb7EwUMQPEQVyHar9tkzMMEPrb5ETrxUONANQTLFeRIKQeT2oTBm6exrEDGlwslShkOL7vcClE67_40PzpZZ8Suuo7E-2HdBC549Q7ieLXZnZk0o6DcKXdprdoKC-rnfaESwH1dUf8pbLYIaaLhWvdk616FcKbbp5ipOOxVF9nE4HR64Vz74cBvwyztOvnLaLLfLf5jGBO1sGPY6uXj8BP1AfdKZ4IMBInR-L5y8MzXsSflv0jv2yiMYRFfsx6plm00)
+![Control Plane Nodes](http://www.plantuml.com/plantuml/svg/dP11RiCW44Ntd09brIuSYPbz5Qa7iQYDqaZOiG1tK_NkjJ4E43A9avs7__qOti4wQTpOQMPKusH_r8hlFi-zCsVD1orxjUFIycOvgVs9uB-CyrOw-INjL5UkQNrh_X1JbA3aSBBA_2ZZ2vVfgcMRRzMEEhJ2LBJ24bDGTRANnr2FnxK_NlvxUryMgynfkizUzgkNUQqaQGmOJtRWrJXK7p4jxoixyQ4Xog_-Oq_OXdksOPDjs6GRNhGDZsq3PHjOwXeoZt3JTTc9ponTmtEkyPvhtEGQDxd65rtZOzT8kSRCDMOUyQRhiXEVMRh6sVKy2xxV-m3y2Ek8Z2LraH045G0LO1e0XG8A1HGAAHHIACnGsQPHbw02e88L1HGAA1HGAAHGIA6mH1rKtuwT_WS0)
 
 DNS
 ---

--- a/docs/sabakan-integration.md
+++ b/docs/sabakan-integration.md
@@ -165,9 +165,7 @@ CKE generates cluster configuration with the following conditions.
 * The number of servers for each role should be proportional to the given weights in the template.
 * Newer machines should be preferred than old ones.
 * Healthy machines should be preferred than non-healthy ones.
-* Unreachable machines should be removed from the cluster.  
-    This is because CKE cannot work if the cluster configuration contains dead nodes.
-* Unhealthy machines in the cluster should be [tainted][taint] with `NoSchedule`.
+* Unhealthy and unreachable machines in the cluster should be [tainted][taint] with `NoSchedule`.
 * Retiring machines should be [tainted][taint] with `NoExecute`.
 * Rebooting machines should not be removed from the cluster nor be tainted.
 * Each change of the cluster configuration should be made as small as possible.
@@ -240,11 +238,11 @@ sabakan then compares the list with _the current cluster_ configuration.
 
 Then it selects one of the following actions if the condition matches.
 
-#### Remove unreachable nodes
+#### Remove non-existent nodes
 
 If the current cluster contains nodes that no longer exist in the list,
-or if it contains unreachable nodes, they are removed.  This algorithm
-should be chosen first as unreachable nodes block CKE.
+they are removed.  This algorithm should be work first because non-existent
+nodes block CKE.
 
 New nodes may be added to satisfy constraints.
 
@@ -296,11 +294,12 @@ If a worker node is either retiring or retired for a while,
 CKE adds  [taints][taint] to nodes as follows.
 The taint key is `cke.cybozu.com/state`.
 
-| Machine state | Taint value | Taint effect |
-| ------------- | ----------- | ------------ |
-| Unhealthy     | `unhealthy` | `NoSchedule` |
-| Retiring      | `retiring`  | `NoExecute`  |
-| Retired       | `retired`   | `NoExecute`  |
+| Machine state | Taint value   | Taint effect |
+| ------------- | ------------- | ------------ |
+| Unhealthy     | `unhealthy`   | `NoSchedule` |
+| Unreachable   | `unreachable` | `NoSchedule` |
+| Retiring      | `retiring`    | `NoExecute`  |
+| Retired       | `retired`     | `NoExecute`  |
 
 For other machine states, the taint is removed.
 

--- a/docs/sabakan-integration.md
+++ b/docs/sabakan-integration.md
@@ -241,7 +241,7 @@ Then it selects one of the following actions if the condition matches.
 #### Remove non-existent nodes
 
 If the current cluster contains nodes that no longer exist in the list,
-they are removed.  This algorithm should be work first because non-existent
+they are removed. This should be executed at the beginning because non-existent
 nodes block CKE.
 
 New nodes may be added to satisfy constraints.

--- a/sabakan/generator.go
+++ b/sabakan/generator.go
@@ -14,7 +14,7 @@ import (
 var (
 	errNotAvailable       = errors.New("no healthy machine is available")
 	errMissingMachine     = errors.New("failed to apply new template due to missing machines")
-	errTooManyUnreachable = errors.New("too many unreachable/non-existent control plane nodes")
+	errTooManyNonExistent = errors.New("too many non-existent control plane nodes")
 
 	// DefaultWaitRetiringSeconds before removing retiring nodes from the cluster.
 	DefaultWaitRetiringSeconds = 300.0
@@ -59,6 +59,12 @@ func MachineToNode(m *Machine, tmpl *cke.Node) *cke.Node {
 		n.Taints = append(n.Taints, corev1.Taint{
 			Key:    "cke.cybozu.com/state",
 			Value:  "unhealthy",
+			Effect: corev1.TaintEffectNoSchedule,
+		})
+	case StateUnreachable:
+		n.Taints = append(n.Taints, corev1.Taint{
+			Key:    "cke.cybozu.com/state",
+			Value:  "unreachable",
 			Effect: corev1.TaintEffectNoSchedule,
 		})
 	case StateRetiring:
@@ -390,7 +396,7 @@ func (g *Generator) Regenerate() (*cke.Cluster, error) {
 // Update updates the current configuration when necessary.
 // If the generator decides no updates are necessary, it returns (nil, nil).
 func (g *Generator) Update() (*cke.Cluster, error) {
-	op, err := g.removeUnreachable()
+	op, err := g.removeNonExistentNode()
 	if err != nil {
 		return nil, err
 	}
@@ -449,9 +455,9 @@ func (g *Generator) Update() (*cke.Cluster, error) {
 	return nil, nil
 }
 
-func (g *Generator) removeUnreachable() (*updateOp, error) {
+func (g *Generator) removeNonExistentNode() (*updateOp, error) {
 	op := &updateOp{
-		name: "remove unreachable",
+		name: "remove non-existent node",
 	}
 
 	for _, n := range g.controlPlanes {
@@ -460,27 +466,19 @@ func (g *Generator) removeUnreachable() (*updateOp, error) {
 			op.record("remove non-existent control plane: " + n.Address)
 			continue
 		}
-		if m.Status.State == StateUnreachable {
-			op.record("remove unreachable control plane: " + n.Address)
-			continue
-		}
 		op.cps = append(op.cps, m)
 	}
 
 	if len(op.cps)*2 <= len(g.controlPlanes) {
 		// Replacing more than half of control plane nodes would destroy
 		// etcd cluster.  We cannot do anything in this case.
-		return nil, errTooManyUnreachable
+		return nil, errTooManyNonExistent
 	}
 
 	for _, n := range g.workers {
 		m := g.machineMap[n.Address]
 		if m == nil {
 			op.record("remove non-existent worker: " + n.Address)
-			continue
-		}
-		if m.Status.State == StateUnreachable {
-			op.record("remove unreachable worker: " + n.Address)
 			continue
 		}
 		op.workers = append(op.workers, m)
@@ -716,6 +714,10 @@ func hasValidTaint(n *cke.Node, m *Machine) bool {
 	switch m.Status.State {
 	case StateUnhealthy:
 		if ckeTaint.Value != "unhealthy" || ckeTaint.Effect != corev1.TaintEffectNoSchedule {
+			return false
+		}
+	case StateUnreachable:
+		if ckeTaint.Value != "unreachable" || ckeTaint.Effect != corev1.TaintEffectNoSchedule {
 			return false
 		}
 	case StateRetiring:

--- a/sabakan/generator_test.go
+++ b/sabakan/generator_test.go
@@ -457,47 +457,48 @@ func testRegenerate(t *testing.T) {
 
 func testUpdate(t *testing.T) {
 	machines := []Machine{
-		newTestMachineWithIP(0, testFuture500, StateHealthy, "10.0.0.1", "cs"),
-		newTestMachineWithIP(0, testFuture250, StateRetiring, "10.0.0.2", "cs"),
-		newTestMachineWithIP(1, testFuture250, StateUnhealthy, "10.0.0.3", "cs"),
-		newTestMachineWithIP(1, testFuture250, StateUnreachable, "10.0.0.4", "cs"),
-		newTestMachineWithIP(2, testFuture250, StateUnreachable, "10.0.0.5", "cs"),
-		newTestMachineWithIP(2, testFuture500, StateHealthy, "10.0.0.6", "cs"),
-		newTestMachineWithIP(3, testFuture1000, StateHealthy, "10.0.0.7", "cs"),
-		newTestMachineWithIP(3, testFuture500, StateHealthy, "10.0.0.8", "cs"),
-		newTestMachineWithIP(4, testFuture500, StateUpdating, "10.0.0.9", "cs"),
+		newTestMachineWithIP(0, testFuture500, StateHealthy, "10.0.0.1", "cs"),     // [0]
+		newTestMachineWithIP(0, testFuture250, StateRetiring, "10.0.0.2", "cs"),    // [1]
+		newTestMachineWithIP(1, testFuture250, StateUnhealthy, "10.0.0.3", "cs"),   // [2]
+		newTestMachineWithIP(1, testFuture250, StateUnreachable, "10.0.0.4", "cs"), // [3]
+		newTestMachineWithIP(2, testFuture250, StateUnreachable, "10.0.0.5", "cs"), // [4]
+		newTestMachineWithIP(2, testFuture500, StateHealthy, "10.0.0.6", "cs"),     // [5]
+		newTestMachineWithIP(3, testFuture1000, StateHealthy, "10.0.0.7", "cs"),    // [6]
+		newTestMachineWithIP(3, testFuture500, StateHealthy, "10.0.0.8", "cs"),     // [7]
+		newTestMachineWithIP(4, testFuture500, StateUpdating, "10.0.0.9", "cs"),    // [8]
 	}
 	cps := []*cke.Node{
-		{Address: "10.0.0.1", ControlPlane: true},
-		{Address: "10.0.0.2", ControlPlane: true},
-		{Address: "10.0.0.3", ControlPlane: true},
-		{Address: "10.0.0.4", ControlPlane: true},
-		{Address: "10.0.0.5", ControlPlane: true},
-		{Address: "10.0.0.6", ControlPlane: true},
-		{Address: "10.0.0.7", ControlPlane: true},
-		{Address: "10.0.0.8", ControlPlane: true},
-		{Address: "10.0.0.9", ControlPlane: true},
-		{Address: "10.100.0.10", ControlPlane: true},
-		{Address: "10.100.0.11", ControlPlane: true},
+		{Address: "10.0.0.1", ControlPlane: true},    // [0]
+		{Address: "10.0.0.2", ControlPlane: true},    // [1]
+		{Address: "10.0.0.3", ControlPlane: true},    // [2]
+		{Address: "10.0.0.4", ControlPlane: true},    // [3]
+		{Address: "10.0.0.5", ControlPlane: true},    // [4]
+		{Address: "10.0.0.6", ControlPlane: true},    // [5]
+		{Address: "10.0.0.7", ControlPlane: true},    // [6]
+		{Address: "10.0.0.8", ControlPlane: true},    // [7]
+		{Address: "10.0.0.9", ControlPlane: true},    // [8]
+		{Address: "10.100.0.10", ControlPlane: true}, // [9]  non-existent
+		{Address: "10.100.0.11", ControlPlane: true}, // [10] non-existent
 	}
 	workers := []*cke.Node{
-		{Address: "10.0.0.1"},
-		{Address: "10.0.0.2", Taints: []corev1.Taint{
-			{
-				Key:    "cke.cybozu.com/state",
-				Value:  "retiring",
-				Effect: corev1.TaintEffectNoExecute,
-			},
-		}},
-		{Address: "10.0.0.3"},
-		{Address: "10.0.0.4"},
-		{Address: "10.0.0.5"},
-		{Address: "10.0.0.6"},
-		{Address: "10.0.0.7"},
-		{Address: "10.0.0.8"},
-		{Address: "10.0.0.9"},
-		{Address: "10.100.0.10"},
-		{Address: "10.100.0.11"},
+		{Address: "10.0.0.1"}, // [0]
+		{Address: "10.0.0.2", // [1]
+			Taints: []corev1.Taint{
+				{
+					Key:    "cke.cybozu.com/state",
+					Value:  "retiring",
+					Effect: corev1.TaintEffectNoExecute,
+				},
+			}},
+		{Address: "10.0.0.3"},    // [2]
+		{Address: "10.0.0.4"},    // [3]
+		{Address: "10.0.0.5"},    // [4]
+		{Address: "10.0.0.6"},    // [5]
+		{Address: "10.0.0.7"},    // [6]
+		{Address: "10.0.0.8"},    // [7]
+		{Address: "10.0.0.9"},    // [8]
+		{Address: "10.100.0.10"}, // [9]  non-existent
+		{Address: "10.100.0.11"}, // [10] non-existent
 	}
 
 	tmpl := &cke.Cluster{
@@ -522,7 +523,7 @@ func testUpdate(t *testing.T) {
 		expected  *cke.Cluster
 	}{
 		{
-			"RemoveUnreachable",
+			"RemoveNonExistent",
 			&cke.Cluster{
 				Nodes: []*cke.Node{cps[0], cps[1], cps[9], workers[2], workers[3], workers[10]},
 			},
@@ -534,7 +535,7 @@ func testUpdate(t *testing.T) {
 
 			nil,
 			&cke.Cluster{
-				Nodes: []*cke.Node{cps[0], cps[1], cps[6], workers[2]},
+				Nodes: []*cke.Node{cps[0], cps[1], cps[6], workers[2], workers[3]},
 			},
 		},
 		{
@@ -546,7 +547,7 @@ func testUpdate(t *testing.T) {
 				ControlPlaneCount: 3,
 				MinimumWorkers:    1,
 			},
-			machines,
+			[]Machine{machines[3], machines[5]},
 
 			errTooManyNonExistent,
 			nil,
@@ -560,7 +561,7 @@ func testUpdate(t *testing.T) {
 				ControlPlaneCount: 3,
 				MinimumWorkers:    1,
 			},
-			[]Machine{machines[0], machines[3], machines[5], machines[6]},
+			[]Machine{machines[0], machines[3], machines[6]},
 
 			errNotAvailable,
 			nil,

--- a/sabakan/generator_test.go
+++ b/sabakan/generator_test.go
@@ -538,7 +538,7 @@ func testUpdate(t *testing.T) {
 			},
 		},
 		{
-			"TooManyUnreachable",
+			"TooManyNonExistent",
 			&cke.Cluster{
 				Nodes: []*cke.Node{cps[0], cps[3], cps[4], workers[5]},
 			},
@@ -548,7 +548,7 @@ func testUpdate(t *testing.T) {
 			},
 			machines,
 
-			errTooManyUnreachable,
+			errTooManyNonExistent,
 			nil,
 		},
 		{


### PR DESCRIPTION
As we are would like to remove Node resource only when the Node is not listed from the result of GraphQL. 

This pull request made the following changes.
- treat `unreachable` nodes in the same way as `unhealthy` nodes. 
- update documents