### PR TITLE
Validate KubeSchedulerConfiguration API version

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -156,7 +156,7 @@ func (p SchedulerParams) GetConfigV1Alpha2(base *schedulerv1alpha2.KubeScheduler
 	}
 
 	if version != schedulerv1alpha2.SchemeGroupVersion.String() {
-		return nil, fmt.Errorf("unexpected kube-scheduler API version: %s", p.Config.GetAPIVersion())
+		return nil, fmt.Errorf("unexpected kube-scheduler API version: %s", version)
 	}
 
 	cfg := *base

--- a/cluster.go
+++ b/cluster.go
@@ -138,10 +138,14 @@ func (p SchedulerParams) GetAPIversion() (string, error) {
 	}
 
 	if len(p.Extenders) > 0 || len(p.Predicates) > 0 || len(p.Priorities) > 0 {
-		return "", fmt.Errorf("both Config and Extenders/Predicates/Priorities should not be configured: %#v", p)
+		return "", fmt.Errorf("both Config and extenders/predicates/priorities should not be configured: %#v", p)
 	}
 
-	return p.Config.GetAPIVersion(), nil
+	v := p.Config.GetAPIVersion()
+	if v == schedulerv1alpha1.SchemeGroupVersion.String() {
+		return "", fmt.Errorf("config for KubeSchedulerConfiguration in v1alpha1 should be made with extenders/predicates/priorities fields")
+	}
+	return v, nil
 }
 
 // MergeConfigV1Alpha2 merges the input struct with Connfig field and returns *schedulerv1alpha2.KubeSchedulerConfiguration.

--- a/cluster.go
+++ b/cluster.go
@@ -144,8 +144,8 @@ func (p SchedulerParams) GetAPIversion() (string, error) {
 	return p.Config.GetAPIVersion(), nil
 }
 
-// GetConfigV1Alpha2 returns *schedulerv1alpha2.KubeSchedulerConfiguration.
-func (p SchedulerParams) GetConfigV1Alpha2(base *schedulerv1alpha2.KubeSchedulerConfiguration) (*schedulerv1alpha2.KubeSchedulerConfiguration, error) {
+// OverwriteBaseConfigV1Alpha2 returns *schedulerv1alpha2.KubeSchedulerConfiguration.
+func (p SchedulerParams) OverwriteBaseConfigV1Alpha2(base *schedulerv1alpha2.KubeSchedulerConfiguration) (*schedulerv1alpha2.KubeSchedulerConfiguration, error) {
 	if base == nil {
 		return nil, errors.New("base should not be nil")
 	}
@@ -191,8 +191,8 @@ type KubeletParams struct {
 	Config                   *unstructured.Unstructured `json:"config,omitempty"`
 }
 
-// GetConfigV1Beta1 returns *kubeletv1beta1.KubeletConfiguration.
-func (p KubeletParams) GetConfigV1Beta1(base *kubeletv1beta1.KubeletConfiguration) (*kubeletv1beta1.KubeletConfiguration, error) {
+// OverwriteBaseConfigV1Beta1 returns *kubeletv1beta1.KubeletConfiguration.
+func (p KubeletParams) OverwriteBaseConfigV1Beta1(base *kubeletv1beta1.KubeletConfiguration) (*kubeletv1beta1.KubeletConfiguration, error) {
 	if base == nil {
 		return nil, errors.New("base should not be nil")
 	}
@@ -511,7 +511,7 @@ func validateOptions(opts Options) error {
 	}
 
 	base := &kubeletv1beta1.KubeletConfiguration{}
-	kubeletConfig, err := opts.Kubelet.GetConfigV1Beta1(base)
+	kubeletConfig, err := opts.Kubelet.OverwriteBaseConfigV1Beta1(base)
 	if err != nil {
 		return err
 	}
@@ -620,7 +620,7 @@ func validateOptions(opts Options) error {
 		}
 	case schedulerv1alpha2.SchemeGroupVersion.String():
 		base := schedulerv1alpha2.KubeSchedulerConfiguration{}
-		_, err := opts.Scheduler.GetConfigV1Alpha2(&base)
+		_, err := opts.Scheduler.OverwriteBaseConfigV1Alpha2(&base)
 		if err != nil {
 			return err
 		}

--- a/cluster.go
+++ b/cluster.go
@@ -132,16 +132,11 @@ type SchedulerParams struct {
 
 const (
 	// SchedulerAPIv1alpha1 is API version of kubescheduler, v1alpha1.
-	SchedulerAPIv1alpha1 = "v1alpha1"
+	SchedulerAPIv1alpha1 = "kubescheduler.config.k8s.io/v1alpha1"
 
 	// SchedulerAPIv1alpha2 is API version of kubescheduler, v1alpha2.
-	SchedulerAPIv1alpha2 = "v1alpha2"
+	SchedulerAPIv1alpha2 = "kubescheduler.config.k8s.io/v1alpha2"
 )
-
-// IsConfigV1Alpha1 returns whether params is v1alpha1.
-func (p SchedulerParams) IsConfigV1Alpha1() bool {
-	return p.Config == nil
-}
 
 // GetAPIversion returns API version of KubeSchedulerConfiguration.
 func (p SchedulerParams) GetAPIversion() (string, error) {
@@ -158,9 +153,14 @@ func (p SchedulerParams) GetAPIversion() (string, error) {
 
 // GetConfigV1Alpha2 returns *schedulerv1alpha2.KubeSchedulerConfiguration.
 func (p SchedulerParams) GetConfigV1Alpha2(base *schedulerv1alpha2.KubeSchedulerConfiguration) (*schedulerv1alpha2.KubeSchedulerConfiguration, error) {
+	if base == nil {
+		return nil, errors.New("base should not be nil")
+	}
 	cfg := *base
-	if p.Config == nil {
-		return nil, errors.New("api version mismatch")
+
+	version, err := p.GetAPIversion()
+	if version != SchedulerAPIv1alpha2 || err != nil {
+		return nil, errors.New("api version mismatch: " + version)
 	}
 
 	if p.Config.GetAPIVersion() != schedulerv1alpha2.SchemeGroupVersion.String() {

--- a/cluster.go
+++ b/cluster.go
@@ -144,8 +144,8 @@ func (p SchedulerParams) GetAPIversion() (string, error) {
 	return p.Config.GetAPIVersion(), nil
 }
 
-// OverwriteBaseConfigV1Alpha2 returns *schedulerv1alpha2.KubeSchedulerConfiguration.
-func (p SchedulerParams) OverwriteBaseConfigV1Alpha2(base *schedulerv1alpha2.KubeSchedulerConfiguration) (*schedulerv1alpha2.KubeSchedulerConfiguration, error) {
+// MergeConfigV1Alpha2 merges the input struct with Connfig field and returns *schedulerv1alpha2.KubeSchedulerConfiguration.
+func (p SchedulerParams) MergeConfigV1Alpha2(base *schedulerv1alpha2.KubeSchedulerConfiguration) (*schedulerv1alpha2.KubeSchedulerConfiguration, error) {
 	if base == nil {
 		return nil, errors.New("base should not be nil")
 	}
@@ -191,8 +191,8 @@ type KubeletParams struct {
 	Config                   *unstructured.Unstructured `json:"config,omitempty"`
 }
 
-// OverwriteBaseConfigV1Beta1 returns *kubeletv1beta1.KubeletConfiguration.
-func (p KubeletParams) OverwriteBaseConfigV1Beta1(base *kubeletv1beta1.KubeletConfiguration) (*kubeletv1beta1.KubeletConfiguration, error) {
+// MergeConfigV1Beta1 merges the input struct with Connfig and returns *kubeletv1beta1.KubeletConfiguration.
+func (p KubeletParams) MergeConfigV1Beta1(base *kubeletv1beta1.KubeletConfiguration) (*kubeletv1beta1.KubeletConfiguration, error) {
 	if base == nil {
 		return nil, errors.New("base should not be nil")
 	}
@@ -511,7 +511,7 @@ func validateOptions(opts Options) error {
 	}
 
 	base := &kubeletv1beta1.KubeletConfiguration{}
-	kubeletConfig, err := opts.Kubelet.OverwriteBaseConfigV1Beta1(base)
+	kubeletConfig, err := opts.Kubelet.MergeConfigV1Beta1(base)
 	if err != nil {
 		return err
 	}
@@ -620,7 +620,7 @@ func validateOptions(opts Options) error {
 		}
 	case schedulerv1alpha2.SchemeGroupVersion.String():
 		base := schedulerv1alpha2.KubeSchedulerConfiguration{}
-		_, err := opts.Scheduler.OverwriteBaseConfigV1Alpha2(&base)
+		_, err := opts.Scheduler.MergeConfigV1Alpha2(&base)
 		if err != nil {
 			return err
 		}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -114,7 +114,7 @@ rules:
 		t.Error(`c.Options.ControllerManager.ExtraEnvvar["env1"] != "val1"`)
 	}
 	kubeSchedulerHealthz := "0.0.0.0"
-	kubeSchedulerConfig, err := c.Options.Scheduler.OverwriteBaseConfigV1Alpha2(&schedulerv1alpha2.KubeSchedulerConfiguration{
+	kubeSchedulerConfig, err := c.Options.Scheduler.MergeConfigV1Alpha2(&schedulerv1alpha2.KubeSchedulerConfiguration{
 		HealthzBindAddress: &kubeSchedulerHealthz,
 	})
 	if err != nil {
@@ -198,7 +198,7 @@ rules:
 	if len(c.Options.Kubelet.CNIConfFile.Content) == 0 {
 		t.Error(`len(c.Options.Kubelet.CNIConfFile.Content) == 0`)
 	}
-	kubeletConfig, err := c.Options.Kubelet.OverwriteBaseConfigV1Beta1(&kubeletv1beta1.KubeletConfiguration{
+	kubeletConfig, err := c.Options.Kubelet.MergeConfigV1Beta1(&kubeletv1beta1.KubeletConfiguration{
 		ClusterDomain: "hoge.com",
 	})
 	if err != nil {
@@ -238,12 +238,12 @@ func testClusterYAML117(t *testing.T) {
 	if !reflect.DeepEqual(c.Options.Scheduler.Priorities, []string{"name: some_priority"}) {
 		t.Error(`!reflect.DeepEqual(c.Options.Scheduler.Priorities, []string{"name: some_priority"}`)
 	}
-	_, err = c.Options.Scheduler.OverwriteBaseConfigV1Alpha2(&schedulerv1alpha2.KubeSchedulerConfiguration{})
+	_, err = c.Options.Scheduler.MergeConfigV1Alpha2(&schedulerv1alpha2.KubeSchedulerConfiguration{})
 	if err == nil {
 		t.Error(`c.Options.Scheduler.GetConfigV1Alpha2() should fail`)
 	}
 
-	kubeletConfig, err := c.Options.Kubelet.OverwriteBaseConfigV1Beta1(&kubeletv1beta1.KubeletConfiguration{
+	kubeletConfig, err := c.Options.Kubelet.MergeConfigV1Beta1(&kubeletv1beta1.KubeletConfiguration{
 		ClusterDomain:       "hoge.com",
 		ContainerLogMaxSize: "5Mi",
 	})

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -150,9 +150,12 @@ rules:
 
 	kubeSchedulerExtenderName := "test-extender"
 	c.Options.Scheduler.Extenders = []string{kubeSchedulerExtenderName}
-	_, err = c.Options.Scheduler.GetAPIversion()
+	version, err := c.Options.Scheduler.GetAPIversion()
 	if err == nil {
 		t.Fatal(errors.New("kube-scheduler configuration must not have its Extenders/Predicates/Priorities parameters when its Config parameter is set"))
+	}
+	if version != schedulerv1alpha2.SchemeGroupVersion.String() {
+		t.Errorf(`version != "%s"`, schedulerv1alpha2.SchemeGroupVersion.String())
 	}
 
 	if c.Options.Kubelet.Domain != "my.domain" {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -114,7 +114,7 @@ rules:
 		t.Error(`c.Options.ControllerManager.ExtraEnvvar["env1"] != "val1"`)
 	}
 	kubeSchedulerHealthz := "0.0.0.0"
-	kubeSchedulerConfig, err := c.Options.Scheduler.GetConfigV1Alpha2(&schedulerv1alpha2.KubeSchedulerConfiguration{
+	kubeSchedulerConfig, err := c.Options.Scheduler.OverwriteBaseConfigV1Alpha2(&schedulerv1alpha2.KubeSchedulerConfiguration{
 		HealthzBindAddress: &kubeSchedulerHealthz,
 	})
 	if err != nil {
@@ -198,7 +198,7 @@ rules:
 	if len(c.Options.Kubelet.CNIConfFile.Content) == 0 {
 		t.Error(`len(c.Options.Kubelet.CNIConfFile.Content) == 0`)
 	}
-	kubeletConfig, err := c.Options.Kubelet.GetConfigV1Beta1(&kubeletv1beta1.KubeletConfiguration{
+	kubeletConfig, err := c.Options.Kubelet.OverwriteBaseConfigV1Beta1(&kubeletv1beta1.KubeletConfiguration{
 		ClusterDomain: "hoge.com",
 	})
 	if err != nil {
@@ -238,12 +238,12 @@ func testClusterYAML117(t *testing.T) {
 	if !reflect.DeepEqual(c.Options.Scheduler.Priorities, []string{"name: some_priority"}) {
 		t.Error(`!reflect.DeepEqual(c.Options.Scheduler.Priorities, []string{"name: some_priority"}`)
 	}
-	_, err = c.Options.Scheduler.GetConfigV1Alpha2(&schedulerv1alpha2.KubeSchedulerConfiguration{})
+	_, err = c.Options.Scheduler.OverwriteBaseConfigV1Alpha2(&schedulerv1alpha2.KubeSchedulerConfiguration{})
 	if err == nil {
 		t.Error(`c.Options.Scheduler.GetConfigV1Alpha2() should fail`)
 	}
 
-	kubeletConfig, err := c.Options.Kubelet.GetConfigV1Beta1(&kubeletv1beta1.KubeletConfiguration{
+	kubeletConfig, err := c.Options.Kubelet.OverwriteBaseConfigV1Beta1(&kubeletv1beta1.KubeletConfiguration{
 		ClusterDomain:       "hoge.com",
 		ContainerLogMaxSize: "5Mi",
 	})

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1,7 +1,6 @@
 package cke
 
 import (
-	"errors"
 	"io/ioutil"
 	"reflect"
 	"testing"
@@ -148,14 +147,20 @@ rules:
 		t.Error(`*kubeSchedulerConfig.Profiles[0].Plugins.Score.Enabled[0].Weight != int32(500)`)
 	}
 
+	version, err := c.Options.Scheduler.GetAPIversion()
+	if err != nil {
+		t.Fatalf("failed to get get API version: %v", err)
+	}
+	expected := schedulerv1alpha2.SchemeGroupVersion.String()
+	if version != expected {
+		t.Errorf("version should be %s: %s", expected, version)
+	}
+
 	kubeSchedulerExtenderName := "test-extender"
 	c.Options.Scheduler.Extenders = []string{kubeSchedulerExtenderName}
-	version, err := c.Options.Scheduler.GetAPIversion()
+	_, err = c.Options.Scheduler.GetAPIversion()
 	if err == nil {
-		t.Fatal(errors.New("kube-scheduler configuration must not have its Extenders/Predicates/Priorities parameters when its Config parameter is set"))
-	}
-	if version != schedulerv1alpha2.SchemeGroupVersion.String() {
-		t.Errorf(`version != "%s"`, schedulerv1alpha2.SchemeGroupVersion.String())
+		t.Fatal("kube-scheduler configuration must not have its Extenders/Predicates/Priorities parameters when its Config parameter is set")
 	}
 
 	if c.Options.Kubelet.Domain != "my.domain" {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1,6 +1,7 @@
 package cke
 
 import (
+	"errors"
 	"io/ioutil"
 	"reflect"
 	"testing"
@@ -146,6 +147,14 @@ rules:
 	if *kubeSchedulerConfig.Profiles[0].Plugins.Score.Enabled[0].Weight != int32(500) {
 		t.Error(`*kubeSchedulerConfig.Profiles[0].Plugins.Score.Enabled[0].Weight != int32(500)`)
 	}
+
+	kubeSchedulerExtenderName := "test-extender"
+	c.Options.Scheduler.Extenders = []string{kubeSchedulerExtenderName}
+	_, err = c.Options.Scheduler.GetAPIversion()
+	if err == nil {
+		t.Fatal(errors.New("kube-scheduler configuration must not have its Extenders/Predicates/Priorities parameters when its Config parameter is set"))
+	}
+
 	if c.Options.Kubelet.Domain != "my.domain" {
 		t.Error(`c.Options.Kubelet.Domain != "my.domain"`)
 	}

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -218,7 +218,9 @@ Elements of `extenders`, `predicates` and `priorities` are contents of
 [`PriorityPolicy`](https://github.com/kubernetes/kube-scheduler/blob/release-1.18/config/v1/types.go#L60)
 in JSON format, respectively.
 
-If `config` is specified, the following fields are ignored: `extenders`, `predicates`, `priorities`.
+`config` should be used only for `v1alpha2.KubeSchedulerConfiguration`.
+If you want to configure `v1alpha1.KubeSchedulerConfiguration`, please use the `extenders`, `predicates`, and `priorities` fields.
+CKE does not allow users to configure both `config` and more than one of `extenders`, `predicates`, and `priorities`, so please configure either of them.
 
 Some fields in `config` have CKE-defined default values.
 Some other fields are forced to have certain values.

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,6 @@ require (
 	github.com/vektah/gqlparser v1.1.2
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
 	golang.org/x/text v0.3.3 // indirect
-	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.18.8
 	k8s.io/apimachinery v0.18.8
 	k8s.io/apiserver v0.18.8

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/vektah/gqlparser v1.1.2
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
 	golang.org/x/text v0.3.3 // indirect
+	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.18.8
 	k8s.io/apimachinery v0.18.8
 	k8s.io/apiserver v0.18.8

--- a/mtest/operators_test.go
+++ b/mtest/operators_test.go
@@ -560,14 +560,17 @@ func testOperators(isDegraded bool) {
 		// - KubeClusterDNSUpdateOp
 		cluster.Options.Etcd.ExtraEnvvar = map[string]string{"AAA": "aaa"}
 		cluster.Options.ControllerManager.ExtraEnvvar = map[string]string{"AAA": "aaa"}
-		cluster.Options.Scheduler.ExtraEnvvar = map[string]string{"AAA": "aaa"}
-		cluster.Options.Scheduler.Extenders = []string{"urlPrefix: http://127.0.0.1:8000"}
-		cluster.Options.Scheduler.Predicates = []string{"name: some_predicate"}
-		cluster.Options.Scheduler.Priorities = []string{"name: some_priority"}
 		cluster.Options.Proxy.ExtraEnvvar = map[string]string{"AAA": "aaa"}
 		cluster.Options.Kubelet.ExtraEnvvar = map[string]string{"AAA": "aaa"}
 		cluster.Options.Kubelet.Domain = "neconeco"
 		clusterSetAndWait(cluster)
+
+		cluster.Options.Scheduler.ExtraEnvvar = map[string]string{"AAA": "aaa"}
+		cluster.Options.Scheduler.Extenders = []string{"urlPrefix: http://127.0.0.1:8000"}
+		cluster.Options.Scheduler.Predicates = []string{"name: some_predicate"}
+		cluster.Options.Scheduler.Priorities = []string{"name: some_priority"}
+		_, err = ckecliClusterSet(cluster)
+		Expect(err).Should(HaveOccurred())
 	})
 
 	It("updates Node resources", func() {

--- a/mtest/operators_test.go
+++ b/mtest/operators_test.go
@@ -550,7 +550,7 @@ func testOperators(isDegraded bool) {
 			runCKE(ckeImageURL)
 		}
 
-		By("Changing options")
+		By("Changing options to have scheduler field contain both Config and Extenders/Predicates/Priorities")
 		// this will run these ops:
 		// - EtcdRestartOp
 		// - ControllerManagerRestartOp

--- a/mtest/run_test.go
+++ b/mtest/run_test.go
@@ -390,8 +390,11 @@ func ckecliClusterSet(cluster *cke.Cluster) (time.Time, error) {
 	data := string(y) + "\npod_subnet: 10.1.0.0/16"
 
 	rf := remoteTempFile(data)
-	_, _, err = ckecli("cluster", "set", rf)
-	return time.Now(), err
+	stdout, stderr, err := ckecli("cluster", "set", rf)
+	if err != nil {
+		return time.Now(), fmt.Errorf("failed to execute cluster set command. stdout: %v, stderr: %v, err: %v", string(stdout), string(stderr), err)
+	}
+	return time.Now(), nil
 }
 
 func setupCKE(img string) {

--- a/op/k8s/config.go
+++ b/op/k8s/config.go
@@ -96,13 +96,13 @@ func GenerateSchedulerPolicyV1(params cke.SchedulerParams) (*schedulerv1.Policy,
 }
 
 // GenerateSchedulerConfigurationV1Alpha2 generates scheduler configuration for v1alpha2.
-func GenerateSchedulerConfigurationV1Alpha2(params cke.SchedulerParams) schedulerv1alpha2.KubeSchedulerConfiguration {
+func GenerateSchedulerConfigurationV1Alpha2(params cke.SchedulerParams) (*schedulerv1alpha2.KubeSchedulerConfiguration, error) {
 	// default values
 	base := schedulerv1alpha2.KubeSchedulerConfiguration{}
 
 	c, err := params.GetConfigV1Alpha2(&base)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	// forced values
@@ -115,7 +115,7 @@ func GenerateSchedulerConfigurationV1Alpha2(params cke.SchedulerParams) schedule
 		},
 	}
 
-	return *c
+	return c, nil
 }
 
 func proxyKubeconfig(cluster string, ca, clientCrt, clientKey string) *api.Config {

--- a/op/k8s/config.go
+++ b/op/k8s/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cybozu-go/cke"
 	"github.com/cybozu-go/cke/op"
+	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -13,6 +14,7 @@ import (
 	apiserverv1 "k8s.io/apiserver/pkg/apis/config/v1"
 	"k8s.io/client-go/tools/clientcmd/api"
 	componentv1alpha1 "k8s.io/component-base/config/v1alpha1"
+	schedulerv1 "k8s.io/kube-scheduler/config/v1"
 	schedulerv1alpha2 "k8s.io/kube-scheduler/config/v1alpha2"
 	kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
 )
@@ -53,8 +55,48 @@ func schedulerKubeconfig(cluster string, ca, clientCrt, clientKey string) *api.C
 	return cke.Kubeconfig(cluster, "system:kube-scheduler", ca, clientCrt, clientKey)
 }
 
-// GenerateSchedulerConfiguration generates scheduler configuration.
-func GenerateSchedulerConfiguration(params cke.SchedulerParams) schedulerv1alpha2.KubeSchedulerConfiguration {
+// GenerateSchedulerPolicyV1 generates scheduler policy.
+func GenerateSchedulerPolicyV1(params cke.SchedulerParams) (*schedulerv1.Policy, error) {
+	var extenders []schedulerv1.Extender
+	for _, extStr := range params.Extenders {
+		conf := new(schedulerv1.Extender)
+		err := yaml.Unmarshal([]byte(extStr), conf)
+		if err != nil {
+			return nil, err
+		}
+		extenders = append(extenders, *conf)
+	}
+
+	var predicates []schedulerv1.PredicatePolicy
+	for _, extStr := range params.Predicates {
+		conf := new(schedulerv1.PredicatePolicy)
+		err := yaml.Unmarshal([]byte(extStr), conf)
+		if err != nil {
+			return nil, err
+		}
+		predicates = append(predicates, *conf)
+	}
+
+	var priorities []schedulerv1.PriorityPolicy
+	for _, extStr := range params.Priorities {
+		conf := new(schedulerv1.PriorityPolicy)
+		err := yaml.Unmarshal([]byte(extStr), conf)
+		if err != nil {
+			return nil, err
+		}
+		priorities = append(priorities, *conf)
+	}
+
+	return &schedulerv1.Policy{
+		TypeMeta:   metav1.TypeMeta{Kind: "Policy", APIVersion: "v1"},
+		Extenders:  extenders,
+		Predicates: predicates,
+		Priorities: priorities,
+	}, nil
+}
+
+// GenerateSchedulerConfigurationV1Alpha2 generates scheduler configuration for v1alpha2.
+func GenerateSchedulerConfigurationV1Alpha2(params cke.SchedulerParams) schedulerv1alpha2.KubeSchedulerConfiguration {
 	// default values
 	base := schedulerv1alpha2.KubeSchedulerConfiguration{}
 

--- a/op/k8s/config.go
+++ b/op/k8s/config.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/cybozu-go/cke"
 	"github.com/cybozu-go/cke/op"
-	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -17,6 +16,7 @@ import (
 	schedulerv1 "k8s.io/kube-scheduler/config/v1"
 	schedulerv1alpha2 "k8s.io/kube-scheduler/config/v1alpha2"
 	kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
+	"sigs.k8s.io/yaml"
 )
 
 var (

--- a/op/k8s/config.go
+++ b/op/k8s/config.go
@@ -100,7 +100,7 @@ func GenerateSchedulerConfigurationV1Alpha2(params cke.SchedulerParams) (*schedu
 	// default values
 	base := schedulerv1alpha2.KubeSchedulerConfiguration{}
 
-	c, err := params.OverwriteBaseConfigV1Alpha2(&base)
+	c, err := params.MergeConfigV1Alpha2(&base)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,7 @@ func newKubeletConfiguration(cert, key, ca string, params cke.KubeletParams) kub
 	}
 
 	// This won't raise an error because of prior validation
-	c, err := params.OverwriteBaseConfigV1Beta1(base)
+	c, err := params.MergeConfigV1Beta1(base)
 	if err != nil {
 		panic(err)
 	}

--- a/op/k8s/config.go
+++ b/op/k8s/config.go
@@ -100,7 +100,7 @@ func GenerateSchedulerConfigurationV1Alpha2(params cke.SchedulerParams) (*schedu
 	// default values
 	base := schedulerv1alpha2.KubeSchedulerConfiguration{}
 
-	c, err := params.GetConfigV1Alpha2(&base)
+	c, err := params.OverwriteBaseConfigV1Alpha2(&base)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,7 @@ func newKubeletConfiguration(cert, key, ca string, params cke.KubeletParams) kub
 	}
 
 	// This won't raise an error because of prior validation
-	c, err := params.GetConfigV1Beta1(base)
+	c, err := params.OverwriteBaseConfigV1Beta1(base)
 	if err != nil {
 		panic(err)
 	}

--- a/op/k8s/config_test.go
+++ b/op/k8s/config_test.go
@@ -49,8 +49,10 @@ func TestGenerateSchedulerConfiguration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	if !reflect.DeepEqual(conf, expected) {
+	if conf == nil {
+		t.Fatal("conf should not be nil")
+	}
+	if !reflect.DeepEqual(*conf, expected) {
 		t.Errorf("GenerateSchedulerConfiguration() generated unexpected result:\n%s", cmp.Diff(conf, expected))
 	}
 }

--- a/op/k8s/config_test.go
+++ b/op/k8s/config_test.go
@@ -45,7 +45,11 @@ func TestGenerateSchedulerConfiguration(t *testing.T) {
 		PodMaxBackoffSeconds: &podMaxBackoffSeconds,
 	}
 
-	conf := GenerateSchedulerConfigurationV1Alpha2(input)
+	conf, err := GenerateSchedulerConfigurationV1Alpha2(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if !reflect.DeepEqual(conf, expected) {
 		t.Errorf("GenerateSchedulerConfiguration() generated unexpected result:\n%s", cmp.Diff(conf, expected))
 	}

--- a/op/k8s/config_test.go
+++ b/op/k8s/config_test.go
@@ -45,7 +45,7 @@ func TestGenerateSchedulerConfiguration(t *testing.T) {
 		PodMaxBackoffSeconds: &podMaxBackoffSeconds,
 	}
 
-	conf := GenerateSchedulerConfiguration(input)
+	conf := GenerateSchedulerConfigurationV1Alpha2(input)
 	if !reflect.DeepEqual(conf, expected) {
 		t.Errorf("GenerateSchedulerConfiguration() generated unexpected result:\n%s", cmp.Diff(conf, expected))
 	}

--- a/op/k8s/scheduler_boot.go
+++ b/op/k8s/scheduler_boot.go
@@ -131,7 +131,11 @@ leaderElection:
 
 	case schedulerv1alpha2.SchemeGroupVersion.String():
 		return c.files.AddFile(ctx, op.SchedulerConfigPath, func(ctx context.Context, n *cke.Node) ([]byte, error) {
-			cfg := GenerateSchedulerConfigurationV1Alpha2(c.params)
+			cfg, err := GenerateSchedulerConfigurationV1Alpha2(c.params)
+			if err != nil {
+				return nil, err
+			}
+
 			return yaml.Marshal(cfg)
 		})
 	default:

--- a/op/k8s/scheduler_boot.go
+++ b/op/k8s/scheduler_boot.go
@@ -11,6 +11,9 @@ import (
 	"github.com/cybozu-go/cke/op/common"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/yaml"
+
+	schedulerv1alpha1 "k8s.io/kube-scheduler/config/v1alpha1"
+	schedulerv1alpha2 "k8s.io/kube-scheduler/config/v1alpha2"
 )
 
 type schedulerBootOp struct {
@@ -97,7 +100,7 @@ func (c prepareSchedulerFilesCommand) Run(ctx context.Context, inf cke.Infrastru
 		return err
 	}
 	switch version {
-	case cke.SchedulerAPIv1alpha1:
+	case schedulerv1alpha1.SchemeGroupVersion.String():
 		// Create v1 Policy for scheduler extender
 		err := c.files.AddFile(ctx, op.PolicyConfigPath, func(ctx context.Context, n *cke.Node) ([]byte, error) {
 			policy, err := GenerateSchedulerPolicyV1(c.params)
@@ -126,7 +129,7 @@ leaderElection:
 `, op.SchedulerKubeConfigPath, op.PolicyConfigPath)), nil
 		})
 
-	case cke.SchedulerAPIv1alpha2:
+	case schedulerv1alpha2.SchemeGroupVersion.String():
 		return c.files.AddFile(ctx, op.SchedulerConfigPath, func(ctx context.Context, n *cke.Node) ([]byte, error) {
 			cfg := GenerateSchedulerConfigurationV1Alpha2(c.params)
 			return yaml.Marshal(cfg)

--- a/server/node_filter.go
+++ b/server/node_filter.go
@@ -440,8 +440,6 @@ func (nf *NodeFilter) schedulerOutdatedNodesV1Alpha1(params cke.SchedulerParams)
 		return nil
 	}
 
-	currentConfig := k8s.GenerateSchedulerConfigurationV1Alpha2(params)
-
 	for _, n := range nf.cp {
 		st := nf.nodeStatus(n).Scheduler
 		var runningConfig schedulerv1alpha2.KubeSchedulerConfiguration
@@ -482,7 +480,6 @@ func (nf *NodeFilter) schedulerOutdatedNodesV1Alpha1(params cke.SchedulerParams)
 				"current_extenders_configs":  policy.Extenders,
 				"current_predicates_configs": policy.Predicates,
 				"current_priorities_configs": policy.Priorities,
-				"current_config":             currentConfig,
 				"running_config":             runningConfig,
 			})
 			nodes = append(nodes, n)

--- a/server/node_filter.go
+++ b/server/node_filter.go
@@ -384,7 +384,14 @@ func (nf *NodeFilter) SchedulerOutdatedNodes(params cke.SchedulerParams) []*cke.
 func (nf *NodeFilter) schedulerOutdatedNodesV1Alpha2(params cke.SchedulerParams) (nodes []*cke.Node) {
 	currentBuiltIn := k8s.SchedulerParams()
 	currentExtra := nf.cluster.Options.Scheduler
-	currentConfig := k8s.GenerateSchedulerConfigurationV1Alpha2(params)
+	currentConfig, err := k8s.GenerateSchedulerConfigurationV1Alpha2(params)
+	if err != nil {
+		log.Error("failed to generate scheduler config for v1alpha2", map[string]interface{}{
+			log.FnError: err,
+			"params":    params,
+		})
+		return nil
+	}
 
 	for _, n := range nf.cp {
 		st := nf.nodeStatus(n).Scheduler

--- a/server/node_filter.go
+++ b/server/node_filter.go
@@ -15,7 +15,6 @@ import (
 	schedulerv1 "k8s.io/kube-scheduler/config/v1"
 	schedulerv1alpha2 "k8s.io/kube-scheduler/config/v1alpha2"
 	kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
-	"sigs.k8s.io/yaml"
 )
 
 // NodeFilter filters nodes to
@@ -359,59 +358,32 @@ func (nf *NodeFilter) SchedulerStoppedNodes() (nodes []*cke.Node) {
 }
 
 // SchedulerOutdatedNodes returns nodes that are running kube-scheduler with outdated image or params.
-func (nf *NodeFilter) SchedulerOutdatedNodes(params cke.SchedulerParams) (nodes []*cke.Node) {
+func (nf *NodeFilter) SchedulerOutdatedNodes(params cke.SchedulerParams) []*cke.Node {
+	version, err := params.GetAPIversion()
+	// TODO
+	if err != nil {
+		return nf.schedulerOutdatedNodesV1Alpha2(params)
+	}
+	switch version {
+	case cke.SchedulerAPIv1alpha1:
+		return nf.schedulerOutdatedNodesV1Alpha1(params)
+	case cke.SchedulerAPIv1alpha2:
+		return nf.schedulerOutdatedNodesV1Alpha2(params)
+	// TODO
+	default:
+		return nf.schedulerOutdatedNodesV1Alpha2(params)
+	}
+}
+
+func (nf *NodeFilter) schedulerOutdatedNodesV1Alpha2(params cke.SchedulerParams) (nodes []*cke.Node) {
 	currentBuiltIn := k8s.SchedulerParams()
 	currentExtra := nf.cluster.Options.Scheduler
 
-	var extenders []schedulerv1.Extender
-	for _, ext := range params.Extenders {
-		conf := new(schedulerv1.Extender)
-		err := yaml.Unmarshal([]byte(ext), conf)
-		if err != nil {
-			log.Warn("failed to unmarshal extender config", map[string]interface{}{
-				log.FnError: err,
-				"config":    ext,
-			})
-			panic(err)
-		}
-		extenders = append(extenders, *conf)
-	}
-
-	var predicates []schedulerv1.PredicatePolicy
-	for _, ext := range params.Predicates {
-		conf := new(schedulerv1.PredicatePolicy)
-		err := yaml.Unmarshal([]byte(ext), conf)
-		if err != nil {
-			log.Warn("failed to unmarshal predicates config", map[string]interface{}{
-				log.FnError: err,
-				"config":    ext,
-			})
-			panic(err)
-		}
-		predicates = append(predicates, *conf)
-	}
-
-	var priorities []schedulerv1.PriorityPolicy
-	for _, ext := range params.Priorities {
-		conf := new(schedulerv1.PriorityPolicy)
-		err := yaml.Unmarshal([]byte(ext), conf)
-		if err != nil {
-			log.Warn("failed to unmarshal priorities config", map[string]interface{}{
-				log.FnError: err,
-				"config":    ext,
-			})
-			panic(err)
-		}
-		priorities = append(priorities, *conf)
-	}
-
 	for _, n := range nf.cp {
 		st := nf.nodeStatus(n).Scheduler
-		var currentConfig schedulerv1alpha2.KubeSchedulerConfiguration
+		currentConfig := k8s.GenerateSchedulerConfigurationV1Alpha2(params)
+
 		var runningConfig schedulerv1alpha2.KubeSchedulerConfiguration
-		if !params.IsConfigV1Alpha1() {
-			currentConfig = k8s.GenerateSchedulerConfiguration(params)
-		}
 		if st.Config != nil {
 			runningConfig = *st.Config
 		}
@@ -424,13 +396,7 @@ func (nf *NodeFilter) SchedulerOutdatedNodes(params cke.SchedulerParams) (nodes 
 			fallthrough
 		case !currentExtra.ServiceParams.Equal(st.ExtraParams):
 			fallthrough
-		case params.IsConfigV1Alpha1() && !equalExtenders(extenders, st.Extenders):
-			fallthrough
-		case params.IsConfigV1Alpha1() && !equalPredicates(predicates, st.Predicates):
-			fallthrough
-		case params.IsConfigV1Alpha1() && !equalPriorities(priorities, st.Priorities):
-			fallthrough
-		case !params.IsConfigV1Alpha1() && !reflect.DeepEqual(currentConfig, *st.Config):
+		case !reflect.DeepEqual(currentConfig, runningConfig):
 			log.Debug("node has been appended", map[string]interface{}{
 				"node":                       n.Nodename(),
 				"st_builtin_args":            st.BuiltInParams.ExtraArguments,
@@ -447,11 +413,66 @@ func (nf *NodeFilter) SchedulerOutdatedNodes(params cke.SchedulerParams) (nodes 
 				"current_extra_extenders":    currentExtra.Extenders,
 				"current_extra_predicates":   currentExtra.Predicates,
 				"current_extra_priorities":   currentExtra.Priorities,
-				"current_extenders_configs":  extenders,
-				"current_predicates_configs": predicates,
-				"current_priorities_configs": priorities,
+				"current_extenders_configs":  params.Extenders,
+				"current_predicates_configs": params.Predicates,
+				"current_priorities_configs": params.Priorities,
 				"config":                     currentConfig,
 				"diff":                       cmp.Diff(currentConfig, runningConfig),
+			})
+			nodes = append(nodes, n)
+		}
+	}
+	return nodes
+}
+
+func (nf *NodeFilter) schedulerOutdatedNodesV1Alpha1(params cke.SchedulerParams) (nodes []*cke.Node) {
+	currentBuiltIn := k8s.SchedulerParams()
+	currentExtra := nf.cluster.Options.Scheduler
+
+	policy, err := k8s.GenerateSchedulerPolicyV1(params)
+	if err != nil {
+		log.Warn("failed to unmarshal predicates config", map[string]interface{}{
+			log.FnError: err,
+			"params":    params,
+		})
+		panic(err)
+	}
+
+	for _, n := range nf.cp {
+		st := nf.nodeStatus(n).Scheduler
+		switch {
+		case !st.Running:
+			// stopped nodes are excluded
+		case cke.KubernetesImage.Name() != st.Image:
+			fallthrough
+		case !currentBuiltIn.Equal(st.BuiltInParams):
+			fallthrough
+		case !currentExtra.ServiceParams.Equal(st.ExtraParams):
+			fallthrough
+		case !equalExtenders(policy.Extenders, st.Extenders):
+			fallthrough
+		case !equalPredicates(policy.Predicates, st.Predicates):
+			fallthrough
+		case !equalPriorities(policy.Priorities, st.Priorities):
+			log.Debug("node has been appended", map[string]interface{}{
+				"node":                       n.Nodename(),
+				"st_builtin_args":            st.BuiltInParams.ExtraArguments,
+				"st_builtin_env":             st.BuiltInParams.ExtraEnvvar,
+				"st_extra_args":              st.ExtraParams.ExtraArguments,
+				"st_extra_env":               st.ExtraParams.ExtraEnvvar,
+				"st_extra_extenders":         st.Extenders,
+				"st_extra_predicates":        st.Predicates,
+				"st_extra_priorities":        st.Priorities,
+				"current_builtin_args":       currentBuiltIn.ExtraArguments,
+				"current_builtin_env":        currentBuiltIn.ExtraEnvvar,
+				"current_extra_args":         currentExtra.ExtraArguments,
+				"current_extra_env":          currentExtra.ExtraEnvvar,
+				"current_extra_extenders":    currentExtra.Extenders,
+				"current_extra_predicates":   currentExtra.Predicates,
+				"current_extra_priorities":   currentExtra.Priorities,
+				"current_extenders_configs":  policy.Extenders,
+				"current_predicates_configs": policy.Predicates,
+				"current_priorities_configs": policy.Priorities,
 			})
 			nodes = append(nodes, n)
 		}

--- a/server/node_filter.go
+++ b/server/node_filter.go
@@ -360,19 +360,13 @@ func (nf *NodeFilter) SchedulerStoppedNodes() (nodes []*cke.Node) {
 // SchedulerOutdatedNodes returns nodes that are running kube-scheduler with outdated image or params.
 func (nf *NodeFilter) SchedulerOutdatedNodes(params cke.SchedulerParams) []*cke.Node {
 	version, err := params.GetAPIversion()
-	// TODO
-	if err != nil {
-		return nf.schedulerOutdatedNodesV1Alpha2(params)
-	}
-	switch version {
-	case cke.SchedulerAPIv1alpha1:
+	switch {
+	case version == cke.SchedulerAPIv1alpha1:
 		return nf.schedulerOutdatedNodesV1Alpha1(params)
-	case cke.SchedulerAPIv1alpha2:
-		return nf.schedulerOutdatedNodesV1Alpha2(params)
-	// TODO
-	default:
+	case version == cke.SchedulerAPIv1alpha2 || err != nil:
 		return nf.schedulerOutdatedNodesV1Alpha2(params)
 	}
+	return nil
 }
 
 func (nf *NodeFilter) schedulerOutdatedNodesV1Alpha2(params cke.SchedulerParams) (nodes []*cke.Node) {

--- a/server/node_filter.go
+++ b/server/node_filter.go
@@ -384,7 +384,7 @@ func (nf *NodeFilter) SchedulerOutdatedNodes(params cke.SchedulerParams) []*cke.
 func (nf *NodeFilter) schedulerOutdatedNodesV1Alpha2(params cke.SchedulerParams) (nodes []*cke.Node) {
 	currentBuiltIn := k8s.SchedulerParams()
 	currentExtra := nf.cluster.Options.Scheduler
-	currentConfig, err := k8s.GenerateSchedulerConfigurationV1Alpha2(params)
+	ptr, err := k8s.GenerateSchedulerConfigurationV1Alpha2(params)
 	if err != nil {
 		log.Error("failed to generate scheduler config for v1alpha2", map[string]interface{}{
 			log.FnError: err,
@@ -392,6 +392,11 @@ func (nf *NodeFilter) schedulerOutdatedNodesV1Alpha2(params cke.SchedulerParams)
 		})
 		return nil
 	}
+	if ptr == nil {
+		log.Error("currentConfig should not be nil", map[string]interface{}{})
+		return nil
+	}
+	currentConfig := *ptr
 
 	for _, n := range nf.cp {
 		st := nf.nodeStatus(n).Scheduler

--- a/server/node_filter.go
+++ b/server/node_filter.go
@@ -393,7 +393,7 @@ func (nf *NodeFilter) schedulerOutdatedNodesV1Alpha2(params cke.SchedulerParams)
 		return nil
 	}
 	if ptr == nil {
-		log.Error("currentConfig should not be nil", map[string]interface{}{})
+		log.Error("ptr should not be nil", map[string]interface{}{})
 		return nil
 	}
 	currentConfig := *ptr

--- a/server/strategy.go
+++ b/server/strategy.go
@@ -296,7 +296,7 @@ func decideClusterDNSOps(apiServer *cke.Node, c *cke.Cluster, ks cke.KubernetesC
 		}
 	}
 	base := &v1beta1.KubeletConfiguration{}
-	kubeletConfig, err := c.Options.Kubelet.GetConfigV1Beta1(base)
+	kubeletConfig, err := c.Options.Kubelet.OverwriteBaseConfigV1Beta1(base)
 	if err != nil {
 		panic(err)
 	}
@@ -330,7 +330,7 @@ func decideNodeDNSOps(apiServer *cke.Node, c *cke.Cluster, ks cke.KubernetesClus
 	}
 
 	base := &v1beta1.KubeletConfiguration{}
-	kubeletConfig, err := c.Options.Kubelet.GetConfigV1Beta1(base)
+	kubeletConfig, err := c.Options.Kubelet.OverwriteBaseConfigV1Beta1(base)
 	if err != nil {
 		panic(err)
 	}

--- a/server/strategy.go
+++ b/server/strategy.go
@@ -296,7 +296,7 @@ func decideClusterDNSOps(apiServer *cke.Node, c *cke.Cluster, ks cke.KubernetesC
 		}
 	}
 	base := &v1beta1.KubeletConfiguration{}
-	kubeletConfig, err := c.Options.Kubelet.OverwriteBaseConfigV1Beta1(base)
+	kubeletConfig, err := c.Options.Kubelet.MergeConfigV1Beta1(base)
 	if err != nil {
 		panic(err)
 	}
@@ -330,7 +330,7 @@ func decideNodeDNSOps(apiServer *cke.Node, c *cke.Cluster, ks cke.KubernetesClus
 	}
 
 	base := &v1beta1.KubeletConfiguration{}
-	kubeletConfig, err := c.Options.Kubelet.OverwriteBaseConfigV1Beta1(base)
+	kubeletConfig, err := c.Options.Kubelet.MergeConfigV1Beta1(base)
 	if err != nil {
 		panic(err)
 	}

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -865,6 +865,18 @@ func TestDecideOps(t *testing.T) {
 			},
 		},
 		{
+			Name: "RestartScheduler8",
+			Input: newData().withAllServices().with(func(d testData) {
+				d.Cluster.Options.Scheduler.Extenders = []string{"some-extender"}
+			}).withSSHNotConnectedNodes(),
+			ExpectedOps: []string{
+				"wait-kubernetes",
+			},
+			ExpectedTargetNums: map[string]int{
+				"wait-kubernetes": 1,
+			},
+		},
+		{
 			Name:  "RestartKubelet",
 			Input: newData().withAllServices().withKubelet("foo.local", "10.0.0.53", false).withSSHNotConnectedNodes(),
 			ExpectedOps: []string{

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	componentv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	schedulerv1 "k8s.io/kube-scheduler/config/v1"
+	schedulerv1alpha1 "k8s.io/kube-scheduler/config/v1alpha1"
 	schedulerv1alpha2 "k8s.io/kube-scheduler/config/v1alpha2"
 	kubeletv1beta1 "k8s.io/kubelet/config/v1beta1"
 )
@@ -271,7 +272,7 @@ func (d testData) withControllerManager(name, serviceSubnet string) testData {
 	return d
 }
 
-func (d testData) withScheduler() testData {
+func (d testData) withSchedulerV1Alpha2() testData {
 	for _, n := range d.ControlPlane() {
 		st := &d.NodeStatus(n).Scheduler
 		st.Running = true
@@ -364,7 +365,7 @@ func (d testData) withAllServices() testData {
 	d.withHealthyEtcd()
 	d.withAPIServer(testServiceSubnet)
 	d.withControllerManager(testClusterName, testServiceSubnet)
-	d.withScheduler()
+	d.withSchedulerV1Alpha2()
 	d.withKubelet(testDefaultDNSDomain, testDefaultDNSAddr, false)
 	d.withProxy()
 	return d
@@ -864,11 +865,77 @@ func TestDecideOps(t *testing.T) {
 				"kube-scheduler-restart": 1,
 			},
 		},
+		// This test should be deleted after Extenders/Priorities/Prioritizes fields are purged.
 		{
 			Name: "RestartScheduler8",
 			Input: newData().withAllServices().with(func(d testData) {
-				d.Cluster.Options.Scheduler.Extenders = []string{"some-extender"}
-			}).withSSHNotConnectedNodes(),
+				d.Cluster.Options.Scheduler.Extenders = []string{`{ "foo": "some-extender" }`}
+			}),
+			ExpectedOps: []string{
+				"wait-kubernetes",
+			},
+			ExpectedTargetNums: map[string]int{
+				"wait-kubernetes": 1,
+			},
+		},
+		// This test should be deleted after Extenders/Priorities/Prioritizes fields are purged.
+		{
+			Name: "RestartScheduler9",
+			Input: newData().withAllServices().with(func(d testData) {
+				d.Cluster.Options.Scheduler.Config = nil
+				d.Cluster.Options.Scheduler.Extenders = []string{`{ "foo": "some-extender" }`}
+			}),
+			ExpectedOps: []string{
+				"kube-scheduler-restart",
+			},
+			ExpectedTargetNums: map[string]int{
+				"kube-scheduler-restart": 3,
+			},
+		},
+		// This test should be deleted after Extenders/Priorities/Prioritizes fields are purged.
+		{
+			Name: "RestartScheduler10",
+			Input: newData().withAllServices().withSchedulerV1Alpha1().with(func(d testData) {
+				schedulerConfig := &unstructured.Unstructured{}
+				schedulerConfig.SetGroupVersionKind(schedulerv1alpha2.SchemeGroupVersion.WithKind("KubeSchedulerConfiguration"))
+				schedulerConfig.Object["healthzBindAddress"] = "0.0.0.0"
+				d.Cluster.Options.Scheduler.Config = schedulerConfig
+				d.Cluster.Options.Scheduler.Extenders = nil
+				d.Cluster.Options.Scheduler.Priorities = nil
+				d.Cluster.Options.Scheduler.Predicates = nil
+			}),
+			ExpectedOps: []string{
+				"kube-scheduler-restart",
+			},
+			ExpectedTargetNums: map[string]int{
+				"kube-scheduler-restart": 3,
+			},
+		},
+		// This test should be deleted after cke accepts except for v1alpha2 on Config field
+		{
+			Name: "RestartScheduler11",
+			Input: newData().withAllServices().with(func(d testData) {
+				schedulerConfig := &unstructured.Unstructured{}
+				schedulerConfig.SetGroupVersionKind(schedulerv1.SchemeGroupVersion.WithKind("KubeSchedulerConfiguration"))
+				schedulerConfig.Object["healthzBindAddress"] = "1.2.3.4"
+				d.Cluster.Options.Scheduler.Config = schedulerConfig
+			}),
+			ExpectedOps: []string{
+				"wait-kubernetes",
+			},
+			ExpectedTargetNums: map[string]int{
+				"wait-kubernetes": 1,
+			},
+		},
+		// This test should be deleted after cke accepts except for v1alpha2 on Config field
+		{
+			Name: "RestartScheduler12",
+			Input: newData().withAllServices().with(func(d testData) {
+				schedulerConfig := &unstructured.Unstructured{}
+				schedulerConfig.SetGroupVersionKind(schedulerv1alpha1.SchemeGroupVersion.WithKind("KubeSchedulerConfiguration"))
+				schedulerConfig.Object["healthzBindAddress"] = "1.2.3.4"
+				d.Cluster.Options.Scheduler.Config = schedulerConfig
+			}),
 			ExpectedOps: []string{
 				"wait-kubernetes",
 			},


### PR DESCRIPTION
Currently, if both `config` and one of `extenders`/`predicates`/`priorities` are configured in `KubeSchedulerConfiguration` , cke ignores the `extenders`/`predicates`/`priorities` fields.
This is so confusing that this PR validates both the fields are not configured,

Signed-off-by: H.Muraoka <hiroshi-muraoka@cybozu.co.jp>