### PR TITLE
ckecli: prevent rebooting multiple control plane nodes.

### DIFF
--- a/docs/ckecli.md
+++ b/docs/ckecli.md
@@ -288,6 +288,8 @@ Append the nodes written in `FILE` to the reboot queue.
 The nodes should be specified with their IP addresses.
 If `FILE` is `-`, the contents are read from stdin.
 
+For safety, multiple control plane nodes cannot be enqueued in one entry.
+
 ### `ckecli reboot-queue list`
 
 List the entries in the reboot queue.

--- a/mtest/operators_test.go
+++ b/mtest/operators_test.go
@@ -80,11 +80,11 @@ func testRebootOperations(cluster *cke.Cluster) {
 	rebootTargets := node1
 	_, _, err := ckecliWithInput([]byte(rebootTargets), "reboot-queue", "add", "-")
 	Expect(err).ShouldNot(HaveOccurred())
-	rebootTargets = node2 + "\n" + node3
+	rebootTargets = node2 + "\n" + node4
 	_, _, err = ckecliWithInput([]byte(rebootTargets), "reboot-queue", "add", "-")
 	Expect(err).ShouldNot(HaveOccurred())
 	waitRebootCompletion(cluster)
-	checkCordon(node1, node2, node3)
+	checkCordon(node1, node2, node4)
 
 	By("Reboot operation gives up waiting node startup if deadline is exceeded")
 	previousCommand := cluster.Reboot.Command

--- a/pkg/ckecli/cmd/reboot_queue_add_test.go
+++ b/pkg/ckecli/cmd/reboot_queue_add_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/cybozu-go/cke"
+)
+
+func TestValidateNodes(t *testing.T) {
+	cluster := &cke.Cluster{
+		Nodes: []*cke.Node{
+			{
+				Address:      "1.1.1.1",
+				ControlPlane: true,
+			},
+			{
+				Address:      "2.2.2.2",
+				ControlPlane: true,
+			},
+		},
+	}
+
+	testCases := []struct {
+		name    string
+		nodes   []string
+		succeed bool
+	}{
+		{
+			name:    "succeed",
+			nodes:   []string{"1.1.1.1"},
+			succeed: true,
+		},
+		{
+			name:    "non-existing node",
+			nodes:   []string{"3.3.3.3"},
+			succeed: false,
+		},
+		{
+			name:    "multiple control-plane nodes",
+			nodes:   []string{"1.1.1.1", "2.2.2.2"},
+			succeed: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ret := validateNodes(tc.nodes, cluster)
+			if tc.succeed {
+				if ret != nil {
+					t.Errorf("validateNodes() failed unexpectedly: %v", ret)
+				}
+			} else {
+				if ret == nil {
+					t.Error("validateNodes() succeeded unexpectedly")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>