### PR TITLE
reboot: enable/disable reboot queue processing

### DIFF
--- a/docs/ckecli.md
+++ b/docs/ckecli.md
@@ -43,6 +43,7 @@ $ ckecli [--config FILE] <subcommand> args...
 - [`ckecli ssh [user@]NODE [COMMAND...]`](#ckecli-ssh-usernode-command)
 - [`ckecli scp [-r] [[user@]NODE1:]FILE1 ... [[user@]NODE2:]FILE2`](#ckecli-scp--r-usernode1file1--usernode2file2)
 - [`ckecli reboot-queue`, `ckecli rq`](#ckecli-reboot-queue-ckecli-rq)
+  - [`ckecli reboot-queue enable|disable`](#ckecli-reboot-queue-enabledisable)
   - [`ckecli reboot-queue add FILE`](#ckecli-reboot-queue-add-file)
   - [`ckecli reboot-queue list`](#ckecli-reboot-queue-list)
   - [`ckecli reboot-queue cancel INDEX`](#ckecli-reboot-queue-cancel-index)
@@ -276,6 +277,10 @@ Copy files between hosts via scp.
 ## `ckecli reboot-queue`, `ckecli rq`
 
 `rq` is an alias of `reboot-queue`.
+
+### `ckecli reboot-queue enable|disable`
+
+Enable/Disables processing reboot queue entries.
 
 ### `ckecli reboot-queue add FILE`
 

--- a/docs/ckecli.md
+++ b/docs/ckecli.md
@@ -280,7 +280,7 @@ Copy files between hosts via scp.
 
 ### `ckecli reboot-queue enable|disable`
 
-Enable/Disables processing reboot queue entries.
+Enable/Disable processing reboot queue entries.
 
 ### `ckecli reboot-queue add FILE`
 

--- a/docs/reboot.md
+++ b/docs/reboot.md
@@ -38,9 +38,10 @@ The command writes a reboot queue entry and increments `reboots/write-index` ato
 
 The queue is processed by CKE as follows:
 
-1. Check the number of unreachable nodes. If it exceeds `maximum-unreachable-nodes-for-reboot` in the constraints, it doesn't process the queue.
-2. Check the reboot queue to find an entry. If the entry's status is `cancelled`, remove it and check the queue again. If there is no entry, CKE stops the processing.
-3. For the first entry in the reboot queue, do the following steps.
+1. If `reboots/disabled` is `true`, it doesn't process the queue.
+2. Check the number of unreachable nodes. If it exceeds `maximum-unreachable-nodes-for-reboot` in the constraints, it doesn't process the queue.
+3. Check the reboot queue to find an entry. If the entry's status is `cancelled`, remove it and check the queue again. If there is no entry, CKE stops the processing.
+4. For the first entry in the reboot queue, do the following steps.
    1. Update the entry status to `rebooting`.
    2. Cordon the nodes in the entry.
    3. Call the eviction API for Pods running on the target nodes.  DaemonSet-managed Pods are ignored.  If pods not in the `protected_namespaces` fail to be evicted, they are deleted instead.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -113,6 +113,10 @@ Sabakan URL.
 
 The reboot queue.
 
+### `reboots/disabled`
+
+If this key exists and its value is `true`, reboot queue is not processed.
+
 ### `reboots/write-index`
 
 The next index to write reboot queue entry formatted as a decimal string.

--- a/pkg/ckecli/cmd/reboot_queue_disable.go
+++ b/pkg/ckecli/cmd/reboot_queue_disable.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/cybozu-go/well"
+	"github.com/spf13/cobra"
+)
+
+var rebootQueueDisableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "disable reboot queue processing",
+	Long:  `Disable reboot queue processing.`,
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		well.Go(func(ctx context.Context) error {
+			return storage.EnableRebootQueue(ctx, false)
+		})
+		well.Stop()
+		return well.Wait()
+	},
+}
+
+func init() {
+	rebootQueueCmd.AddCommand(rebootQueueDisableCmd)
+}

--- a/pkg/ckecli/cmd/reboot_queue_enable.go
+++ b/pkg/ckecli/cmd/reboot_queue_enable.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/cybozu-go/well"
+	"github.com/spf13/cobra"
+)
+
+var rebootQueueEnableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "enable reboot queue processing",
+	Long:  `Enable reboot queue processing.`,
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		well.Go(func(ctx context.Context) error {
+			return storage.EnableRebootQueue(ctx, true)
+		})
+		well.Stop()
+		return well.Wait()
+	},
+}
+
+func init() {
+	rebootQueueCmd.AddCommand(rebootQueueEnableCmd)
+}

--- a/server/control.go
+++ b/server/control.go
@@ -266,18 +266,19 @@ func (c Controller) runOnce(ctx context.Context, leaderKey string, tick <-chan t
 		return err
 	}
 
-	var reboot *cke.RebootQueueEntry
-	disabled, err := inf.Storage().IsRebootQueueDisabled(ctx)
+	re, err := inf.Storage().GetRebootsEntries(ctx)
 	if err != nil {
 		return err
 	}
-	if !disabled {
-		re, err := inf.Storage().GetRebootsEntries(ctx)
+	metrics.UpdateReboot(len(re))
+
+	var reboot *cke.RebootQueueEntry
+	if len(re) > 0 {
+		disabled, err := inf.Storage().IsRebootQueueDisabled(ctx)
 		if err != nil {
 			return err
 		}
-		metrics.UpdateReboot(len(re))
-		if len(re) > 0 {
+		if !disabled {
 			reboot = re[0]
 		}
 	}

--- a/server/control.go
+++ b/server/control.go
@@ -266,14 +266,20 @@ func (c Controller) runOnce(ctx context.Context, leaderKey string, tick <-chan t
 		return err
 	}
 
-	re, err := inf.Storage().GetRebootsEntries(ctx)
+	var reboot *cke.RebootQueueEntry
+	disabled, err := inf.Storage().IsRebootQueueDisabled(ctx)
 	if err != nil {
 		return err
 	}
-	metrics.UpdateReboot(len(re))
-	var reboot *cke.RebootQueueEntry
-	if len(re) > 0 {
-		reboot = re[0]
+	if !disabled {
+		re, err := inf.Storage().GetRebootsEntries(ctx)
+		if err != nil {
+			return err
+		}
+		metrics.UpdateReboot(len(re))
+		if len(re) > 0 {
+			reboot = re[0]
+		}
 	}
 	ops, phase := DecideOps(cluster, status, constraints, rcs, reboot)
 

--- a/storage.go
+++ b/storage.go
@@ -698,16 +698,18 @@ func (s Storage) IsRebootQueueDisabled(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
-	if bytes.Equal([]byte("true"), resp.Kvs[0].Value) {
-		return true, nil
-	}
-	return false, nil
+	return bytes.Equal([]byte("true"), resp.Kvs[0].Value), nil
 }
 
 // EnableRebootQueue enables reboot queue processing when flag is true.
 // When flag is false, reboot queue is not processed.
 func (s Storage) EnableRebootQueue(ctx context.Context, flag bool) error {
-	val := fmt.Sprint(!flag)
+	var val string
+	if flag {
+		val = "false"
+	} else {
+		val = "true"
+	}
 	_, err := s.Put(ctx, KeyRebootsDisabled, val)
 	return err
 }

--- a/storage.go
+++ b/storage.go
@@ -30,6 +30,7 @@ const (
 	KeyClusterRevision       = "cluster-revision"
 	KeyConstraints           = "constraints"
 	KeyLeader                = "leader/"
+	KeyRebootsDisabled       = "reboots/disabled"
 	KeyRebootsPrefix         = "reboots/data/"
 	KeyRebootsWriteIndex     = "reboots/write-index"
 	KeyRecords               = "records/"
@@ -685,6 +686,30 @@ func (s Storage) SetSabakanURL(ctx context.Context, url string) error {
 // The URL must be an absolute URL pointing GraphQL endpoint.
 func (s Storage) GetSabakanURL(ctx context.Context) (string, error) {
 	return s.getStringValue(ctx, KeySabakanURL)
+}
+
+// IsRebootQueueDisabled returns true if reboot queue is disabled.
+func (s Storage) IsRebootQueueDisabled(ctx context.Context) (bool, error) {
+	resp, err := s.Get(ctx, KeyRebootsDisabled)
+	if err != nil {
+		return false, err
+	}
+	if resp.Count == 0 {
+		return false, nil
+	}
+
+	if bytes.Equal([]byte("true"), resp.Kvs[0].Value) {
+		return true, nil
+	}
+	return false, nil
+}
+
+// EnableRebootQueue enables reboot queue processing when flag is true.
+// When flag is false, reboot queue is not processed.
+func (s Storage) EnableRebootQueue(ctx context.Context, flag bool) error {
+	val := fmt.Sprint(!flag)
+	_, err := s.Put(ctx, KeyRebootsDisabled, val)
+	return err
 }
 
 func rebootsEntryKey(index int64) string {

--- a/storage_test.go
+++ b/storage_test.go
@@ -650,7 +650,7 @@ func testStorageReboot(t *testing.T) {
 
 	_, err = storage.GetRebootsEntry(ctx, 0)
 	if err != ErrNotFound {
-		t.Error("unexptected error:", err)
+		t.Error("unexpected error:", err)
 	}
 
 	ents, err := storage.GetRebootsEntries(ctx)
@@ -721,11 +721,43 @@ func testStorageReboot(t *testing.T) {
 	}
 	_, err = storage.GetRebootsEntry(ctx, 0)
 	if err != ErrNotFound {
-		t.Error("unexptected error:", err)
+		t.Error("unexpected error:", err)
 	}
 	err = storage.UpdateRebootsEntry(ctx, entry)
 	if err == nil {
 		t.Error("UpdateRebootsEntry succeeded for deleted entry")
+	}
+
+	disabled, err := storage.IsRebootQueueDisabled(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if disabled {
+		t.Error("reboot queue should not be disabled by default")
+	}
+
+	err = storage.EnableRebootQueue(ctx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	disabled, err = storage.IsRebootQueueDisabled(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !disabled {
+		t.Error("reboot queue could not be disabled")
+	}
+
+	err = storage.EnableRebootQueue(ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	disabled, err = storage.IsRebootQueueDisabled(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if disabled {
+		t.Error("reboot queue could not be re-enabled")
 	}
 }
 


### PR DESCRIPTION
This PR adds `ckecli rq enable` and `ckecli rq disable` commands.
They allow us to suspend/resume reboot queue processing.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>