### PR TITLE
Purge github.com/pkg/errors

### DIFF
--- a/container.go
+++ b/container.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -63,7 +62,7 @@ type docker struct {
 func (c docker) PullImage(img Image) error {
 	stdout, stderr, err := c.agent.Run("docker image list --format '{{.Repository}}:{{.Tag}}'")
 	if err != nil {
-		return errors.Wrapf(err, "stdout: %s, stderr: %s", stdout, stderr)
+		return fmt.Errorf("%w, stdout: %s, stderr: %s", err, stdout, stderr)
 	}
 
 	for _, i := range strings.Split(string(stdout), "\n") {
@@ -74,7 +73,7 @@ func (c docker) PullImage(img Image) error {
 
 	stdout, stderr, err = c.agent.Run("docker image pull " + img.Name())
 	if err != nil {
-		return errors.Wrapf(err, "stdout: %s, stderr: %s", stdout, stderr)
+		return fmt.Errorf("%w, stdout: %s, stderr: %s", err, stdout, stderr)
 	}
 	return nil
 }
@@ -134,7 +133,7 @@ func (c docker) RunSystem(name string, img Image, opts []string, params, extra S
 		cmdline := "docker rm " + name
 		stderr, stdout, err := c.agent.Run(cmdline)
 		if err != nil {
-			return errors.Wrapf(err, "cmdline: %s, stdout: %s, stderr: %s", cmdline, stdout, stderr)
+			return fmt.Errorf("%w, cmdline: %s, stdout: %s, stderr: %s", err, cmdline, stdout, stderr)
 		}
 	}
 
@@ -192,7 +191,7 @@ func (c docker) RunSystem(name string, img Image, opts []string, params, extra S
 	cmdline := strings.Join(args, " ")
 	stdout, stderr, err := c.agent.Run(cmdline)
 	if err != nil {
-		return errors.Wrapf(err, "cmdline: %s, stdout: %s, stderr: %s", cmdline, stdout, stderr)
+		return fmt.Errorf("%w, cmdline: %s, stdout: %s, stderr: %s", err, cmdline, stdout, stderr)
 	}
 	return nil
 }
@@ -201,7 +200,7 @@ func (c docker) Stop(name string) error {
 	cmdline := "docker container stop " + name
 	stdout, stderr, err := c.agent.Run(cmdline)
 	if err != nil {
-		return errors.Wrapf(err, "cmdline: %s, stdout: %s, stderr: %s", cmdline, stdout, stderr)
+		return fmt.Errorf("%w, cmdline: %s, stdout: %s, stderr: %s", err, cmdline, stdout, stderr)
 	}
 	return nil
 }
@@ -210,7 +209,7 @@ func (c docker) Kill(name string) error {
 	cmdline := "docker container kill " + name
 	stdout, stderr, err := c.agent.Run(cmdline)
 	if err != nil {
-		return errors.Wrapf(err, "cmdline: %s, stdout: %s, stderr: %s", cmdline, stdout, stderr)
+		return fmt.Errorf("%w, cmdline: %s, stdout: %s, stderr: %s", err, cmdline, stdout, stderr)
 	}
 	return nil
 }
@@ -219,7 +218,7 @@ func (c docker) Remove(name string) error {
 	cmdline := "docker container rm " + name
 	stdout, stderr, err := c.agent.Run(cmdline)
 	if err != nil {
-		return errors.Wrapf(err, "cmdline: %s, stdout: %s, stderr: %s", cmdline, stdout, stderr)
+		return fmt.Errorf("%w, cmdline: %s, stdout: %s, stderr: %s", err, cmdline, stdout, stderr)
 	}
 	return nil
 }
@@ -242,7 +241,7 @@ func (c docker) getID(name string) (string, error) {
 	cmdline := "docker ps -a --no-trunc --filter name=^/" + name + "$ --format {{.ID}}"
 	stdout, stderr, err := c.agent.Run(cmdline)
 	if err != nil {
-		return "", errors.Wrapf(err, "cmdline: %s, stdout: %s, stderr: %s", cmdline, stdout, stderr)
+		return "", fmt.Errorf("%w, cmdline: %s, stdout: %s, stderr: %s", err, cmdline, stdout, stderr)
 	}
 	return strings.TrimSpace(string(stdout)), nil
 }
@@ -255,7 +254,7 @@ func (c docker) getIDs(names []string) (map[string]string, error) {
 	cmdline := "docker ps -a --no-trunc " + strings.Join(filters, " ") + " --format {{.Names}}:{{.ID}}"
 	stdout, stderr, err := c.agent.Run(cmdline)
 	if err != nil {
-		return nil, errors.Wrapf(err, "cmdline: %s, stdout: %s, stderr: %s", cmdline, stdout, stderr)
+		return nil, fmt.Errorf("%w, cmdline: %s, stdout: %s, stderr: %s", err, cmdline, stdout, stderr)
 	}
 
 	ids := make(map[string]string)
@@ -296,7 +295,7 @@ RETRY:
 	if err != nil {
 		retryCount++
 		if retryCount >= 3 {
-			return nil, errors.Wrapf(err, "cmdline: %s, stdout: %s, stderr: %s", cmdline, stdout, stderr)
+			return nil, fmt.Errorf("%w, cmdline: %s, stdout: %s, stderr: %s", err, cmdline, stdout, stderr)
 		}
 		goto RETRY
 	}
@@ -333,7 +332,7 @@ func (c docker) VolumeCreate(name string) error {
 	cmdline := "docker volume create " + name
 	stdout, stderr, err := c.agent.Run(cmdline)
 	if err != nil {
-		return errors.Wrapf(err, "cmdline: %s, stdout: %s, stderr: %s", cmdline, stdout, stderr)
+		return fmt.Errorf("%w, cmdline: %s, stdout: %s, stderr: %s", err, cmdline, stdout, stderr)
 	}
 	return nil
 }
@@ -342,7 +341,7 @@ func (c docker) VolumeRemove(name string) error {
 	cmdline := "docker volume remove " + name
 	stdout, stderr, err := c.agent.Run(cmdline)
 	if err != nil {
-		return errors.Wrapf(err, "cmdline: %s, stdout: %s, stderr: %s", cmdline, stdout, stderr)
+		return fmt.Errorf("%w, cmdline: %s, stdout: %s, stderr: %s", err, cmdline, stdout, stderr)
 	}
 	return nil
 }
@@ -351,7 +350,7 @@ func (c docker) VolumeExists(name string) (bool, error) {
 	cmdline := "docker volume list -q"
 	stdout, stderr, err := c.agent.Run(cmdline)
 	if err != nil {
-		return false, errors.Wrapf(err, "cmdline: %s, stdout: %s, stderr: %s", cmdline, stdout, stderr)
+		return false, fmt.Errorf("%w, cmdline: %s, stdout: %s, stderr: %s", err, cmdline, stdout, stderr)
 	}
 
 	for _, n := range strings.Split(string(stdout), "\n") {

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/onsi/gomega v1.5.0
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
-	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.2 // indirect
 	github.com/sirupsen/logrus v1.4.2 // indirect
 	github.com/spf13/cobra v0.0.5

--- a/infrastructure.go
+++ b/infrastructure.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -14,7 +15,6 @@ import (
 	"github.com/cybozu-go/log"
 	"github.com/cybozu-go/well"
 	vault "github.com/hashicorp/vault/api"
-	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )


### PR DESCRIPTION
Now that we are using Go 1.13, Wrapf can be replaced
with fmt.Errorf's %w.