### PR TITLE
Remove pod_subnet field from cluster.yml

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -161,7 +161,6 @@ type Cluster struct {
 	Nodes         []*Node    `json:"nodes"`
 	TaintCP       bool       `json:"taint_control_plane"`
 	ServiceSubnet string     `json:"service_subnet"`
-	PodSubnet     string     `json:"pod_subnet"`
 	DNSServers    []string   `json:"dns_servers"`
 	DNSService    string     `json:"dns_service"`
 	EtcdBackup    EtcdBackup `json:"etcd_backup"`
@@ -175,10 +174,6 @@ func (c *Cluster) Validate(isTmpl bool) error {
 	}
 
 	_, _, err := net.ParseCIDR(c.ServiceSubnet)
-	if err != nil {
-		return err
-	}
-	_, _, err = net.ParseCIDR(c.PodSubnet)
 	if err != nil {
 		return err
 	}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -22,7 +22,6 @@ nodes:
     labels:
       label1: value1
 service_subnet: 12.34.56.00/24
-pod_subnet: 10.1.0.0/16
 dns_servers: ["1.1.1.1", "8.8.8.8"]
 dns_service: kube-system/dns
 etcd_backup:
@@ -113,9 +112,6 @@ options:
 	if c.ServiceSubnet != "12.34.56.00/24" {
 		t.Error(`c.ServiceSubnet != "12.34.56.00/24"`)
 	}
-	if c.PodSubnet != "10.1.0.0/16" {
-		t.Error(`c.PodSubnet != "10.1.0.0/16"`)
-	}
 	if !reflect.DeepEqual(c.DNSServers, []string{"1.1.1.1", "8.8.8.8"}) {
 		t.Error(`!reflect.DeepEqual(c.DNSServers, []string{"1.1.1.1", "8.8.8.8"})`)
 	}
@@ -205,7 +201,6 @@ func testClusterValidate(t *testing.T) {
 			Cluster{
 				Name:          "",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 			},
 			true,
 		},
@@ -214,16 +209,6 @@ func testClusterValidate(t *testing.T) {
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "",
-				PodSubnet:     "10.1.0.0/16",
-			},
-			true,
-		},
-		{
-			"No pod subnet",
-			Cluster{
-				Name:          "testcluster",
-				ServiceSubnet: "10.1.0.0/16",
-				PodSubnet:     "",
 			},
 			true,
 		},
@@ -232,7 +217,6 @@ func testClusterValidate(t *testing.T) {
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 				DNSServers:    []string{"a.b.c.d"},
 			},
 			true,
@@ -242,7 +226,6 @@ func testClusterValidate(t *testing.T) {
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 				DNSService:    "hoge",
 			},
 			true,
@@ -252,7 +235,6 @@ func testClusterValidate(t *testing.T) {
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 				EtcdBackup: EtcdBackup{
 					Enabled:  true,
 					PVCName:  "",
@@ -266,7 +248,6 @@ func testClusterValidate(t *testing.T) {
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 				EtcdBackup: EtcdBackup{
 					Enabled:  true,
 					PVCName:  "etcdbackup-pvc",
@@ -280,7 +261,6 @@ func testClusterValidate(t *testing.T) {
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 				Options: Options{
 					APIServer: APIServerParams{
 						AuditLogEnabled: true,
@@ -295,7 +275,6 @@ func testClusterValidate(t *testing.T) {
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 				Options: Options{
 					APIServer: APIServerParams{
 						AuditLogEnabled: true,
@@ -310,7 +289,6 @@ func testClusterValidate(t *testing.T) {
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 				Options: Options{
 					APIServer: APIServerParams{
 						AuditLogEnabled: true,
@@ -329,7 +307,6 @@ rules:
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 				Options: Options{
 					Kubelet: KubeletParams{
 						Domain: "a_b.c",
@@ -343,7 +320,6 @@ rules:
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 				Options: Options{
 					Kubelet: KubeletParams{
 						ContainerRuntime:         "test",
@@ -358,7 +334,6 @@ rules:
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 				Options: Options{
 					Kubelet: KubeletParams{
 						ContainerRuntime:         "remote",
@@ -373,7 +348,6 @@ rules:
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 				Options: Options{
 					Kubelet: KubeletParams{
 						BootTaints: []corev1.Taint{
@@ -393,7 +367,6 @@ rules:
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 				Options: Options{
 					Kubelet: KubeletParams{
 						BootTaints: []corev1.Taint{
@@ -413,7 +386,6 @@ rules:
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 				Options: Options{
 					Kubelet: KubeletParams{
 						BootTaints: []corev1.Taint{
@@ -433,7 +405,6 @@ rules:
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 				Options: Options{
 					Kubelet: KubeletParams{
 						BootTaints: []corev1.Taint{
@@ -453,7 +424,6 @@ rules:
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 				Options: Options{
 					Kubelet: KubeletParams{
 						CNIConfFile: CNIConfFile{
@@ -470,7 +440,6 @@ rules:
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 				Options: Options{
 					Kubelet: KubeletParams{
 						CNIConfFile: CNIConfFile{
@@ -487,7 +456,6 @@ rules:
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 				Options: Options{
 					Kubelet: KubeletParams{
 						CNIConfFile: CNIConfFile{
@@ -504,7 +472,6 @@ rules:
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 				Options: Options{
 					Scheduler: SchedulerParams{
 						Extenders: []string{`foo: bar`},
@@ -518,7 +485,6 @@ rules:
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 				Options: Options{
 					Scheduler: SchedulerParams{
 						Extenders: []string{`urlPrefix: http://127.0.0.1:8000`},
@@ -532,7 +498,6 @@ rules:
 			Cluster{
 				Name:          "testcluster",
 				ServiceSubnet: "10.0.0.0/14",
-				PodSubnet:     "10.1.0.0/16",
 				DNSService:    "kube-system/dns",
 				Options: Options{
 					Kubelet: KubeletParams{

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -11,14 +11,11 @@ a YAML or JSON object with these fields:
 | `nodes`               | true     | array        | `Node` list.                                                     |
 | `taint_control_plane` | false    | bool         | If true, taint contorl plane nodes.                              |
 | `service_subnet`      | true     | string       | CIDR subnet for k8s `Service`.                                   |
-| `pod_subnet`          | true     | string       | CIDR subnet for k8s `Pod`.                                       |
 | `dns_servers`         | false    | array        | List of upstream DNS server IP addresses.                        |
 | `dns_service`         | false    | string       | Upstream DNS service name with namespace as `namespace/service`. |
 | `etcd_backup`         | false    | `EtcdBackup` | See EtcdBackup.                                                  |
 | `options`             | false    | `Options`    | See options.                                                     |
 
-* IP addresses in `pod_subnet` are only used for host-local communication
-  as a fallback CNI plugin.  They are never seen from outside of the cluster.
 * Upstream DNS servers can be specified one of the following ways:
     * List server IP addresses in `dns_servers`.
     * Specify Kubernetes `Service` name in `dns_service` (e.g. `"kube-system/dns"`).  

--- a/docs/sabakan-integration.md
+++ b/docs/sabakan-integration.md
@@ -43,7 +43,6 @@ nodes:
 - user: cybozu
   control_plane: false
 service_subnet: 10.68.0.0/16
-pod_subnet: 10.64.0.0/14
 ```
 
 When the configuration template is updated, CKE will soon regenerate
@@ -97,7 +96,6 @@ nodes:
     value: gpu
     effect: PreferNoSchedule
 service_subnet: 10.68.0.0/16
-pod_subnet: 10.64.0.0/14
 ```
 
 ### Node template without role

--- a/example/cke-cluster.yml
+++ b/example/cke-cluster.yml
@@ -8,7 +8,6 @@ nodes:
   - address: 192.168.1.103
     user: core
 service_subnet: 10.100.0.0/16
-pod_subnet: 10.10.0.0/16
 dns_servers: ["8.8.8.8", "1.1.1.1"]
 options:
   kubelet:

--- a/mtest/cke-cluster.yml
+++ b/mtest/cke-cluster.yml
@@ -11,7 +11,6 @@ nodes:
   - address: __NODE5__
     user: cke
 service_subnet: 10.34.56.0/24
-pod_subnet: 10.1.0.0/16
 dns_servers: ["8.8.8.8", "1.1.1.1"]
 options:
   kube-api:

--- a/mtest/run.go
+++ b/mtest/run.go
@@ -396,7 +396,10 @@ func ckecliClusterSet(cluster *cke.Cluster) (time.Time, error) {
 		return time.Time{}, err
 	}
 
-	rf := remoteTempFile(string(y))
+	// TODO: remove this workaround added in #334
+	data := string(y) + "\npod_subnet: 10.1.0.0/16"
+
+	rf := remoteTempFile(data)
 	_, _, err = ckecli("cluster", "set", rf)
 	return time.Now(), err
 }

--- a/op/k8s/kubelet_boot.go
+++ b/op/k8s/kubelet_boot.go
@@ -28,22 +28,20 @@ type kubeletBootOp struct {
 	registeredNodes []*cke.Node
 	apiServer       *cke.Node
 
-	cluster   string
-	podSubnet string
-	params    cke.KubeletParams
+	cluster string
+	params  cke.KubeletParams
 
 	step  int
 	files *common.FilesBuilder
 }
 
 // KubeletBootOp returns an Operator to boot kubelet.
-func KubeletBootOp(nodes, registeredNodes []*cke.Node, apiServer *cke.Node, cluster, podSubnet string, params cke.KubeletParams) cke.Operator {
+func KubeletBootOp(nodes, registeredNodes []*cke.Node, apiServer *cke.Node, cluster string, params cke.KubeletParams) cke.Operator {
 	return &kubeletBootOp{
 		nodes:           nodes,
 		registeredNodes: registeredNodes,
 		apiServer:       apiServer,
 		cluster:         cluster,
-		podSubnet:       podSubnet,
 		params:          params,
 		files:           common.NewFilesBuilder(nodes),
 	}
@@ -78,7 +76,7 @@ func (o *kubeletBootOp) NextCommand() cke.Commander {
 		return common.MakeDirsCommand(o.nodes, dirs)
 	case 3:
 		o.step++
-		return prepareKubeletFilesCommand{o.cluster, o.podSubnet, o.params, o.files}
+		return prepareKubeletFilesCommand{o.cluster, o.params, o.files}
 	case 4:
 		o.step++
 		return o.files
@@ -165,10 +163,9 @@ func (c emptyDirCommand) Command() cke.Command {
 }
 
 type prepareKubeletFilesCommand struct {
-	cluster   string
-	podSubnet string
-	params    cke.KubeletParams
-	files     *common.FilesBuilder
+	cluster string
+	params  cke.KubeletParams
+	files   *common.FilesBuilder
 }
 
 func (c prepareKubeletFilesCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {

--- a/op/k8s/kubelet_restart.go
+++ b/op/k8s/kubelet_restart.go
@@ -12,22 +12,20 @@ import (
 type kubeletRestartOp struct {
 	nodes []*cke.Node
 
-	cluster   string
-	podSubnet string
-	params    cke.KubeletParams
+	cluster string
+	params  cke.KubeletParams
 
 	step  int
 	files *common.FilesBuilder
 }
 
 // KubeletRestartOp returns an Operator to restart kubelet
-func KubeletRestartOp(nodes []*cke.Node, cluster, podSubnet string, params cke.KubeletParams) cke.Operator {
+func KubeletRestartOp(nodes []*cke.Node, cluster string, params cke.KubeletParams) cke.Operator {
 	return &kubeletRestartOp{
-		nodes:     nodes,
-		cluster:   cluster,
-		podSubnet: podSubnet,
-		params:    params,
-		files:     common.NewFilesBuilder(nodes),
+		nodes:   nodes,
+		cluster: cluster,
+		params:  params,
+		files:   common.NewFilesBuilder(nodes),
 	}
 }
 

--- a/server/strategy.go
+++ b/server/strategy.go
@@ -121,13 +121,13 @@ func k8sOps(c *cke.Cluster, nf *NodeFilter) (ops []cke.Operator) {
 	// For all nodes
 	apiServer := nf.HealthyAPIServer()
 	if nodes := nf.SSHConnectedNodes(nf.KubeletUnrecognizedNodes(), true, true); len(nodes) > 0 {
-		ops = append(ops, k8s.KubeletRestartOp(nodes, c.Name, c.ServiceSubnet, c.Options.Kubelet))
+		ops = append(ops, k8s.KubeletRestartOp(nodes, c.Name, c.Options.Kubelet))
 	}
 	if nodes := nf.SSHConnectedNodes(nf.KubeletStoppedNodes(), true, true); len(nodes) > 0 {
-		ops = append(ops, k8s.KubeletBootOp(nodes, nf.KubeletStoppedRegisteredNodes(), apiServer, c.Name, c.PodSubnet, c.Options.Kubelet))
+		ops = append(ops, k8s.KubeletBootOp(nodes, nf.KubeletStoppedRegisteredNodes(), apiServer, c.Name, c.Options.Kubelet))
 	}
 	if nodes := nf.SSHConnectedNodes(nf.KubeletOutdatedNodes(), true, true); len(nodes) > 0 {
-		ops = append(ops, k8s.KubeletRestartOp(nodes, c.Name, c.ServiceSubnet, c.Options.Kubelet))
+		ops = append(ops, k8s.KubeletRestartOp(nodes, c.Name, c.Options.Kubelet))
 	}
 	nupvNodes, nupvs := nf.NeedUpdateUpBlockPVsToV1_16()
 	if nodes := nf.SSHConnectedNodes(nupvNodes, true, true); len(nodes) > 0 {

--- a/sonobuoy/cke-cluster.yml
+++ b/sonobuoy/cke-cluster.yml
@@ -1,1 +1,0 @@
-../example/cke-cluster.yml

--- a/sonobuoy/cke-cluster.yml.template
+++ b/sonobuoy/cke-cluster.yml.template
@@ -8,7 +8,6 @@ nodes:
   - address: @WORKER3_ADDRESS@
     user: cybozu
 service_subnet: 10.100.0.0/16
-pod_subnet: 10.10.0.0/16
 dns_servers: ["8.8.8.8", "1.1.1.1"]
 options:
   kubelet:


### PR DESCRIPTION
pod_subnet was meant to specify Node's spec.podCIDR field
allocation.  But it was not used at all!

To set node.spec.podCIDR, users can specify extra_args for
kube-controller-manager in cluster.yml as follows:

```yaml
options:
  kube-controller:
    extra_args:
      - "--allocate-node-cidrs=true"
      - "--cluster-cidr=10.20.0.0/16"
```

Moreover, node.spec.podCIDR is considered as "poor-man's IPAM"
according to https://github.com/kubernetes/kubernetes/issues/57130

Taking these into account, pod_subnet is just removed from the spec.