### PR TITLE
Avoid node duplication due to regeneration after update

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -191,8 +191,7 @@ func (c *Cluster) Validate(isTmpl bool) error {
 
 	nodeAddressSet := make(map[string]struct{})
 	for _, n := range c.Nodes {
-		_, ok := nodeAddressSet[n.Address]
-		if ok {
+		if _, ok := nodeAddressSet[n.Address]; ok {
 			return errors.New("duplicate node address: " + n.Address)
 		}
 		nodeAddressSet[n.Address] = struct{}{}

--- a/cluster.go
+++ b/cluster.go
@@ -189,13 +189,13 @@ func (c *Cluster) Validate(isTmpl bool) error {
 		}
 	}
 
-	nodeAddressSet := make(map[string]int)
+	nodeAddressSet := make(map[string]struct{})
 	for _, n := range c.Nodes {
 		_, ok := nodeAddressSet[n.Address]
 		if ok {
 			return errors.New("duplicate node address: " + n.Address)
 		}
-		nodeAddressSet[n.Address] = 1
+		nodeAddressSet[n.Address] = struct{}{}
 	}
 
 	for _, a := range c.DNSServers {

--- a/cluster.go
+++ b/cluster.go
@@ -189,6 +189,15 @@ func (c *Cluster) Validate(isTmpl bool) error {
 		}
 	}
 
+	nodeAddressSet := make(map[string]int)
+	for _, n := range c.Nodes {
+		_, ok := nodeAddressSet[n.Address]
+		if ok {
+			return errors.New("duplicate node address: " + n.Address)
+		}
+		nodeAddressSet[n.Address] = 1
+	}
+
 	for _, a := range c.DNSServers {
 		if net.ParseIP(a) == nil {
 			return errors.New("invalid IP address: " + a)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -560,6 +560,24 @@ rules:
 			false,
 		},
 		{
+			"duplicate node address",
+			Cluster{
+				Name:          "testcluster",
+				ServiceSubnet: "10.0.0.0/14",
+				Nodes: []*Node{
+					{
+						Address: "10.0.0.1",
+						User:    "user",
+					},
+					{
+						Address: "10.0.0.1",
+						User:    "another",
+					},
+				},
+			},
+			true,
+		},
+		{
 			"valid case",
 			Cluster{
 				Name:          "testcluster",


### PR DESCRIPTION
Avoid node duplication due to `Generator.Regenere` after `Generator.Update`.
And add validation for node duplication.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>