### PR TITLE
Do not restart kubelet when cgroup_driver is changed

### DIFF
--- a/op/status.go
+++ b/op/status.go
@@ -160,7 +160,6 @@ func GetNodeStatus(ctx context.Context, inf cke.Infrastructure, node *cke.Node, 
 			v := struct {
 				ClusterDomain        string `json:"clusterDomain"`
 				FailSwapOn           bool   `json:"failSwapOn"`
-				CgroupDriver         string `json:"cgroupDriver"`
 				ContainerLogMaxSize  string `json:"containerLogMaxSize"`
 				ContainerLogMaxFiles int32  `json:"containerLogMaxFiles"`
 			}{}
@@ -168,7 +167,6 @@ func GetNodeStatus(ctx context.Context, inf cke.Infrastructure, node *cke.Node, 
 			if err == nil {
 				status.Kubelet.Domain = v.ClusterDomain
 				status.Kubelet.AllowSwap = !v.FailSwapOn
-				status.Kubelet.CgroupDriver = v.CgroupDriver
 				status.Kubelet.ContainerLogMaxSize = v.ContainerLogMaxSize
 				status.Kubelet.ContainerLogMaxFiles = v.ContainerLogMaxFiles
 			}

--- a/server/node_filter.go
+++ b/server/node_filter.go
@@ -524,8 +524,6 @@ func (nf *NodeFilter) KubeletOutdatedNodes() (nodes []*cke.Node) {
 			fallthrough
 		case currentOpts.AllowSwap != st.AllowSwap:
 			fallthrough
-		case currentOpts.CgroupDriver != st.CgroupDriver:
-			fallthrough
 		case currentOpts.ContainerLogMaxSize != st.ContainerLogMaxSize:
 			fallthrough
 		case currentOpts.ContainerLogMaxFiles != st.ContainerLogMaxFiles:

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -888,10 +888,7 @@ func TestDecideOps(t *testing.T) {
 				d.Cluster.Options.Kubelet.CgroupDriver = "systemd"
 			}).withSSHNotConnectedNodes(),
 			ExpectedOps: []string{
-				"kubelet-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kubelet-restart": 4,
+				"wait-kubernetes",
 			},
 		},
 		{

--- a/status.go
+++ b/status.go
@@ -149,7 +149,6 @@ type KubeletStatus struct {
 	IsHealthy                   bool
 	Domain                      string
 	AllowSwap                   bool
-	CgroupDriver                string
 	ContainerLogMaxSize         string
 	ContainerLogMaxFiles        int32
 	NeedUpdateBlockPVsUpToV1_16 []string


### PR DESCRIPTION
cgroup_driver should not be changed for already running kubelet.

If cgroup_driver option was wrong, kubelet could not be run.
Changing the option for running kubelet does not make sense.

The option should be applied only when kubelet is _not_ running.