### PR TITLE
reboot: uncordon rebooted nodes

### DIFF
--- a/docs/reboot.md
+++ b/docs/reboot.md
@@ -46,9 +46,9 @@ The queue is processed by CKE as follows:
    3. Call the eviction API for Pods running on the target nodes.  DaemonSet-managed Pods are ignored.  If pods not in the `protected_namespaces` fail to be evicted, they are deleted instead.
    4. Wait for the deletion of the Pods.  If this step exceeds a deadline specified in the cluster configuration, the operation is aborted and the queue entry is left as is.
    5. Reboot the nodes using `.reboot.command` in the cluster configuration. In this step, all the nodes are rebooted simultaneously. If some of the nodes won't get back ready within the deadline specified in the cluster configuration, CKE gives up waiting for them (no error).
-   6. Uncordon the nodes.
-   7. Record the status in the history record.  It includes the list of nodes that failed to reboot.
-   8. Remove the entry.
+   6. Record the status in the history record.  It includes the list of nodes that failed to reboot.
+   7. Remove the entry.
+   8. Uncordon the nodes.
 
 
 [LabelSelector]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors

--- a/op/constants.go
+++ b/op/constants.go
@@ -65,6 +65,9 @@ const (
 	// EtcdBackupAppName is application name for etcdbackup
 	EtcdBackupAppName = "etcdbackup"
 
+	// CKEAnnotationReboot is the annotation to mark reboot targets
+	CKEAnnotationReboot = "cke.cybozu.com/reboot"
+
 	// PolicyConfigPath is a path for scheduler extender policy
 	PolicyConfigPath = "/etc/kubernetes/scheduler/policy.cfg"
 	// SchedulerConfigPath is a path for scheduler extender config

--- a/op/reboot_dequeue.go
+++ b/op/reboot_dequeue.go
@@ -21,7 +21,7 @@ func RebootDequeueOp(index int64) cke.Operator {
 }
 
 func (o *rebootDequeueOp) Name() string {
-	return "rebootDequeue"
+	return "reboot-dequeue"
 }
 
 func (o *rebootDequeueOp) NextCommand() cke.Commander {

--- a/phase.go
+++ b/phase.go
@@ -18,6 +18,7 @@ const (
 	PhaseEtcdMaintain    = OperationPhase("etcd-maintain")
 	PhaseK8sMaintain     = OperationPhase("k8s-maintain")
 	PhaseStopCP          = OperationPhase("stop-control-plane")
+	PhaseUncordonNodes   = OperationPhase("uncordon-nodes")
 	PhaseRebootNodes     = OperationPhase("reboot-nodes")
 	PhaseCompleted       = OperationPhase("completed")
 )
@@ -35,6 +36,7 @@ var AllOperationPhases = []OperationPhase{
 	PhaseEtcdMaintain,
 	PhaseK8sMaintain,
 	PhaseStopCP,
+	PhaseUncordonNodes,
 	PhaseRebootNodes,
 	PhaseCompleted,
 }

--- a/server/node_filter.go
+++ b/server/node_filter.go
@@ -715,6 +715,9 @@ func (nf *NodeFilter) UnhealthyAPIServerNodes() (nodes []*cke.Node) {
 }
 
 func isInternal(name string) bool {
+	if name == op.CKEAnnotationReboot {
+		return false
+	}
 	if strings.HasPrefix(name, "cke.cybozu.com/") {
 		return true
 	}
@@ -895,6 +898,17 @@ func nodeIsOutdated(n *cke.Node, current *corev1.Node, taintCP bool) bool {
 	}
 
 	return false
+}
+
+// CordonedNodes returns nodes that are cordoned and annotated as reboot operation targets.
+func (nf *NodeFilter) CordonedNodes() (nodes []*corev1.Node) {
+	for i := range nf.status.Kubernetes.Nodes {
+		n := &nf.status.Kubernetes.Nodes[i]
+		if n.Spec.Unschedulable && n.Annotations[op.CKEAnnotationReboot] == "true" {
+			nodes = append(nodes, n)
+		}
+	}
+	return nodes
 }
 
 // SSHNotConnectedNodes returns nodes that are not connected via SSH out of targets.


### PR DESCRIPTION
This PR makes a separate operation for uncordoning nodes as follows:

1. cordon and reboot nodes,
2. restart services on the nodes,
3. uncordon the nodes.

This change is required to reboot control plane nodes.
Also, a small bug is fixed (`rebootDequeue` -> `reboot-dequeue`).

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>