### PR TITLE
Add flag deletion to etcd-add-member

### DIFF
--- a/mtest/Makefile
+++ b/mtest/Makefile
@@ -17,7 +17,7 @@ ifeq ($(CONTAINER_RUNTIME),remote)
 RUNTIME_ENDPOINT = unix:///var/run/k8s-containerd.sock
 endif
 PLACEMAT = /usr/bin/placemat
-GINKGO = env GOFLAGS=-mod=vendor $(GOPATH)/bin/ginkgo
+GINKGO = env GOFLAGS=-mod=vendor $(GOPATH)/bin/ginkgo --failFast -v
 CURL = curl -fsL
 MANAGEMENT_ETCD_VERSION = 3.3.15
 VAULT_VERSION = 1.2.2

--- a/op/etcd/add.go
+++ b/op/etcd/add.go
@@ -49,27 +49,30 @@ func (o *addMemberOp) NextCommand() cke.Commander {
 		return common.StopContainerCommand(o.targetNode, op.EtcdContainerName)
 	case 2:
 		o.step++
-		return common.VolumeRemoveCommand(nodes, volname)
+		return common.VolumeRemoveCommand(nodes, op.EtcdAddedMemberVolumeName)
 	case 3:
 		o.step++
-		return common.VolumeCreateCommand(nodes, volname)
+		return common.VolumeRemoveCommand(nodes, volname)
 	case 4:
 		o.step++
-		return prepareEtcdCertificatesCommand{o.files, o.domain}
+		return common.VolumeCreateCommand(nodes, volname)
 	case 5:
 		o.step++
-		return o.files
+		return prepareEtcdCertificatesCommand{o.files, o.domain}
 	case 6:
+		o.step++
+		return o.files
+	case 7:
 		o.step++
 		opts := []string{
 			"--mount",
 			"type=volume,src=" + volname + ",dst=/var/lib/etcd",
 		}
 		return addMemberCommand{o.endpoints, o.targetNode, opts, extra}
-	case 7:
+	case 8:
 		o.step++
 		return waitEtcdSyncCommand{etcdEndpoints([]*cke.Node{o.targetNode}), false}
-	case 8:
+	case 9:
 		o.step++
 		return common.VolumeCreateCommand(nodes, op.EtcdAddedMemberVolumeName)
 	}


### PR DESCRIPTION
In this issue, I add flag volume deletion to etcd-add-member operation to handle the following situation:
1. A cp node is removed without EtcdDestroyMemberOp
2. The cp node re-join to cluster without initializing
3. etcd-add-member fails because of something wrong