### PR TITLE
mtest: remove use of loose check.

### DIFF
--- a/mtest/before.go
+++ b/mtest/before.go
@@ -21,8 +21,6 @@ const (
 func RunBeforeSuite(img string) {
 	if img == "" {
 		img = ckeImageURL
-	} else {
-		looseCheck = true
 	}
 	fmt.Println("Preparing...")
 

--- a/mtest/run.go
+++ b/mtest/run.go
@@ -44,9 +44,6 @@ var (
 		Timeout:   defaultDialTimeout,
 		KeepAlive: defaultKeepAlive,
 	}
-
-	// TODO Remove looseCheck when the version which writes Processing Status is released.
-	looseCheck = false
 )
 
 type sshAgent struct {
@@ -443,17 +440,6 @@ func (e checkError) Error() string {
 }
 
 func checkCluster(c *cke.Cluster, ts time.Time) error {
-	// TODO: Remove getClusterStatus and if clause with looseCheck
-	// once a new version containing this is released.
-	status, _, err := getClusterStatus(c)
-	if err != nil {
-		return err
-	}
-
-	if looseCheck && status.Kubernetes.IsControlPlaneReady {
-		return nil
-	}
-
 	st, err := getServerStatus()
 	if err != nil {
 		if err == cke.ErrNotFound {

--- a/mtest/upgrade.go
+++ b/mtest/upgrade.go
@@ -44,7 +44,6 @@ func TestUpgrade() {
 		for i := 0; i < 3; i++ {
 			cluster.Nodes[i].ControlPlane = true
 		}
-		looseCheck = false
 		Eventually(func() error {
 			return checkCluster(cluster, ts)
 		}).Should(Succeed())


### PR DESCRIPTION
`looseCheck` in the mtest becomes unnecessary, because the completion check of the CKE server's activity is now observable through `ckecli status` without using the version-dependent internal algorithm.
This PR removes it.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>
