### PR TITLE
Remove defaulting for kubelet OOMScoreAdj.

### DIFF
--- a/op/k8s/config.go
+++ b/op/k8s/config.go
@@ -107,7 +107,6 @@ func newKubeletConfiguration(cert, key, ca string, params cke.KubeletParams) kub
 	base := &kubeletv1beta1.KubeletConfiguration{
 		RuntimeRequestTimeout: metav1.Duration{Duration: 15 * time.Minute},
 		HealthzBindAddress:    "0.0.0.0",
-		OOMScoreAdj:           int32Pointer(-1000),
 	}
 
 	// This won't raise an error because of prior validation

--- a/op/k8s/config_test.go
+++ b/op/k8s/config_test.go
@@ -57,7 +57,6 @@ func TestGenerateKubeletConfiguration(t *testing.T) {
 	baseExpected := kubeletv1beta1.KubeletConfiguration{
 		ReadOnlyPort:          0,
 		HealthzBindAddress:    "0.0.0.0",
-		OOMScoreAdj:           int32Pointer(-1000),
 		FailSwapOn:            boolPointer(true),
 		RuntimeRequestTimeout: metav1.Duration{Duration: 15 * time.Minute},
 		TLSCertFile:           "/etc/kubernetes/pki/kubelet.crt",

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -320,7 +320,6 @@ func (d testData) withKubelet(domain, dns string, allowSwap bool) testData {
 			ContainerRuntimeEndpoint: "/var/run/k8s-containerd.sock",
 		})
 
-		var oomScoreAdj int32 = -1000
 		webhookEnabled := true
 		st.Config = &kubeletv1beta1.KubeletConfiguration{
 			TypeMeta: metav1.TypeMeta{
@@ -330,7 +329,6 @@ func (d testData) withKubelet(domain, dns string, allowSwap bool) testData {
 			ClusterDomain:         domain,
 			RuntimeRequestTimeout: metav1.Duration{Duration: 15 * time.Minute},
 			HealthzBindAddress:    "0.0.0.0",
-			OOMScoreAdj:           &oomScoreAdj,
 			ContainerLogMaxSize:   "20Mi",
 			TLSCertFile:           "/etc/kubernetes/pki/kubelet.crt",
 			TLSPrivateKeyFile:     "/etc/kubernetes/pki/kubelet.key",


### PR DESCRIPTION
Currently, `kubelet` is executed with `oom-score-adj=-1000` which means the OOM killer doesn't kill the `kubelet` if it makes a memory leak.
This PR removes the option `oom-score-adj`, which results to use the default value `-999`, then the OOM killer can kill the `kubelet`.