### PR TITLE
Upgrade cluster configuration from previous CKE versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,14 @@ jobs:
       - run-mtest:
           runtime: remote
           suite: ./robustness
+  mtest-upgrade:
+    docker:
+      - image: google/cloud-sdk
+    steps:
+      - checkout
+      - run-mtest:
+          runtime: remote
+          suite: ./upgrade
   mtest-docker-functions:
     docker:
       - image: google/cloud-sdk
@@ -220,6 +228,10 @@ workflows:
       - mtest-containerd-functions
       - mtest-containerd-operators
       - mtest-containerd-robustness
+      - mtest-upgrade:
+          filters:
+            branches:
+              ignore: /master|release-/
       - compose
   conformance:
     jobs:

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,7 +20,7 @@ Get health information of this CKE instance.
 **Example**
 
 ```console
-$ curl localhost:10180/health
+$ curl http://localhost:10180/health
 {"health":"healthy"}
 ```
 
@@ -37,6 +37,6 @@ Get current CKE version.
 **Example**
 
 ```console
-$ curl localhost:10180/version
-{"version":"0.1"}
+$ curl http://localhost:10180/version
+{"version":"1.15.5"}
 ```

--- a/docs/cluster_overview.md
+++ b/docs/cluster_overview.md
@@ -6,21 +6,15 @@ How CKE works
 
 ![How CKE works](http://www.plantuml.com/plantuml/svg/PO-nQiGm38PtFOMWiuScwTAXf9HEXOxTLKi9eOvTRFdkzS--S11i3yRVzsEXVqvAKVFk88fLygiJ_FZwH4fe_mIVc9ToJk4FPQSrljG7C2dzKX8KjGnaDKHyvttpMz98bIWXLG7W0mj-rwku2i-z6derzchgrGj0NTZaV_Ds36zuQ7XiU6huCP33rPkZtecFzd1lXiR9ekLRoL_H1hziQuw2rkMa4c4MptbtDm00)
 
-CKE constructs and maintains Kubernetes cluster from cluster configuration
-defined by user (administrator).  CKE also deploys some components to nodes
-and onto Kubernetes.
+CKE constructs and maintains Kubernetes cluster according to [a cluster
+configuration](cluster.md) supplied by a user (administrator).
 
-User defines two type of nodes to cluster configuration:
+There are two types of nodes in the cluster configuration, that is,
+workers and control planes.  A worker node runs only `kubelet` and `kube-proxy`.
+A control plane runs `etcd`, `kube-apiserver`, `kube-controller-manager`,
+`kube-scheduler` as well as `kubelet` and `kube-proxy`.
 
-- Worker node: kubelet and kube-proxy
-- Control plane node: Etcd, Kubernetes control plane components.
-
-Worker node is a worker for Kubernetes cluster where containers are running.
-Control plane node works as a master node for the cluster.  It also contains
-etcd server used by kube-apiservers.  The number of the control plane nodes is
-typically three or five.  Control plane node also has a feature of a worker
-nodes.  Therefore, Kubernetes worker components (kubelet and kube-proxy) are
-deployed to every node, and only a few nodes have control plane components.
+The number of the control plane nodes must be at least 1.
 
 Worker Nodes
 ------------

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -10,6 +10,15 @@ Prefix
 Keys are prefixed by a constant string.
 The default prefix is `/cke/`.
 
+`config-version`
+----------------
+
+This represents the configuration version of the constructed
+Kubernetes cluster.  If this key does not exist, the version
+is considered as "1".
+
+See [cluster_overview.md](cluster_overview.md#config-version) for details.
+
 `cluster`
 ---------
 

--- a/mtest/before.go
+++ b/mtest/before.go
@@ -18,7 +18,12 @@ const (
 )
 
 // RunBeforeSuite is for Ginkgo BeforeSuite
-func RunBeforeSuite() {
+func RunBeforeSuite(img string) {
+	if img == "" {
+		img = ckeImageURL
+	} else {
+		looseCheck = true
+	}
 	fmt.Println("Preparing...")
 
 	SetDefaultEventuallyPollingInterval(3 * time.Second)
@@ -74,7 +79,7 @@ func RunBeforeSuite() {
 	Expect(err).NotTo(HaveOccurred())
 
 	By("running install-tools")
-	err = installTools(ckeImageURL)
+	err = installTools(img)
 	Expect(err).NotTo(HaveOccurred())
 
 	f, err := os.Open(ckeConfigPath)
@@ -107,7 +112,7 @@ func RunBeforeSuite() {
 	err = cke.ConnectVault(context.Background(), resp.Kvs[0].Value)
 	Expect(err).NotTo(HaveOccurred())
 
-	setupCKE()
+	setupCKE(img)
 
 	By("initializing control plane")
 	initializeControlPlane()

--- a/mtest/operators/suite_test.go
+++ b/mtest/operators/suite_test.go
@@ -18,7 +18,7 @@ func TestMtest(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	mtest.RunBeforeSuite()
+	mtest.RunBeforeSuite("")
 })
 
 // This must be the only top-level test container.

--- a/mtest/robustness/suite_test.go
+++ b/mtest/robustness/suite_test.go
@@ -18,7 +18,7 @@ func TestMtest(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	mtest.RunBeforeSuite()
+	mtest.RunBeforeSuite("")
 })
 
 // This must be the only top-level test container.

--- a/mtest/run.go
+++ b/mtest/run.go
@@ -44,6 +44,8 @@ var (
 		Timeout:   defaultDialTimeout,
 		KeepAlive: defaultKeepAlive,
 	}
+
+	looseCheck = false
 )
 
 type sshAgent struct {
@@ -411,10 +413,10 @@ func stopVault(client *ssh.Client) error {
 	return nil
 }
 
-func setupCKE() {
+func setupCKE(img string) {
 	err := stopCKE()
 	Expect(err).NotTo(HaveOccurred())
-	err = runCKE(ckeImageURL)
+	err = runCKE(img)
 	Expect(err).NotTo(HaveOccurred())
 }
 
@@ -431,6 +433,10 @@ func checkCluster(c *cke.Cluster) error {
 	status, res, err := getClusterStatus(c)
 	if err != nil {
 		return err
+	}
+
+	if looseCheck && status.Kubernetes.IsControlPlaneReady {
+		return nil
 	}
 
 	nf := server.NewNodeFilter(c, status)

--- a/mtest/suites.go
+++ b/mtest/suites.go
@@ -3,22 +3,30 @@ package mtest
 import . "github.com/onsi/ginkgo"
 
 // FunctionsSuite is a test suite that tests small test cases
-var FunctionsSuite = func() {
+func FunctionsSuite() {
 	Context("ckecli", TestCKECLI)
 	Context("kubernetes", TestKubernetes)
 }
 
 // OperatorsSuite is a test suite that tests CKE operators
-var OperatorsSuite = func() {
+func OperatorsSuite() {
 	Context("operators", func() {
 		TestOperators(false)
 	})
 }
 
 // RobustnessSuite is a test suite that tests CKE operators with SSH-not-connected nodes
-var RobustnessSuite = func() {
+func RobustnessSuite() {
 	Context("operators", func() {
 		TestStopCP()
 		TestOperators(true)
+	})
+}
+
+// UpgradeSuite is a test suite that reboots all nodes and upgrade CKE.
+func UpgradeSuite() {
+	Context("upgrade", func() {
+		TestUpgrade()
+		Context("kubernetes", TestKubernetes)
 	})
 }

--- a/mtest/upgrade.go
+++ b/mtest/upgrade.go
@@ -1,0 +1,51 @@
+package mtest
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// TestUpgrade tests CKE upgrade operators
+func TestUpgrade() {
+	It("tests Kubernetes before reboot", func() {
+		Eventually(func() error {
+			_, _, err := kubectl("get", "sa/default")
+			return err
+		}).Should(Succeed())
+	})
+
+	It("reboots all nodes", func() {
+		stopCKE()
+
+		nodes := []string{node1, node2, node3, node4, node5, node6}
+		for _, n := range nodes {
+			execAt(n, "sudo", "systemd-run", "reboot", "-f", "-f")
+		}
+		time.Sleep(10 * time.Second)
+		Eventually(func() error {
+			for _, n := range nodes {
+				_, err := execAtLocal("ping", "-c", "1", "-W", "1", n)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		}).Should(Succeed())
+
+		Expect(prepareSSHClients(nodes...)).Should(Succeed())
+	})
+
+	It("runs new CKE", func() {
+		runCKE(ckeImageURL)
+		cluster := getCluster()
+		for i := 0; i < 3; i++ {
+			cluster.Nodes[i].ControlPlane = true
+		}
+		looseCheck = false
+		Eventually(func() error {
+			return checkCluster(cluster)
+		}).Should(Succeed())
+	})
+}

--- a/mtest/upgrade/suite_test.go
+++ b/mtest/upgrade/suite_test.go
@@ -1,9 +1,10 @@
-package mtest
+package upgrade
 
 import (
 	"os"
 	"testing"
 
+	"github.com/cybozu-go/cke"
 	"github.com/cybozu-go/cke/mtest"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -18,11 +19,11 @@ func TestMtest(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	mtest.RunBeforeSuite("")
+	mtest.RunBeforeSuite("quay.io/cybozu/cke:" + cke.Version)
 })
 
 // This must be the only top-level test container.
 // Other tests and test containers must be listed in this.
-var _ = Describe("Test CKE functions", func() {
-	mtest.FunctionsSuite()
+var _ = Describe("Test CKE functions with upgrade", func() {
+	mtest.UpgradeSuite()
 })

--- a/op/clusterdns/create_configmap.go
+++ b/op/clusterdns/create_configmap.go
@@ -56,7 +56,7 @@ type createConfigMapCommand struct {
 	dnsServers []string
 }
 
-func (c createConfigMapCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c createConfigMapCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/clusterdns/update_config_map.go
+++ b/op/clusterdns/update_config_map.go
@@ -44,7 +44,7 @@ type updateConfigMapCommand struct {
 	configmap *corev1.ConfigMap
 }
 
-func (c updateConfigMapCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c updateConfigMapCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/common/container.go
+++ b/op/common/container.go
@@ -64,7 +64,7 @@ func WithExtra(params cke.ServiceParams) RunOption {
 	return func(c *runContainerCommand) { c.extra = params }
 }
 
-func (c runContainerCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c runContainerCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	env := well.NewEnvironment(ctx)
 	for _, n := range c.nodes {
 		n := n
@@ -118,7 +118,7 @@ func StopContainerCommand(node *cke.Node, name string) cke.Commander {
 	return stopContainerCommand{node, name}
 }
 
-func (c stopContainerCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c stopContainerCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	begin := time.Now()
 	ce := inf.Engine(c.node.Address)
 	exists, err := ce.Exists(c.name)
@@ -164,7 +164,7 @@ func KillContainersCommand(nodes []*cke.Node, name string) cke.Commander {
 	return killContainersCommand{nodes, name}
 }
 
-func (c killContainersCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c killContainersCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	begin := time.Now()
 	env := well.NewEnvironment(ctx)
 	for _, n := range c.nodes {

--- a/op/common/image_pull.go
+++ b/op/common/image_pull.go
@@ -24,7 +24,7 @@ func ImagePullCommand(nodes []*cke.Node, img cke.Image) cke.Commander {
 	return imagePullCommand{nodes, img}
 }
 
-func (c imagePullCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c imagePullCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	env := well.NewEnvironment(ctx)
 	for _, n := range c.nodes {
 		ce := inf.Engine(n.Address)

--- a/op/common/mkdirs.go
+++ b/op/common/mkdirs.go
@@ -25,7 +25,7 @@ func MakeDirsCommandWithMode(nodes []*cke.Node, dirs []string, mode string) cke.
 	return makeDirsCommand{nodes, dirs, mode}
 }
 
-func (c makeDirsCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c makeDirsCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	bindMap := make(map[string]cke.Mount)
 	dests := make([]string, len(c.dirs))
 	for i, d := range c.dirs {

--- a/op/common/mkfiles.go
+++ b/op/common/mkfiles.go
@@ -94,7 +94,7 @@ func (c *FilesBuilder) AddKeyPair(ctx context.Context, name string,
 }
 
 // Run implements cke.Commander.
-func (c *FilesBuilder) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c *FilesBuilder) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	bindMap := make(map[string]cke.Mount)
 	for _, f := range c.files {
 		parentDir := filepath.Dir(f.name)

--- a/op/common/volume.go
+++ b/op/common/volume.go
@@ -17,7 +17,7 @@ func VolumeCreateCommand(nodes []*cke.Node, name string) cke.Commander {
 	return volumeCreateCommand{nodes, name}
 }
 
-func (c volumeCreateCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c volumeCreateCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	env := well.NewEnvironment(ctx)
 	for _, n := range c.nodes {
 		ce := inf.Engine(n.Address)
@@ -46,7 +46,7 @@ func VolumeRemoveCommand(nodes []*cke.Node, name string) cke.Commander {
 	return volumeRemoveCommand{nodes, name}
 }
 
-func (c volumeRemoveCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c volumeRemoveCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	env := well.NewEnvironment(ctx)
 	for _, n := range c.nodes {
 		ce := inf.Engine(n.Address)

--- a/op/etcd/add.go
+++ b/op/etcd/add.go
@@ -92,7 +92,7 @@ type addMemberCommand struct {
 	extra     cke.ServiceParams
 }
 
-func (c addMemberCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c addMemberCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cli, err := inf.NewEtcdClient(ctx, c.endpoints)
 	if err != nil {
 		return err

--- a/op/etcd/boot.go
+++ b/op/etcd/boot.go
@@ -94,7 +94,7 @@ type setupEtcdAuthCommand struct {
 	endpoints []string
 }
 
-func (c setupEtcdAuthCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c setupEtcdAuthCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cli, err := inf.NewEtcdClient(ctx, c.endpoints)
 	if err != nil {
 		return err

--- a/op/etcd/common.go
+++ b/op/etcd/common.go
@@ -94,7 +94,7 @@ type prepareEtcdCertificatesCommand struct {
 	domain string
 }
 
-func (c prepareEtcdCertificatesCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c prepareEtcdCertificatesCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	f := func(ctx context.Context, n *cke.Node) (cert, key []byte, err error) {
 		c, k, e := cke.EtcdCA{}.IssueServerCert(ctx, inf, n, c.domain)
 		if e != nil {
@@ -191,7 +191,7 @@ func (c waitEtcdSyncCommand) try(ctx context.Context, inf cke.Infrastructure) er
 	return nil
 }
 
-func (c waitEtcdSyncCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c waitEtcdSyncCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	for i := 0; i < 9; i++ {
 		err := c.try(ctx, inf)
 		if err == nil {

--- a/op/etcd/remove.go
+++ b/op/etcd/remove.go
@@ -66,7 +66,7 @@ type removeMemberCommand struct {
 	ids       []uint64
 }
 
-func (c removeMemberCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c removeMemberCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cli, err := inf.NewEtcdClient(ctx, c.endpoints)
 	if err != nil {
 		return err

--- a/op/etcdbackup/craete_configmap.go
+++ b/op/etcdbackup/craete_configmap.go
@@ -49,7 +49,7 @@ type createEtcdBackupConfigMapCommand struct {
 	rotate    int
 }
 
-func (c createEtcdBackupConfigMapCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c createEtcdBackupConfigMapCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/etcdbackup/create_cronjob.go
+++ b/op/etcdbackup/create_cronjob.go
@@ -49,7 +49,7 @@ type createEtcdBackupCronJobCommand struct {
 	schedule  string
 }
 
-func (c createEtcdBackupCronJobCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c createEtcdBackupCronJobCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/etcdbackup/create_pod.go
+++ b/op/etcdbackup/create_pod.go
@@ -49,7 +49,7 @@ type createEtcdBackupPodCommand struct {
 	pvcname   string
 }
 
-func (c createEtcdBackupPodCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c createEtcdBackupPodCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/etcdbackup/create_secret.go
+++ b/op/etcdbackup/create_secret.go
@@ -47,7 +47,7 @@ type createEtcdBackupSecretCommand struct {
 	apiserver *cke.Node
 }
 
-func (c createEtcdBackupSecretCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c createEtcdBackupSecretCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/etcdbackup/create_service.go
+++ b/op/etcdbackup/create_service.go
@@ -46,7 +46,7 @@ type createEtcdBackupServiceCommand struct {
 	apiserver *cke.Node
 }
 
-func (c createEtcdBackupServiceCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c createEtcdBackupServiceCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/etcdbackup/remove_configmap.go
+++ b/op/etcdbackup/remove_configmap.go
@@ -42,7 +42,7 @@ type removeEtcdBackupConfigMapCommand struct {
 	apiserver *cke.Node
 }
 
-func (c removeEtcdBackupConfigMapCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c removeEtcdBackupConfigMapCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/etcdbackup/remove_cronjob.go
+++ b/op/etcdbackup/remove_cronjob.go
@@ -42,7 +42,7 @@ type removeEtcdBackupCronJobCommand struct {
 	apiserver *cke.Node
 }
 
-func (c removeEtcdBackupCronJobCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c removeEtcdBackupCronJobCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/etcdbackup/remove_pod.go
+++ b/op/etcdbackup/remove_pod.go
@@ -42,7 +42,7 @@ type removeEtcdBackupPodCommand struct {
 	apiserver *cke.Node
 }
 
-func (c removeEtcdBackupPodCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c removeEtcdBackupPodCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/etcdbackup/remove_secret.go
+++ b/op/etcdbackup/remove_secret.go
@@ -42,7 +42,7 @@ type removeEtcdBackupSecretCommand struct {
 	apiserver *cke.Node
 }
 
-func (c removeEtcdBackupSecretCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c removeEtcdBackupSecretCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/etcdbackup/remove_service.go
+++ b/op/etcdbackup/remove_service.go
@@ -42,7 +42,7 @@ type removeEtcdBackupServiceCommand struct {
 	apiserver *cke.Node
 }
 
-func (c removeEtcdBackupServiceCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c removeEtcdBackupServiceCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/etcdbackup/update_configmap.go
+++ b/op/etcdbackup/update_configmap.go
@@ -46,7 +46,7 @@ type updateEtcdBackupConfigMapCommand struct {
 	rotate    int
 }
 
-func (c updateEtcdBackupConfigMapCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c updateEtcdBackupConfigMapCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/etcdbackup/update_cronjob.go
+++ b/op/etcdbackup/update_cronjob.go
@@ -46,7 +46,7 @@ type updateEtcdBackupCronJobCommand struct {
 	schedule  string
 }
 
-func (c updateEtcdBackupCronJobCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c updateEtcdBackupCronJobCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/etcdbackup/update_pod.go
+++ b/op/etcdbackup/update_pod.go
@@ -47,7 +47,7 @@ type updateEtcdBackupPodCommand struct {
 	pvcname   string
 }
 
-func (c updateEtcdBackupPodCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c updateEtcdBackupPodCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/k8s/apiserver_boot.go
+++ b/op/k8s/apiserver_boot.go
@@ -110,7 +110,7 @@ type prepareAPIServerFilesCommand struct {
 	params        cke.APIServerParams
 }
 
-func (c prepareAPIServerFilesCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c prepareAPIServerFilesCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	storage := inf.Storage()
 
 	// server (and client) certs of API server.

--- a/op/k8s/controller_manager_boot.go
+++ b/op/k8s/controller_manager_boot.go
@@ -70,7 +70,7 @@ type prepareControllerManagerFilesCommand struct {
 	files   *common.FilesBuilder
 }
 
-func (c prepareControllerManagerFilesCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c prepareControllerManagerFilesCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	const kubeconfigPath = "/etc/kubernetes/controller-manager/kubeconfig"
 	storage := inf.Storage()
 

--- a/op/k8s/kubelet_boot.go
+++ b/op/k8s/kubelet_boot.go
@@ -137,7 +137,7 @@ type emptyDirCommand struct {
 	dir   string
 }
 
-func (c emptyDirCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c emptyDirCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	dest := filepath.Join("/mnt", c.dir)
 	arg := "/usr/local/cke-tools/bin/empty-dir " + dest
 
@@ -172,7 +172,7 @@ type prepareKubeletFilesCommand struct {
 	files     *common.FilesBuilder
 }
 
-func (c prepareKubeletFilesCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c prepareKubeletFilesCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	caPath := op.K8sPKIPath("ca.crt")
 	tlsCertPath := op.K8sPKIPath("kubelet.crt")
 	tlsKeyPath := op.K8sPKIPath("kubelet.key")
@@ -243,7 +243,7 @@ type installCNICommand struct {
 	nodes []*cke.Node
 }
 
-func (c installCNICommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c installCNICommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	env := well.NewEnvironment(ctx)
 
 	binds := []cke.Mount{
@@ -273,7 +273,7 @@ type retaintBeforeKubeletBootCommand struct {
 	params    cke.KubeletParams
 }
 
-func (c retaintBeforeKubeletBootCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c retaintBeforeKubeletBootCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiServer)
 	if err != nil {
 		return err
@@ -329,7 +329,7 @@ type waitForKubeletReadyCommand struct {
 	nodes []*cke.Node
 }
 
-func (c waitForKubeletReadyCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c waitForKubeletReadyCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	for i := 0; i < 9; i++ {
 		err := c.try(ctx, inf)
 		if err == nil {

--- a/op/k8s/kubelet_restart.go
+++ b/op/k8s/kubelet_restart.go
@@ -85,7 +85,7 @@ type prepareKubeletConfigCommand struct {
 	files   *common.FilesBuilder
 }
 
-func (c prepareKubeletConfigCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c prepareKubeletConfigCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	caPath := op.K8sPKIPath("ca.crt")
 	tlsCertPath := op.K8sPKIPath("kubelet.crt")
 	tlsKeyPath := op.K8sPKIPath("kubelet.key")

--- a/op/k8s/proxy_boot.go
+++ b/op/k8s/proxy_boot.go
@@ -77,7 +77,7 @@ type prepareProxyFilesCommand struct {
 	files   *common.FilesBuilder
 }
 
-func (c prepareProxyFilesCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c prepareProxyFilesCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	const kubeconfigPath = "/etc/kubernetes/proxy/kubeconfig"
 	storage := inf.Storage()
 

--- a/op/k8s/scheduler_boot.go
+++ b/op/k8s/scheduler_boot.go
@@ -73,7 +73,7 @@ type prepareSchedulerFilesCommand struct {
 	params  cke.SchedulerParams
 }
 
-func (c prepareSchedulerFilesCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c prepareSchedulerFilesCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	const kubeconfigPath = "/etc/kubernetes/scheduler/kubeconfig"
 	storage := inf.Storage()
 

--- a/op/kube_endpoints.go
+++ b/op/kube_endpoints.go
@@ -79,7 +79,7 @@ type createEndpointsCommand struct {
 	endpoints *corev1.Endpoints
 }
 
-func (c createEndpointsCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c createEndpointsCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err
@@ -106,7 +106,7 @@ type updateEndpointsCommand struct {
 	endpoints *corev1.Endpoints
 }
 
-func (c updateEndpointsCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c updateEndpointsCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/kube_etcd_service.go
+++ b/op/kube_etcd_service.go
@@ -74,7 +74,7 @@ type createEtcdServiceCommand struct {
 	apiserver *cke.Node
 }
 
-func (c createEtcdServiceCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c createEtcdServiceCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err
@@ -104,7 +104,7 @@ type updateEtcdServiceCommand struct {
 	apiserver *cke.Node
 }
 
-func (c updateEtcdServiceCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c updateEtcdServiceCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/kube_node_remove.go
+++ b/op/kube_node_remove.go
@@ -47,7 +47,7 @@ type nodeRemoveCommand struct {
 	nodes     []*corev1.Node
 }
 
-func (c nodeRemoveCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c nodeRemoveCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/kube_node_update.go
+++ b/op/kube_node_update.go
@@ -44,7 +44,7 @@ type nodeUpdateCommand struct {
 	nodes     []*corev1.Node
 }
 
-func (c nodeUpdateCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c nodeUpdateCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/kube_wait.go
+++ b/op/kube_wait.go
@@ -43,7 +43,7 @@ type waitKubeCommand struct {
 	apiserver *cke.Node
 }
 
-func (c waitKubeCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c waitKubeCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/nodedns/create_configmap.go
+++ b/op/nodedns/create_configmap.go
@@ -52,7 +52,7 @@ type createConfigMapCommand struct {
 	dnsServers []string
 }
 
-func (c createConfigMapCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c createConfigMapCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/nodedns/update_configmap.go
+++ b/op/nodedns/update_configmap.go
@@ -44,7 +44,7 @@ type updateConfigMapCommand struct {
 	configMap *corev1.ConfigMap
 }
 
-func (c updateConfigMapCommand) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (c updateConfigMapCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, c.apiserver)
 	if err != nil {
 		return err

--- a/op/resource.go
+++ b/op/resource.go
@@ -38,7 +38,7 @@ func (o *resourceApplyOp) Targets() []string {
 	}
 }
 
-func (o *resourceApplyOp) Run(ctx context.Context, inf cke.Infrastructure) error {
+func (o *resourceApplyOp) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	cs, err := inf.K8sClient(ctx, o.apiserver)
 	if err != nil {
 		return err

--- a/op/upgrade.go
+++ b/op/upgrade.go
@@ -1,0 +1,79 @@
+package op
+
+import (
+	"context"
+
+	"github.com/cybozu-go/cke"
+	"github.com/cybozu-go/well"
+)
+
+type upgradeOp struct {
+	current string
+	nodes   []*cke.Node
+}
+
+// UpgradeOp returns an Operator to upgrade cluster configuration.
+func UpgradeOp(current string, nodes []*cke.Node) cke.Operator {
+	return &upgradeOp{current: current, nodes: nodes}
+}
+
+func (u *upgradeOp) Name() string {
+	return "upgrade"
+}
+
+func (u *upgradeOp) NextCommand() cke.Commander {
+	switch u.current {
+	case "1":
+		u.current = "2"
+		return UpgradeToVersion2Command(u.nodes)
+	default:
+		return nil
+	}
+}
+
+func (u *upgradeOp) Targets() []string {
+	targets := make([]string, len(u.nodes))
+	for i, n := range u.nodes {
+		targets[i] = n.Address
+	}
+	return targets
+}
+
+type upgradeToVersion2Command struct {
+	nodes []*cke.Node
+}
+
+// UpgradeToVersion2Command returns a Commander to upgrade from version 1 to 2.
+func UpgradeToVersion2Command(nodes []*cke.Node) cke.Commander {
+	return upgradeToVersion2Command{nodes}
+}
+
+func (u upgradeToVersion2Command) Run(ctx context.Context, inf cke.Infrastructure, leaderKey string) error {
+	env := well.NewEnvironment(ctx)
+	for _, n := range u.nodes {
+		ce := inf.Engine(n.Address)
+		env.Go(func(ctx context.Context) error {
+			exists, err := ce.VolumeExists(EtcdAddedMemberVolumeName)
+			if err != nil {
+				return err
+			}
+			if !exists {
+				return ce.VolumeCreate(EtcdAddedMemberVolumeName)
+			}
+			return nil
+		})
+	}
+	env.Stop()
+	if err := env.Wait(); err != nil {
+		return err
+	}
+
+	return inf.Storage().PutConfigVersion(ctx, leaderKey)
+}
+
+func (u upgradeToVersion2Command) Command() cke.Command {
+	return cke.Command{
+		Name:   "upgrade-version-from-1-to-2",
+		Target: EtcdAddedMemberVolumeName,
+	}
+}

--- a/operation.go
+++ b/operation.go
@@ -18,7 +18,7 @@ type Operator interface {
 // Commander is a single step to proceed an operation
 type Commander interface {
 	// Run executes the command
-	Run(ctx context.Context, inf Infrastructure) error
+	Run(ctx context.Context, inf Infrastructure, leaderKey string) error
 	// Command returns the command information
 	Command() Command
 }

--- a/server/control.go
+++ b/server/control.go
@@ -322,7 +322,7 @@ func runOp(ctx context.Context, op cke.Operator, leaderKey string, storage cke.S
 			"op":      op.Name(),
 			"command": commander.Command().String(),
 		})
-		err = commander.Run(ctx, inf)
+		err = commander.Run(ctx, inf, leaderKey)
 		if err == nil {
 			continue
 		}

--- a/server/get_status.go
+++ b/server/get_status.go
@@ -38,6 +38,11 @@ func (c Controller) GetClusterStatus(ctx context.Context, cluster *cke.Cluster, 
 	}
 
 	cs := new(cke.ClusterStatus)
+	version, err := inf.Storage().GetConfigVersion(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cs.ConfigVersion = version
 	cs.NodeStatuses = statuses
 
 	var etcdRunning bool

--- a/server/strategy.go
+++ b/server/strategy.go
@@ -20,6 +20,11 @@ func DecideOps(c *cke.Cluster, cs *cke.ClusterStatus, resources []cke.ResourceDe
 
 	nf := NewNodeFilter(c, cs)
 
+	// 0. Execute upgrade opeartion if necessary
+	if cs.ConfigVersion != cke.ConfigVersion {
+		return []cke.Operator{op.UpgradeOp(cs.ConfigVersion, nf.ControlPlane())}
+	}
+
 	// 1. Run or restart rivers.  This guarantees:
 	// - CKE tools image is pulled on all nodes.
 	// - Rivers runs on all nodes and will proxy requests only to control plane nodes.

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -142,7 +142,8 @@ func newData() testData {
 	nodeList[3].Labels = cluster.Nodes[3].Labels
 	nodeList[3].Spec.Taints = cluster.Nodes[3].Taints
 	status := &cke.ClusterStatus{
-		NodeStatuses: nodeStatuses,
+		ConfigVersion: cke.ConfigVersion,
+		NodeStatuses:  nodeStatuses,
 		Kubernetes: cke.KubernetesClusterStatus{
 			ResourceStatuses: map[string]map[string]string{
 				"Namespace/foo": {cke.AnnotationResourceRevision: "1"},
@@ -1787,6 +1788,32 @@ func TestDecideOps(t *testing.T) {
 				"stop-kube-controller-manager": 1,
 				"stop-kube-scheduler":          1,
 			},
+		},
+		{
+			Name: "Upgrade",
+			Input: newData().withNodes(corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "10.0.0.14",
+					Labels:      map[string]string{"label1": "value"},
+					Annotations: map[string]string{"annotation1": "value"},
+				},
+				Spec: corev1.NodeSpec{
+					Taints: []corev1.Taint{
+						{
+							Key:    "taint1",
+							Value:  "value1",
+							Effect: corev1.TaintEffectNoSchedule,
+						},
+						{
+							Key:    "taint2",
+							Effect: corev1.TaintEffectPreferNoSchedule,
+						},
+					},
+				},
+			}).with(func(data testData) {
+				data.Status.ConfigVersion = "1"
+			}),
+			ExpectedOps: []string{"upgrade"},
 		},
 	}
 

--- a/status.go
+++ b/status.go
@@ -81,8 +81,9 @@ func (s KubernetesClusterStatus) SetResourceStatus(rkey string, annotations map[
 // ClusterStatus represents the working cluster status.
 // The structure reflects Cluster, of course.
 type ClusterStatus struct {
-	Name         string
-	NodeStatuses map[string]*NodeStatus // keys are IP address strings.
+	ConfigVersion string
+	Name          string
+	NodeStatuses  map[string]*NodeStatus // keys are IP address strings.
 
 	Etcd       EtcdClusterStatus
 	Kubernetes KubernetesClusterStatus

--- a/version.go
+++ b/version.go
@@ -2,3 +2,7 @@ package cke
 
 // Version represents current cke version
 const Version = "1.15.6"
+
+// ConfigVersion represents the current configuration scheme
+// of how CKE constructs its Kubernetes cluster.
+const ConfigVersion = "2"

--- a/version.go
+++ b/version.go
@@ -1,7 +1,7 @@
 package cke
 
 // Version represents current cke version
-const Version = "1.15.6"
+const Version = "1.15.5"
 
 // ConfigVersion represents the current configuration scheme
 // of how CKE constructs its Kubernetes cluster.


### PR DESCRIPTION
This PR introduces `ConfigVersion` concept.

`ConfigVersion` represents how CKE constructs its Kubernetes cluster.
When this is changed, `ConfigVersion` increments by 1.

CKE automatically updates its Kubernetes cluster when the `ConfigVersion`
of the cluster is older than the current.