### PR TITLE
Update kubernetes image to 1.17.6.2

### DIFF
--- a/images.go
+++ b/images.go
@@ -11,7 +11,7 @@ func (i Image) Name() string {
 // Container image definitions
 const (
 	EtcdImage       = Image("quay.io/cybozu/etcd:3.3.22.1")
-	KubernetesImage = Image("quay.io/cybozu/kubernetes:1.17.6.1")
+	KubernetesImage = Image("quay.io/cybozu/kubernetes:1.17.6.2")
 	ToolsImage      = Image("quay.io/cybozu/cke-tools:1.7.1")
 	PauseImage      = Image("quay.io/cybozu/pause:3.2.0.1")
 	CoreDNSImage    = Image("quay.io/cybozu/coredns:1.6.7.1")


### PR DESCRIPTION
This fixes kube-proxy's bug in IPVS mode.
c.f. https://github.com/kubernetes/kubernetes/issues/92019