### PR TITLE
mtest: check changes to scheduler configs

### DIFF
--- a/mtest/operators.go
+++ b/mtest/operators.go
@@ -327,6 +327,9 @@ func TestOperators(isDegraded bool) {
 		cluster.Options.Etcd.ExtraEnvvar = map[string]string{"AAA": "aaa"}
 		cluster.Options.ControllerManager.ExtraEnvvar = map[string]string{"AAA": "aaa"}
 		cluster.Options.Scheduler.ExtraEnvvar = map[string]string{"AAA": "aaa"}
+		cluster.Options.Scheduler.Extenders = []string{"urlPrefix: http://127.0.0.1:8000"}
+		cluster.Options.Scheduler.Predicates = []string{"name: some_predicate"}
+		cluster.Options.Scheduler.Priorities = []string{"name: some_priority"}
 		cluster.Options.Proxy.ExtraEnvvar = map[string]string{"AAA": "aaa"}
 		cluster.Options.Kubelet.ExtraEnvvar = map[string]string{"AAA": "aaa"}
 		cluster.Options.Kubelet.Domain = "neconeco"


### PR DESCRIPTION
Recover conditions that were accidentally removed in 5f517cc73547bd3536a55128f0d9b105cacc7a15