### PR TITLE
reboot: implement ckecli reboot-queue commands

### DIFF
--- a/pkg/ckecli/cmd/reboot_queue.go
+++ b/pkg/ckecli/cmd/reboot_queue.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// rebootQueueCmd represents the reboot-queue command
+var rebootQueueCmd = &cobra.Command{
+	Use:     "reboot-queue",
+	Aliases: []string{"rq"},
+	Short:   "reboot-queue subcommand",
+	Long:    `reboot-queue subcommand`,
+}
+
+func init() {
+	rootCmd.AddCommand(rebootQueueCmd)
+}

--- a/pkg/ckecli/cmd/reboot_queue_add.go
+++ b/pkg/ckecli/cmd/reboot_queue_add.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/cybozu-go/cke"
+	"github.com/cybozu-go/well"
+	"github.com/spf13/cobra"
+)
+
+var rebootQueueAddCmd = &cobra.Command{
+	Use:   "add FILE",
+	Short: "append the nodes written in FILE to the reboot queue",
+	Long: `Append the nodes written in FILE to the reboot queue.
+
+The nodes should be specified with their IP addresses.
+If FILE is -, the contents are read from stdin.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		f := os.Stdin
+		if args[0] != "-" {
+			var err error
+			f, err = os.Open(args[0])
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+		}
+
+		data, err := ioutil.ReadAll(f)
+		if err != nil {
+			return err
+		}
+		nodes := strings.Fields(string(data))
+		entry := cke.NewRebootQueueEntry(nodes)
+
+		well.Go(func(ctx context.Context) error {
+			// Check nodes actually exist
+			cluster, err := storage.GetCluster(ctx)
+			if err != nil {
+				return err
+			}
+		OUTER:
+			for _, rebootNode := range nodes {
+				for _, clusterNode := range cluster.Nodes {
+					if rebootNode == clusterNode.Address {
+						continue OUTER
+					}
+				}
+				return fmt.Errorf("%s is not a valid node IP address", rebootNode)
+			}
+
+			return storage.RegisterRebootsEntry(ctx, entry)
+		})
+		well.Stop()
+		return well.Wait()
+	},
+}
+
+func init() {
+	rebootQueueCmd.AddCommand(rebootQueueAddCmd)
+}

--- a/pkg/ckecli/cmd/reboot_queue_cancel.go
+++ b/pkg/ckecli/cmd/reboot_queue_cancel.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/cybozu-go/well"
+	"github.com/spf13/cobra"
+)
+
+var rebootQueueCancelCmd = &cobra.Command{
+	Use:   "cancel INDEX",
+	Short: "cancel the specified reboot queue entry",
+	Long:  `Cancel the specified reboot queue entry.`,
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		index, err := strconv.ParseInt(args[0], 10, 64)
+		if err != nil {
+			return err
+		}
+
+		well.Go(func(ctx context.Context) error {
+			entry, err := storage.GetRebootsEntry(ctx, index)
+			if err != nil {
+				return err
+			}
+
+			entry.Cancel()
+			return storage.UpdateRebootsEntry(ctx, entry)
+		})
+		well.Stop()
+		return well.Wait()
+	},
+}
+
+func init() {
+	rebootQueueCmd.AddCommand(rebootQueueCancelCmd)
+}

--- a/pkg/ckecli/cmd/reboot_queue_list.go
+++ b/pkg/ckecli/cmd/reboot_queue_list.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"github.com/cybozu-go/well"
+	"github.com/spf13/cobra"
+)
+
+var rebootQueueListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "list the entries in the reboot queue",
+	Long: `List the entries in the reboot queue.
+
+The output is a list of RebootQueueEntry formatted in JSON.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		well.Go(func(ctx context.Context) error {
+			entries, err := storage.GetRebootsEntries(ctx)
+			if err != nil {
+				return err
+			}
+
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "    ")
+			if err := enc.Encode(entries); err != nil {
+				return err
+			}
+			return nil
+		})
+		well.Stop()
+		return well.Wait()
+	},
+}
+
+func init() {
+	rebootQueueCmd.AddCommand(rebootQueueListCmd)
+}


### PR DESCRIPTION
This PR implements ckecli reboot-queue commands:
- `ckecli reboot-queue add`
- `ckecli reboot-queue list`
- `ckecli reboot-queue cancel`

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>
