### PR TITLE
Add cgroup driver option to KubeletParams

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -127,6 +127,7 @@ type SchedulerParams struct {
 // KubeletParams is a set of extra parameters for kubelet.
 type KubeletParams struct {
 	ServiceParams            `json:",inline"`
+	CgroupDriver             string         `json:"cgroup_driver,omitempty"`
 	ContainerRuntime         string         `json:"container_runtime"`
 	ContainerRuntimeEndpoint string         `json:"container_runtime_endpoint"`
 	ContainerLogMaxSize      string         `json:"container_log_max_size"`

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -65,6 +65,7 @@ options:
   kubelet:
     domain: my.domain
     allow_swap: true
+    cgroup_driver: systemd
     container_runtime: remote
     container_runtime_endpoint: /var/run/k8s-containerd.sock
     container_log_max_size: 10Mi
@@ -167,6 +168,9 @@ rules:
 	}
 	if c.Options.Kubelet.ContainerRuntimeEndpoint != "/var/run/k8s-containerd.sock" {
 		t.Error(`c.Options.Kubelet.ContainerRuntimeEndpoint != "/var/run/k8s-containerd.sock"`)
+	}
+	if c.Options.Kubelet.CgroupDriver != "systemd" {
+		t.Error(`c.Options.Kubelet.CgroupDriver != "systemd"`)
 	}
 	if c.Options.Kubelet.ContainerLogMaxSize != "10Mi" {
 		t.Error(`c.Options.Kubelet.ContainerLogMaxSize != "10Mi"`)

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -5,6 +5,18 @@ CKE deploys and maintains a Kubernetes cluster and an etcd cluster solely for
 the Kubernetes cluster.  The configurations of the clusters can be defined by
 a YAML or JSON object with these fields:
 
+- [Node](#node)
+- [Taint](#taint)
+- [EtcdBackup](#etcdbackup)
+- [Options](#options)
+  - [ServiceParams](#serviceparams)
+  - [Mount](#mount)
+  - [EtcdParams](#etcdparams)
+  - [APIServerParams](#apiserverparams)
+  - [KubeletParams](#kubeletparams)
+  - [SchedulerParams](#schedulerparams)
+  - [CNIConfFile](#cniconffile)
+
 | Name                  | Required | Type         | Description                                                      |
 | --------------------- | -------- | ------------ | ---------------------------------------------------------------- |
 | `name`                | true     | string       | The k8s cluster name.                                            |
@@ -35,6 +47,7 @@ A `Node` has these fields:
 | `annotations`   | false    | object    | Node annotations.                                              |
 | `labels`        | false    | object    | Node labels.                                                   |
 | `taints`        | false    | `[]Taint` | Node taints.                                                   |
+|                 |
 
 `annotations`, `labels`, and `taints` are added or updated, but not removed.
 This is because other applications may edit their own annotations, labels, or taints.
@@ -130,6 +143,7 @@ Options
 | `extra_args`                 | false    | array       | Extra command-line arguments.  List of strings.                                                                                                                     |
 | `extra_binds`                | false    | array       | Extra bind mounts.  List of `Mount`.                                                                                                                                |
 | `extra_env`                  | false    | object      | Extra environment variables.                                                                                                                                        |
+| `cgroup_driver`              | false    | string      | Driver that the kubelet uses to manipulate cgroups on the host. `cgroupfs` (default) or `systemd`.                                                                  |
 | `container_runtime`          | false    | string      | Container runtime for Pod. Default: `docker`. You have to choose `docker` or `remote` which supports [CRI][].                                                       |
 | `container_runtime_endpoint` | false    | string      | Path of the runtime socket. It is required when `container_runtime` is `remote`. Default: `/var/run/dockershim.sock`.                                               |
 | `container_log_max_size`     | false    | string      | Equivalent to the [log rotation for CRI runtime]. Size of log file size. If the file size becomes bigger than given size, the log file is rotated. Default: `10Mi`. |

--- a/op/k8s/config.go
+++ b/op/k8s/config.go
@@ -76,7 +76,7 @@ func kubeletKubeconfig(cluster string, n *cke.Node, caPath, certPath, keyPath st
 	return cfg
 }
 
-func newKubeletConfiguration(cert, key, ca, domain, logSize string, logFiles int32, allowSwap bool) kubeletv1beta1.KubeletConfiguration {
+func newKubeletConfiguration(cert, key, ca string, params cke.KubeletParams) kubeletv1beta1.KubeletConfiguration {
 	return kubeletv1beta1.KubeletConfiguration{
 		ReadOnlyPort:      0,
 		TLSCertFile:       cert,
@@ -88,11 +88,12 @@ func newKubeletConfiguration(cert, key, ca, domain, logSize string, logFiles int
 		Authorization:         kubeletv1beta1.KubeletAuthorization{Mode: kubeletv1beta1.KubeletAuthorizationModeWebhook},
 		HealthzBindAddress:    "0.0.0.0",
 		OOMScoreAdj:           int32Pointer(-1000),
-		ClusterDomain:         domain,
+		ClusterDomain:         params.Domain,
 		RuntimeRequestTimeout: metav1.Duration{Duration: 15 * time.Minute},
-		FailSwapOn:            boolPointer(!allowSwap),
-		ContainerLogMaxSize:   logSize,
-		ContainerLogMaxFiles:  int32Pointer(logFiles),
+		FailSwapOn:            boolPointer(!params.AllowSwap),
+		CgroupDriver:          params.CgroupDriver,
+		ContainerLogMaxSize:   params.ContainerLogMaxSize,
+		ContainerLogMaxFiles:  int32Pointer(params.ContainerLogMaxFiles),
 	}
 }
 

--- a/op/k8s/kubelet_boot.go
+++ b/op/k8s/kubelet_boot.go
@@ -185,8 +185,7 @@ func (c prepareKubeletFilesCommand) Run(ctx context.Context, inf cke.Infrastruct
 		}
 	}
 
-	cfg := newKubeletConfiguration(tlsCertPath, tlsKeyPath, caPath, c.params.Domain,
-		c.params.ContainerLogMaxSize, c.params.ContainerLogMaxFiles, c.params.AllowSwap)
+	cfg := newKubeletConfiguration(tlsCertPath, tlsKeyPath, caPath, c.params)
 	g := func(ctx context.Context, n *cke.Node) ([]byte, error) {
 		cfg := cfg
 		cfg.ClusterDNS = []string{n.Address}

--- a/op/k8s/kubelet_restart.go
+++ b/op/k8s/kubelet_restart.go
@@ -87,8 +87,7 @@ func (c prepareKubeletConfigCommand) Run(ctx context.Context, inf cke.Infrastruc
 	tlsCertPath := op.K8sPKIPath("kubelet.crt")
 	tlsKeyPath := op.K8sPKIPath("kubelet.key")
 
-	cfg := newKubeletConfiguration(tlsCertPath, tlsKeyPath, caPath, c.params.Domain,
-		c.params.ContainerLogMaxSize, c.params.ContainerLogMaxFiles, c.params.AllowSwap)
+	cfg := newKubeletConfiguration(tlsCertPath, tlsKeyPath, caPath, c.params)
 	g := func(ctx context.Context, n *cke.Node) ([]byte, error) {
 		cfg := cfg
 		cfg.ClusterDNS = []string{n.Address}

--- a/op/status.go
+++ b/op/status.go
@@ -160,6 +160,7 @@ func GetNodeStatus(ctx context.Context, inf cke.Infrastructure, node *cke.Node, 
 			v := struct {
 				ClusterDomain        string `json:"clusterDomain"`
 				FailSwapOn           bool   `json:"failSwapOn"`
+				CgroupDriver         string `json:"cgroupDriver"`
 				ContainerLogMaxSize  string `json:"containerLogMaxSize"`
 				ContainerLogMaxFiles int32  `json:"containerLogMaxFiles"`
 			}{}
@@ -167,6 +168,7 @@ func GetNodeStatus(ctx context.Context, inf cke.Infrastructure, node *cke.Node, 
 			if err == nil {
 				status.Kubelet.Domain = v.ClusterDomain
 				status.Kubelet.AllowSwap = !v.FailSwapOn
+				status.Kubelet.CgroupDriver = v.CgroupDriver
 				status.Kubelet.ContainerLogMaxSize = v.ContainerLogMaxSize
 				status.Kubelet.ContainerLogMaxFiles = v.ContainerLogMaxFiles
 			}

--- a/server/node_filter.go
+++ b/server/node_filter.go
@@ -517,12 +517,14 @@ func (nf *NodeFilter) KubeletOutdatedNodes() (nodes []*cke.Node) {
 		case !st.Running:
 			// stopped nodes are excluded
 		case kubeletRuntimeChanged(st.BuiltInParams, currentBuiltIn):
-			log.Warn("kubelet's container runtime can not be changed", nil)
+			log.Warn("kubelet's container runtime cannot be changed", nil)
 		case cke.KubernetesImage.Name() != st.Image:
 			fallthrough
 		case currentOpts.Domain != st.Domain:
 			fallthrough
 		case currentOpts.AllowSwap != st.AllowSwap:
+			fallthrough
+		case currentOpts.CgroupDriver != st.CgroupDriver:
 			fallthrough
 		case currentOpts.ContainerLogMaxSize != st.ContainerLogMaxSize:
 			fallthrough

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -885,6 +885,18 @@ func TestDecideOps(t *testing.T) {
 		{
 			Name: "RestartKubelet10",
 			Input: newData().withAllServices().with(func(d testData) {
+				d.Cluster.Options.Kubelet.CgroupDriver = "systemd"
+			}).withSSHNotConnectedNodes(),
+			ExpectedOps: []string{
+				"kubelet-restart",
+			},
+			ExpectedTargetNums: map[string]int{
+				"kubelet-restart": 4,
+			},
+		},
+		{
+			Name: "RestartKubelet11",
+			Input: newData().withAllServices().with(func(d testData) {
 				d.Status.Kubernetes.Nodes = d.Status.Kubernetes.Nodes[:3]
 			}).withSSHNotConnectedNodes(),
 			ExpectedOps: []string{

--- a/sonobuoy/cke-cluster.yml.template
+++ b/sonobuoy/cke-cluster.yml.template
@@ -11,9 +11,9 @@ service_subnet: 10.100.0.0/16
 dns_servers: ["8.8.8.8", "1.1.1.1"]
 options:
   kubelet:
+    cgroup_driver: systemd
     extra_args:
       - "--volume-plugin-dir=/var/lib/kubelet/volumeplugins"
-      - "--cgroup-driver=systemd"
   kube-controller-manager:
     extra_args:
       - "--flex-volume-plugin-dir=/var/lib/kubelet/volumeplugins"

--- a/status.go
+++ b/status.go
@@ -149,6 +149,7 @@ type KubeletStatus struct {
 	IsHealthy                   bool
 	Domain                      string
 	AllowSwap                   bool
+	CgroupDriver                string
 	ContainerLogMaxSize         string
 	ContainerLogMaxFiles        int32
 	NeedUpdateBlockPVsUpToV1_16 []string


### PR DESCRIPTION
kubelet needs to use the same cgroup driver as Docker
if the container runtime is Docker.

New option "cgroup_driver" is added to KubeletParams
in cluster.yml to choose the cgroup driver to be used.

ref: https://github.com/kubernetes/kubelet/blob/v0.17.6/config/v1beta1/types.go#L404-L409