### PR TITLE
Make Node labels and annotations dynamically with sabakan Machine Spec

### DIFF
--- a/docs/sabakan-integration.md
+++ b/docs/sabakan-integration.md
@@ -303,8 +303,10 @@ The taint key is `cke.cybozu.com/state`.
 
 For other machine states, the taint is removed.
 
-Node labels
------------
+Static Node Labels and Annotations
+----------------------------------
+
+#### Labels
 
 Sabakan [`Machine`][schema] `labels` are translated to Kubernetes Node labels.
 The label key will be prefixed by `sabakan.cke.cybozu.com/`.
@@ -317,8 +319,7 @@ Other Machine fields are also translated to labels as follows.
 | `spec.indexInRack` | `cke.cybozu.com/index-in-rack` | `spec.indexInRack` converted to string. |
 | `spec.role`        | `cke.cybozu.com/role`          | The same as `spec.role`.                |
 
-Node annotations
-----------------
+#### Annotations
 
 Following Machine fields are translated to Node annotations:
 
@@ -327,6 +328,13 @@ Following Machine fields are translated to Node annotations:
 | `spec.serial`       | `cke.cybozu.com/serial`        | The same as `spec.serial`.             |
 | `spec.registerDate` | `cke.cybozu.com/register-date` | `spec.registerDate` in RFC3339 format. |
 | `spec.retireDate`   | `cke.cybozu.com/retire-date`   | `spec.retireDate` in RFC3339 format.   |
+
+Dynamic Node Labels and Annotations
+-----------------------------------
+
+CKE can also create labels in combination with fields under Sabakan [`Machine`][schema] `Spec`.
+Only values of the labels are created with go-template (e.g. `rack: {{ .Rack }}` ).
+The available fields can be referenced in [Labels](#labels) and [Annotations](#annotations).
 
 
 [sabakan]: https://github.com/cybozu-go/sabakan

--- a/sabakan/generator.go
+++ b/sabakan/generator.go
@@ -1,9 +1,11 @@
 package sabakan
 
 import (
+	"bytes"
 	"errors"
 	"sort"
 	"strconv"
+	"text/template"
 	"time"
 
 	"github.com/cybozu-go/cke"
@@ -35,7 +37,16 @@ func MachineToNode(m *Machine, tmpl *cke.Node) (*cke.Node, error) {
 	}
 
 	for k, v := range tmpl.Annotations {
-		n.Annotations[k] = v
+		t, err := template.New(k).Parse(v)
+		if err != nil {
+			return nil, err
+		}
+		buf := &bytes.Buffer{}
+		err = t.Execute(buf, m)
+		if err != nil {
+			return nil, err
+		}
+		n.Annotations[k] = buf.String()
 	}
 	n.Annotations["cke.cybozu.com/serial"] = m.Spec.Serial
 	n.Annotations["cke.cybozu.com/register-date"] = m.Spec.RegisterDate.Format(time.RFC3339)
@@ -45,7 +56,16 @@ func MachineToNode(m *Machine, tmpl *cke.Node) (*cke.Node, error) {
 		n.Labels["sabakan.cke.cybozu.com/"+label.Name] = label.Value
 	}
 	for k, v := range tmpl.Labels {
-		n.Labels[k] = v
+		t, err := template.New(k).Parse(v)
+		if err != nil {
+			return nil, err
+		}
+		buf := &bytes.Buffer{}
+		err = t.Execute(buf, m)
+		if err != nil {
+			return nil, err
+		}
+		n.Labels[k] = buf.String()
 	}
 	n.Labels["cke.cybozu.com/rack"] = strconv.Itoa(m.Spec.Rack)
 	n.Labels["cke.cybozu.com/index-in-rack"] = strconv.Itoa(m.Spec.IndexInRack)

--- a/sabakan/generator.go
+++ b/sabakan/generator.go
@@ -42,7 +42,7 @@ func MachineToNode(m *Machine, tmpl *cke.Node) (*cke.Node, error) {
 			return nil, err
 		}
 		buf := &bytes.Buffer{}
-		err = t.Execute(buf, m)
+		err = t.Execute(buf, m.Spec)
 		if err != nil {
 			return nil, err
 		}
@@ -61,7 +61,7 @@ func MachineToNode(m *Machine, tmpl *cke.Node) (*cke.Node, error) {
 			return nil, err
 		}
 		buf := &bytes.Buffer{}
-		err = t.Execute(buf, m)
+		err = t.Execute(buf, m.Spec)
 		if err != nil {
 			return nil, err
 		}

--- a/sabakan/generator_test.go
+++ b/sabakan/generator_test.go
@@ -32,7 +32,10 @@ func testMachineToNode(t *testing.T) {
 		Annotations:  map[string]string{"hoge": "fuga"},
 		Taints:       []corev1.Taint{{Key: "foo", Effect: corev1.TaintEffectNoSchedule}},
 	}
-	res1 := MachineToNode(machine, node)
+	res1, err := MachineToNode(machine, node)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	domain := "cke.cybozu.com"
 	if res1.Annotations["hoge"] != "fuga" {
@@ -70,12 +73,18 @@ func testMachineToNode(t *testing.T) {
 	}
 
 	machine.Status.State = StateRetiring
-	res2 := MachineToNode(machine, node)
+	res2, err := MachineToNode(machine, node)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !containsTaint(res2.Taints, corev1.Taint{Key: domain + "/state", Value: "retiring", Effect: corev1.TaintEffectNoExecute}) {
 		t.Error(`res2.Taints do not have corev1.Taint{Key: "cke.cybozu.com/state", Value: "retiring", Effect: "NoExecute"}, actual:`, res2.Taints)
 	}
 	machine.Status.State = StateRetired
-	res3 := MachineToNode(machine, node)
+	res3, err := MachineToNode(machine, node)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !containsTaint(res3.Taints, corev1.Taint{Key: domain + "/state", Value: "retired", Effect: corev1.TaintEffectNoExecute}) {
 		t.Error(`res3.Taints do not have corev1.Taint{Key: "cke.cybozu.com/state", Value: "retired", Effect: "NoExecute"}, actual:`, res3.Taints)
 	}

--- a/sabakan/generator_test.go
+++ b/sabakan/generator_test.go
@@ -28,8 +28,8 @@ func testMachineToNode(t *testing.T) {
 
 	node := &cke.Node{
 		ControlPlane: true,
-		Labels:       map[string]string{"foo": "bar"},
-		Annotations:  map[string]string{"hoge": "fuga"},
+		Labels:       map[string]string{"foo": "bar", "rack": "{{ .Spec.Rack }}"},
+		Annotations:  map[string]string{"hoge": "fuga", "role": "{{ .Spec.Role }}"},
 		Taints:       []corev1.Taint{{Key: "foo", Effect: corev1.TaintEffectNoSchedule}},
 	}
 	res1, err := MachineToNode(machine, node)
@@ -40,6 +40,9 @@ func testMachineToNode(t *testing.T) {
 	domain := "cke.cybozu.com"
 	if res1.Annotations["hoge"] != "fuga" {
 		t.Error(`res1.Annotations["hoge"] != "fuga", actual:`, res1.Annotations)
+	}
+	if res1.Annotations["role"] != "worker" {
+		t.Error(`res1.Annotations["role"] != "worker", actual:`, res1.Annotations)
 	}
 	if res1.Annotations[domain+"/serial"] != machine.Spec.Serial {
 		t.Error(`res1.Annotations[domain + "/serial"] != "test", actual:`, res1.Annotations)
@@ -52,6 +55,9 @@ func testMachineToNode(t *testing.T) {
 	}
 	if res1.Labels["foo"] != "bar" {
 		t.Error(`res1.Labels["foo"] != "bar", actual:`, res1.Labels)
+	}
+	if res1.Labels["rack"] != "0" {
+		t.Error(`res1.Labels["rack"] != "0", actual:`, res1.Labels)
 	}
 	if res1.Labels["sabakan."+domain+"/foo"] != "foobar" {
 		t.Error(`res1.Labels["sabakan."+domain+"/foo"] != "foobar"`, res1.Labels)

--- a/sabakan/generator_test.go
+++ b/sabakan/generator_test.go
@@ -28,8 +28,8 @@ func testMachineToNode(t *testing.T) {
 
 	node := &cke.Node{
 		ControlPlane: true,
-		Labels:       map[string]string{"foo": "bar", "rack": "{{ .Spec.Rack }}"},
-		Annotations:  map[string]string{"hoge": "fuga", "role": "{{ .Spec.Role }}"},
+		Labels:       map[string]string{"foo": "bar", "rack": "{{ .Rack }}"},
+		Annotations:  map[string]string{"hoge": "fuga", "role": "{{ .Role }}"},
 		Taints:       []corev1.Taint{{Key: "foo", Effect: corev1.TaintEffectNoSchedule}},
 	}
 	res1, err := MachineToNode(machine, node)


### PR DESCRIPTION
To add labels required by rook automatically, we add functionality to make node labels and anotations dynamically in combination with multiple fields under Machine Spec.
https://github.com/cybozu-go/neco/issues/656