### PR TITLE
Fix race in server.Controller.GetClusterStatus

### DIFF
--- a/mtest/operators.go
+++ b/mtest/operators.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/cybozu-go/cke"
-	"github.com/cybozu-go/cke/op"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -332,66 +331,6 @@ func TestOperators(isDegraded bool) {
 		cluster.Options.Kubelet.ExtraEnvvar = map[string]string{"AAA": "aaa"}
 		cluster.Options.Kubelet.Domain = "neconeco"
 		clusterSetAndWait(cluster)
-
-		By("Adding a scheduler extender")
-		// this will run these ops:
-		// - SchedulerRestartOp
-		cluster.Options.Scheduler.Extenders = []string{"urlPrefix: http://127.0.0.1:8000"}
-		clusterSetAndWait(cluster)
-
-		stdout, stderr, err := execAt(node1, "jq", "-r", "'.extenders[0].urlPrefix'", op.PolicyConfigPath)
-		Expect(err).NotTo(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
-		Expect(strings.TrimSpace(string(stdout))).To(Equal("http://127.0.0.1:8000"))
-
-		By("Removing a scheduler extender")
-		// this will run these ops:
-		// - SchedulerRestartOp
-		cluster.Options.Scheduler.Extenders = []string{}
-		clusterSetAndWait(cluster)
-
-		stdout, stderr, err = execAt(node1, "jq", "'.extenders'", op.PolicyConfigPath)
-		Expect(err).NotTo(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
-		Expect(strings.TrimSpace(string(stdout))).To(Equal("null"))
-
-		By("Adding a scheduler predicate")
-		// this will run these ops:
-		// - SchedulerRestartOp
-		cluster.Options.Scheduler.Predicates = []string{"name: some_predicate"}
-		clusterSetAndWait(cluster)
-
-		stdout, stderr, err = execAt(node1, "jq", "-r", "'.predicates[0].name'", op.PolicyConfigPath)
-		Expect(err).NotTo(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
-		Expect(strings.TrimSpace(string(stdout))).To(Equal("some_predicate"))
-
-		By("Removing a scheduler predicate")
-		// this will run these ops:
-		// - SchedulerRestartOp
-		cluster.Options.Scheduler.Predicates = []string{}
-		clusterSetAndWait(cluster)
-
-		stdout, stderr, err = execAt(node1, "jq", "'.predicates'", op.PolicyConfigPath)
-		Expect(err).NotTo(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
-		Expect(strings.TrimSpace(string(stdout))).To(Equal("null"))
-
-		By("Adding a scheduler priorities")
-		// this will run these ops:
-		// - SchedulerRestartOp
-		cluster.Options.Scheduler.Priorities = []string{"name: some_priority"}
-		clusterSetAndWait(cluster)
-
-		stdout, stderr, err = execAt(node1, "jq", "-r", "'.priorities[0].name'", op.PolicyConfigPath)
-		Expect(err).NotTo(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
-		Expect(strings.TrimSpace(string(stdout))).To(Equal("some_priority"))
-
-		By("Removing a scheduler priorities")
-		// this will run these ops:
-		// - SchedulerRestartOp
-		cluster.Options.Scheduler.Priorities = []string{}
-		clusterSetAndWait(cluster)
-
-		stdout, stderr, err = execAt(node1, "jq", "'.priorities'", op.PolicyConfigPath)
-		Expect(err).NotTo(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
-		Expect(strings.TrimSpace(string(stdout))).To(Equal("null"))
 	})
 
 	It("updates Node resources", func() {

--- a/op/status.go
+++ b/op/status.go
@@ -179,22 +179,23 @@ func GetNodeStatus(ctx context.Context, inf cke.Infrastructure, node *cke.Node, 
 }
 
 // GetNodeStatusUpToV1_16 sets node status about k8s v1.16 or below
-func GetNodeStatusUpToV1_16(ctx context.Context, inf cke.Infrastructure, node *cke.Node, cluster *cke.Cluster, status *cke.NodeStatus, apiServer *cke.Node) (*cke.NodeStatus, error) {
-	var err error
-	if status.Kubelet.Running {
-		// Block device paths have been changed between k8s v1.16 and v1.17.
-		// https://github.com/kubernetes/kubernetes/pull/74026
-		// So, old device paths and symlinks must be updated before upgrading.
-		status.Kubelet.NeedUpdateBlockPVsUpToV1_16, err = needUpdateBlockPVsUpToV1_16(ctx, inf, apiServer, node)
-		if err != nil {
-			log.Warn("failed to check outdated block device paths", map[string]interface{}{
-				log.FnError: err,
-				"node":      node.Address,
-			})
-		}
+func GetNodeStatusUpToV1_16(ctx context.Context, inf cke.Infrastructure, node *cke.Node, cluster *cke.Cluster, status *cke.NodeStatus, apiServer *cke.Node) {
+	if !status.Kubelet.Running {
+		return
 	}
 
-	return status, nil
+	// Block device paths have been changed between k8s v1.16 and v1.17.
+	// https://github.com/kubernetes/kubernetes/pull/74026
+	// So, old device paths and symlinks must be updated before upgrading.
+	nu, err := needUpdateBlockPVsUpToV1_16(ctx, inf, apiServer, node)
+	if err != nil {
+		log.Warn("failed to check outdated block device paths", map[string]interface{}{
+			log.FnError: err,
+			"node":      node.Address,
+		})
+	}
+
+	status.Kubelet.NeedUpdateBlockPVsUpToV1_16 = nu
 }
 
 func needUpdateBlockPVsUpToV1_16(ctx context.Context, inf cke.Infrastructure, apiServer *cke.Node, node *cke.Node) ([]string, error) {

--- a/server/get_status.go
+++ b/server/get_status.go
@@ -91,15 +91,9 @@ func (c Controller) GetClusterStatus(ctx context.Context, cluster *cke.Cluster, 
 	env = well.NewEnvironment(ctx)
 	for _, n := range cluster.Nodes {
 		n := n
+		ns := statuses[n.Address]
 		env.Go(func(ctx context.Context) error {
-			mu.Lock()
-			defer mu.Unlock()
-
-			ns, err := op.GetNodeStatusUpToV1_16(ctx, inf, n, cluster, statuses[n.Address], livingMaster)
-			if err != nil {
-				return fmt.Errorf("%s: %v", n.Address, err)
-			}
-			statuses[n.Address] = ns
+			op.GetNodeStatusUpToV1_16(ctx, inf, n, cluster, ns, livingMaster)
 			return nil
 		})
 	}


### PR DESCRIPTION
A concurrent reference of a map caused the race because
other goroutines are mutating the map at the same time.
https://app.circleci.com/pipelines/github/cybozu-go/cke/1085/workflows/92fc41ee-55b3-4877-8098-c5edf86ddcd4/jobs/11128/steps

In fact, the map does not need to be updated, so fixing it that way.

In addition, remove redundant tests from `mtest/operators.go`.