### PR TITLE
sonobuoy: use 'sudo:' stanza in cloud-config

### DIFF
--- a/sonobuoy/worker.cfg
+++ b/sonobuoy/worker.cfg
@@ -2,7 +2,8 @@
 
 users:
 - name: cke
-  groups: docker, google-sudoers
+  groups: docker
+  sudo:  ALL=(ALL) NOPASSWD:ALL
   ssh_authorized_keys:
     - "PUBLIC_KEY"
 


### PR DESCRIPTION
because it seems that `google-sudoers` group sometimes does not
exist when `cloud-init` runs.

c.f. https://cloudinit.readthedocs.io/en/latest/topics/examples.html#including-users-and-groups