### PR TITLE
Contain cke-tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,12 +235,45 @@ jobs:
               prerelease="-prerelease"
             fi
             ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -n ${CIRCLE_TAG} $prerelease ${CIRCLE_TAG} /tmp/upload
+  build-tools:
+    docker:
+    - image: quay.io/cybozu/golang:1.15-focal
+    steps:
+    - checkout
+    - run:
+        command: |
+          cd tools
+          make all
+          tar czf /tmp/tools.tgz bin plugins/LICENSE plugins/bin
+    - persist_to_workspace:
+        root: /tmp
+        paths: ["tools.tgz"]
+  push-tools:
+    docker:
+    - image: docker:stable
+    steps:
+    - run:
+        name: Install tools
+        command: apk add --no-cache git
+    - checkout
+    - attach_workspace:
+        at: /tmp/workspace
+    - run: tar -C tools -xzf /tmp/workspace/tools.tgz
+    - setup_remote_docker
+    - run: 
+        name: Push cke-tools image to Quay.io
+        command: |
+          docker login -u $QUAY_USER -p $QUAY_PASSWORD quay.io
+          TAG=quay.io/cybozu/cke-tools:$(echo $CIRCLE_TAG | cut -c 7-)
+          docker build --no-cache -t $TAG
+          docker push $TAG
 
 workflows:
   version: 2
   main:
     jobs:
       - build
+      - build-tools
       - build-image:
           requires:
             - build
@@ -295,3 +328,19 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
+  release-tools:
+    jobs:
+      - build-tools:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^tools-.*/
+      - push-tools:
+          requires:
+          - build-tools
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^tools-.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,14 @@ jobs:
       - checkout:
           path: ~/work
       - run:
+          name: Check image consistency
+          command: |
+            REV=$(awk '/const Version/ {print $4}' ../version.go | sed -E 's/^"(1.[[:digit:]]+).*/\1/')
+            COMPOSE_REV=$(sed -nE 's,.*quay.io/cybozu/cke:(.*)$,\1,p' docker-compose.yml)
+            if [ "$REV" != "$COMPOSE_REV" ]; then
+                echo Update CKE branch tag in example/docker-compose.yml
+            fi
+      - run:
           name: docker-compose build
           command: docker-compose build
       - run:

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -26,16 +26,6 @@ $ git push -u origin release-1.16
 
 Then, clear the change log entries in `CHANGELOG.md`.
 
-## Back-porting fixes
-
-When vulnerabilities or critical issues are found in the main branch, 
-consider back-porting the fixes to older branches as follows:
-
-```
-$ git checkout release-1.16
-$ git cherry-pick <commit from main>
-```
-
 ### Update `k8s.io` modules
 
 CKE uses `k8s.io/client-go`.
@@ -49,7 +39,25 @@ $ go get k8s.io/client-go@${VERSION} k8s.io/api@${VERSION} k8s.io/apimachinery@v
          k8s.io/apiserver@${VERSION} k8s.io/kube-scheduler@${VERSION} k8s.io/kubelet@${VERSION}
 ```
 
-### Update the Kubernetes resource definitions embedded in CKE.
+### Update the Kubernetes resource definitions embedded in CKE
 
 The Kubernetes resource definitions embedded in CKE is defined in `./static/resource.go`.
 This needs to be updated by `make static` whenever `images.go` updates.
+
+### Update `cke-tools`
+
+Edit [`tools/Makefile`](tools/Makefile) and update `CNI_PLUGIN_VERSION` for the latest release.
+Edit [`tools/CHANGELOG.md`](tools/CHANGELOG.md) to prepare the new version.
+
+After these changes are merged, create and push a tag like `tools-1.17.0`.
+Read [`tools/RELEASE.md`](tools/RELEASE.md) for details.
+
+## Back-porting fixes
+
+When vulnerabilities or critical issues are found in the main branch, 
+consider back-porting the fixes to older branches as follows:
+
+```
+$ git checkout release-1.16
+$ git cherry-pick <commit from main>
+```

--- a/docs/cluster_overview.md
+++ b/docs/cluster_overview.md
@@ -46,7 +46,7 @@ CKE deploys following components to worker nodes:
 - kube-proxy
 - rivers
 
-CKE deploys [`rivers`][rivers] to all nodes to proxy `kube-apiserver` for high
+CKE deploys [`rivers`](../tools/rivers) to all nodes to proxy `kube-apiserver` for high
 availability.  It works as a load balancer to the servers, and every Kubernetes
 components connect to kube-apiservers via it
 (see also [k8s.md](k8s.md#high-availability)).
@@ -86,6 +86,5 @@ in cluster config.
 
 ![DNS](http://www.plantuml.com/plantuml/svg/bPDDImCn48Rl-HN3djf32qq_3XwaK154A887Brwscq74TAOa6HMa_ztTR4BPfG7Tq-mpxtoyCDdwKBiWHwjKOraCL8zoG4SOq5Vmem0SDg6cDujGxQpuW0xkzi-lDDcnmpQQLb1xQFgK8JyikHThst_FzXDTLB8atLafOjDgNjXzfEHN31UZmKzikkI9pQB0TO4lMpwPGhLdWsbjeGCBcNvjQhaXlr0AOdkOoMbsUy6HwgjqEQPbFxhePrNWwmBV_CsFJdvMmnrrJzTNwMPCp_aa7YZ4Y-W6lATOgUmxbLqEu0Q-upTFQ6wvgMtMwt_gSt-MiPgFWvubZSeqYRA3eMYBPBfNy0i0)
 
-[rivers]: https://github.com/cybozu/neco-containers/tree/main/cke-tools/src/cmd/rivers
 [CoreDNS]: https://github.com/coredns/coredns
 [unbound]: https://nlnetlabs.nl/projects/unbound/

--- a/docs/container-runtime.md
+++ b/docs/container-runtime.md
@@ -11,7 +11,7 @@ The following programs are run as Docker containers.
 - `kube-controller-manager`
 - `kube-scheduler`
 - `kubelet`
-- [rivers](https://github.com/cybozu/neco-containers/tree/main/cke-tools/src/cmd/rivers)
+- [rivers](../tools/rivers)
 
 Kubernetes Pods
 ---------------

--- a/docs/etcd.md
+++ b/docs/etcd.md
@@ -87,7 +87,7 @@ The former is described in [ckecli.md](ckecli.md##ckecli-etcd-local-backup).
 
 The rest are the descriptions of the latter.
 
-When the etcd backup is enabled on cluster configuration, [etcdbackup][] `Pod` and `CronJob` are deployed on Kubernetes cluster to manage compressed etcd snapshot.
+When the etcd backup is enabled on cluster configuration, [etcdbackup](../tools/etcdbackup) `Pod` and `CronJob` are deployed on Kubernetes cluster to manage compressed etcd snapshot.
 Before enable etcd backup, you need to create `PersistentVolume` and `PersistentVolumeClaim` to store the backup data.
 
 1. Deploy `PersistentVolume` and `PersistentVolumeClaim`. This is example of using local persistent volume in particular node.
@@ -179,4 +179,3 @@ Before enable etcd backup, you need to create `PersistentVolume` and `Persistent
 [RBAC]: https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/authentication.md
 [Endpoints]: https://kubernetes.io/docs/concepts/services-networking/service/#services-without-selectors
 [PersistentVolume]: https://kubernetes.io/docs/concepts/storage/persistent-volumes
-[etcdbackup]: https://github.com/cybozu/neco-containers/tree/main/cke-tools/src/cmd/etcdbackup

--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -22,7 +22,7 @@ a Kubernetes cluster bootstrapped by CKE.
 
 ## High availability
 
-Every node in Kubernetes cluster runs a TCP reverse proxy called [rivers][]
+Every node in Kubernetes cluster runs a TCP reverse proxy called [rivers](../tools/rivers)
 for load-balancing requests to API servers.  It will implicitly retry
 connection attempts when some API servers are down.
 
@@ -166,7 +166,6 @@ CKE maintains this Endpoints object on behalf of the API servers.
 - `kube-proxy` runs in IPVS mode.
 - [PodSecurityPolicy][] is not enabled.
 
-[rivers]: https://github.com/cybozu/neco-containers/tree/main/cke-tools/src/cmd/rivers
 [unbound]: https://www.nlnetlabs.nl/projects/unbound/
 [webhook]: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
 [ValidatingWebhookConfiguration]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#validatingwebhookconfiguration-v1-admissionregistration-k8s-io

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   cke:
     container_name: cke
-    image: quay.io/cybozu/cke:1.17
+    image: quay.io/cybozu/cke:1.19
     networks:
       app_net:
         ipv4_address: 172.30.0.11

--- a/images.go
+++ b/images.go
@@ -12,7 +12,7 @@ func (i Image) Name() string {
 const (
 	EtcdImage       = Image("quay.io/cybozu/etcd:3.3.25.3")
 	KubernetesImage = Image("quay.io/cybozu/kubernetes:1.19.7.1")
-	ToolsImage      = Image("quay.io/ymmt2005/cke-tools:dev")
+	ToolsImage      = Image("quay.io/cybozu/cke-tools:1.7.4")
 	PauseImage      = Image("quay.io/cybozu/pause:3.2.0.2")
 	CoreDNSImage    = Image("quay.io/cybozu/coredns:1.8.0.1")
 	UnboundImage    = Image("quay.io/cybozu/unbound:1.13.0.1")

--- a/images.go
+++ b/images.go
@@ -12,7 +12,7 @@ func (i Image) Name() string {
 const (
 	EtcdImage       = Image("quay.io/cybozu/etcd:3.3.25.3")
 	KubernetesImage = Image("quay.io/cybozu/kubernetes:1.19.7.1")
-	ToolsImage      = Image("quay.io/cybozu/cke-tools:1.7.4")
+	ToolsImage      = Image("quay.io/ymmt2005/cke-tools:dev")
 	PauseImage      = Image("quay.io/cybozu/pause:3.2.0.2")
 	CoreDNSImage    = Image("quay.io/cybozu/coredns:1.8.0.1")
 	UnboundImage    = Image("quay.io/cybozu/unbound:1.13.0.1")

--- a/mtest/Makefile
+++ b/mtest/Makefile
@@ -1,5 +1,13 @@
 # Makefile for multi-host testing using ginkgo
 
+# tool versions
+MANAGEMENT_ETCD_VERSION = 3.3.25
+VAULT_VERSION = 1.6.1
+K8S_VERSION = 1.19.7
+CONTAINERD_VERSION = 1.4.3
+CRITOOLS_VERSION = 1.19.0
+CT_VERSION = 0.6.1
+
 # configuration variables
 BRIDGE_ADDRESS = 10.0.0.1
 ## 'HOST' runs CKE and management etcd
@@ -19,13 +27,7 @@ endif
 PLACEMAT = /usr/bin/placemat
 GINKGO = $(GOPATH)/bin/ginkgo --failFast -v
 CURL = curl -fsL
-MANAGEMENT_ETCD_VERSION = 3.3.25
-VAULT_VERSION = 1.6.1
-K8S_VERSION = 1.19.7
 PLACEMAT_DATADIR = /var/scratch/placemat
-CONTAINERD_VERSION = 1.4.3
-CRITOOLS_VERSION = 1.19.0
-CT_VERSION = 0.6.1
 CT = /usr/local/bin/ct
 SUDO = sudo
 PACKAGES = libseccomp-dev automake autoconf libtool

--- a/op/common/mkdirs.go
+++ b/op/common/mkdirs.go
@@ -47,7 +47,7 @@ func (c makeDirsCommand) Run(ctx context.Context, inf cke.Infrastructure, _ stri
 	}
 
 	args := append([]string{
-		"/usr/local/cke-tools/bin/make_directories",
+		"make_directories",
 		"--mode=" + c.mode,
 	}, dests...)
 	arg := strings.Join(args, " ")

--- a/op/common/mkfiles.go
+++ b/op/common/mkfiles.go
@@ -137,7 +137,7 @@ func (c *FilesBuilder) Run(ctx context.Context, inf cke.Infrastructure, _ string
 			}
 			data := buf.String()
 
-			arg := "/usr/local/cke-tools/bin/write_files /mnt"
+			arg := "write_files /mnt"
 			ce := inf.Engine(n.Address)
 			return ce.RunWithInput(cke.ToolsImage, binds, arg, data)
 		})

--- a/op/etcdbackup/template.go
+++ b/op/etcdbackup/template.go
@@ -13,7 +13,7 @@ metadata:
   namespace: kube-system
 data:
   config.yml: |
-    backup-dir: /etcdbackup
+    backup-dir: /backup
     listen: 0.0.0.0:8080
     rotate: {{ .Rotate }}
     etcd:
@@ -46,14 +46,14 @@ spec:
   - name: etcdbackup
     image: ` + cke.ToolsImage.Name() + `
     command:
-      - /usr/local/cke-tools/bin/etcdbackup
+      - etcdbackup
     args: ['-config', '/config/config.yml']
     ports:
       - containerPort: 8080
     volumeMounts:
       - mountPath: /etcd-certs
         name: etcd-certs
-      - mountPath: /etcdbackup
+      - mountPath: /backup
         name: etcdbackup
       - mountPath: /config
         name: config
@@ -91,7 +91,7 @@ spec:
             runAsUser: 10000
           containers:
             - name: etcdbackup
-              image: ` + cke.ToolsImage.Name() + `
+              image: quay.io/cybozu/ubuntu:20.04
               command:
                 - curl
                 - -s

--- a/op/k8s/kubelet_boot.go
+++ b/op/k8s/kubelet_boot.go
@@ -139,7 +139,7 @@ type emptyDirCommand struct {
 
 func (c emptyDirCommand) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
 	dest := filepath.Join("/mnt", c.dir)
-	arg := "/usr/local/cke-tools/bin/empty-dir " + dest
+	arg := "empty-dir " + dest
 
 	bind := cke.Mount{
 		Source:      c.dir,
@@ -256,7 +256,7 @@ func (c installCNICommand) Run(ctx context.Context, inf cke.Infrastructure, _ st
 		n := n
 		ce := inf.Engine(n.Address)
 		env.Go(func(ctx context.Context) error {
-			return ce.Run(cke.ToolsImage, binds, "/usr/local/cke-tools/bin/install-cni")
+			return ce.Run(cke.ToolsImage, binds, "install-cni")
 		})
 	}
 	env.Stop()

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -433,7 +433,7 @@ func (d testData) withEtcdBackup() testData {
 	d.Status.Kubernetes.EtcdBackup.Service = &corev1.Service{}
 	d.Status.Kubernetes.EtcdBackup.ConfigMap = &corev1.ConfigMap{
 		Data: map[string]string{
-			"config.yml": `backup-dir: /etcdbackup
+			"config.yml": `backup-dir: /backup
 listen: 0.0.0.0:8080
 rotate: 14
 etcd:

--- a/tools/.dockerignore
+++ b/tools/.dockerignore
@@ -1,0 +1,4 @@
+*
+!bin
+!plugins/bin
+!plugins/LICENSE

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,2 @@
+/bin
+/plugins

--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Change Log
+
+cke-tools related changes.
+
+## 1.19.0
+
+### Changed
+
+- Move the source code to github.com/cybozu-go/cke
+- Rewrite Python and shell scripts in Go

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,0 +1,6 @@
+FROM scratch
+
+COPY bin/ /
+COPY plugins/ /cni_plugins/
+
+ENV PATH=/

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,0 +1,44 @@
+CNI_PLUGIN_VERSION = 0.9.0
+TAG = quay.io/cybozu/cke-tools:dev
+GOBUILD = CGO_ENABLED=0 go build -ldflags="-w -s"
+
+.PHONY: all
+all: bin/empty-dir bin/etcdbackup bin/install-cni bin/make_directories bin/rivers bin/write_files plugins
+
+.PHONY: image
+image: all
+	docker build --no-cache -t $(TAG) .
+
+bin/empty-dir:
+	mkdir -p bin
+	$(GOBUILD) -o $@ ./empty-dir
+
+bin/etcdbackup:
+	mkdir -p bin
+	$(GOBUILD) -o $@ ./etcdbackup
+
+bin/install-cni:
+	mkdir -p bin
+	$(GOBUILD) -o $@ ./install-cni
+
+bin/make_directories:
+	mkdir -p bin
+	$(GOBUILD) -o $@ ./make_directories
+
+bin/rivers:
+	mkdir -p bin
+	$(GOBUILD) -o $@ ./rivers
+
+bin/write_files:
+	mkdir -p bin
+	$(GOBUILD) -o $@ ./write_files
+
+.PHONY: plugins
+plugins:
+	rm -rf plugins
+	git clone --depth 1 -b v$(CNI_PLUGIN_VERSION) https://github.com/containernetworking/plugins
+	cd plugins; CGO_ENABLED=0 ./build_linux.sh
+
+.PHONY: clean
+clean:
+	rm -rf bin plugins

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,5 @@
+This directory contains source code to build `cke-tools`, a helper container for CKE.
+
+The container image is pushed to [quay.io/cybozu/cke-tools](https://quay.io/repository/cybozu/cke-tools) by CircleCI.
+
+See [RELEASE.md](RELEASE.md) for how to push a new image version.

--- a/tools/RELEASE.md
+++ b/tools/RELEASE.md
@@ -1,0 +1,21 @@
+Release procedure
+=================
+
+This document describes how to release a new version of `cke-tools`.
+
+## Versioning
+
+Given a version number MAJOR.MINOR.PATCH.
+The MAJOR and MINOR version matches that of Kubernetes.
+The patch version is increased with `cke-tools` update.
+
+## Publish Docker image to quay.io
+
+1. Edit `CHANGELOG.md` in this directory.
+2. Merge the `CHANGELOG.md` change to the `main` branch.
+3. Tag the head commit as `tools-X.Y.Z` where `X.Y.Z` is the new semantic version of `cke-tools`.
+4. Push the tag to GitHub.
+
+CircleCI will build and push the new image as `quay.io/cybozu/cke-tools:X.Y.Z`.
+
+[semver]: https://semver.org/spec/v2.0.0.html

--- a/tools/empty-dir/main.go
+++ b/tools/empty-dir/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s DIR\n", os.Args[0])
+		os.Exit(2)
+	}
+	if err := subMain(os.Args[1]); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func subMain(dir string) error {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read %s: %w", dir, err)
+	}
+
+	for _, f := range files {
+		target := filepath.Join(dir, f.Name())
+		if err := os.RemoveAll(target); err != nil {
+			return fmt.Errorf("failed to delete %s: %w", target, err)
+		}
+	}
+	return nil
+}

--- a/tools/etcdbackup/README.md
+++ b/tools/etcdbackup/README.md
@@ -1,0 +1,110 @@
+etcdbackup
+==========
+
+etcdbackup is REST API based etcd backup service.
+
+Usage
+-----
+
+Launch etcdbackup by docker as follows:
+
+```console
+$ ./etcdbackup --config string
+```
+
+etcdbackup listen HTTP protocol to receive request from HTTP clients.
+When it receives a request, action for etcd backup and reply the result. 
+
+Configuration file
+------------------
+
+etcdbackup reads etcd configurations from a YAML file.
+
+
+Name         | Type            | Required | Description
+----         | ----            | -------- | -----------
+`backup-dir` | string          | No       | etcd backup saved directory.  Default: `/etcd-backup/`.
+`listen`     | string          | No       | REST API listen address and port.  Default: `0.0.0.0:8080`.
+`rotate`     | int             | No       | Keep a number of backup files.  Default: `14`.
+`etcd`       | etcdutil.Config | Yes      | etcd parameter defined by [cybozu-go/etcdutil](https://github.com/cybozu-go/etcdutil).
+
+APIs
+----
+
+## `GET /api/v1/backup`
+
+List etcd backup files in JSON format.
+
+**Successful response**
+
+- HTTP status code: 200 OK
+- HTTP response header: `Content-Type: application/json`
+- HTTP response body: etcd backup file list
+
+**Failure responses**
+
+**Example**
+
+```console
+$ curl -s -XGET 'localhost:8080/api/v1/backup'
+[
+    "snapshot-20181220_024105.tar.gz",
+    "snapshot-20181220_024204.tar.gz"
+]
+```
+
+## `GET /api/v1/backup/<FILENAME>`
+
+Retrieve an etcd backup file.
+
+**Successful response**
+
+- HTTP status code: 200 OK
+- HTTP response header: `Content-Type: application/gzip`
+- HTTP response body: An etcd backup data
+
+**Failure responses**
+
+- FILENAME does not match "snapshot-*.db.gz"
+
+    - HTTP status code: 400 Bad Request
+
+- FILENAME is not found.
+
+    - HTTP status code: 404 Not Found
+    
+**Example**
+
+```console
+$ curl -O -s -XGET 'localhost:8080/api/v1/backup/snapshot-20181220_024105.tar.gz'
+```
+
+## `POST /api/v1/backup`
+
+Access etcd server to save snapshot as an etcd backup, then compress with tar archive.
+
+**Successful response**
+
+- HTTP status code: 200 OK
+- HTTP response header: `Content-Type: application/json`
+- HTTP response body: Status, file name and file size
+
+**Failure responses**
+
+- Fail to request for etcd server, Fail to save an etcd backup into `backup-dir`.
+
+    - HTTP status code: 500 Internal Server Error
+    - HTTP response header: `Content-Type: application/json`
+    - HTTP response body: Error message
+
+**Example**
+
+```console
+$ curl -s -XPOST 'localhost:8080/api/v1/backup'
+{
+    "message": "backup successfully",
+    "filename": "snapshot-20181220_024105.tar.gz",
+    "filesize": 125927
+}
+```
+

--- a/tools/etcdbackup/apierror.go
+++ b/tools/etcdbackup/apierror.go
@@ -1,0 +1,34 @@
+package main
+
+import "net/http"
+
+// APIError is to define REST API errors.
+type APIError struct {
+	Status  int
+	Message string
+	Err     error
+}
+
+// Error implements error interface.
+func (e APIError) Error() string {
+	if e.Err == nil {
+		return e.Message
+	}
+
+	return e.Err.Error() + ": " + e.Message
+}
+
+// InternalServerError creates an APIError.
+func InternalServerError(e error) APIError {
+	return APIError{
+		http.StatusInternalServerError,
+		http.StatusText(http.StatusInternalServerError),
+		e,
+	}
+}
+
+// Common API errors
+var (
+	APIErrNotFound   = APIError{http.StatusNotFound, "requested resource is not found", nil}
+	APIErrBadRequest = APIError{http.StatusBadRequest, "invalid request", nil}
+)

--- a/tools/etcdbackup/config.go
+++ b/tools/etcdbackup/config.go
@@ -1,0 +1,27 @@
+package main
+
+import "github.com/cybozu-go/etcdutil"
+
+const (
+	defaultBackupDir = "/etcd-backup"
+	defaultListen    = "0.0.0.0:8080"
+	defaultRotate    = 14
+)
+
+// NewConfig returns configuration for etcdbackup
+func NewConfig() *Config {
+	return &Config{
+		BackupDir: defaultBackupDir,
+		Listen:    defaultListen,
+		Rotate:    defaultRotate,
+		Etcd:      etcdutil.NewConfig(""),
+	}
+}
+
+// Config is configuration parameters
+type Config struct {
+	BackupDir string           `json:"backup-dir,omitempty"`
+	Listen    string           `json:"listen,omitempty"`
+	Rotate    int              `json:"rotate,omitempty"`
+	Etcd      *etcdutil.Config `json:"etcd"`
+}

--- a/tools/etcdbackup/main.go
+++ b/tools/etcdbackup/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/cybozu-go/log"
+	"github.com/cybozu-go/well"
+	"sigs.k8s.io/yaml"
+)
+
+var flgConfig = flag.String("config", "", "path to configuration file")
+
+func main() {
+	flag.Parse()
+	well.LogConfig{}.Apply()
+
+	if *flgConfig == "" {
+		log.ErrorExit(errors.New("usage: etcdbackup -config=<CONFIGFILE>"))
+	}
+
+	b, err := ioutil.ReadFile(*flgConfig)
+	if err != nil {
+		log.ErrorExit(err)
+	}
+	cfg := NewConfig()
+	err = yaml.Unmarshal(b, cfg)
+	if err != nil {
+		log.ErrorExit(err)
+	}
+
+	server := NewServer(cfg)
+	s := &well.HTTPServer{
+		Server: &http.Server{
+			Addr:    cfg.Listen,
+			Handler: server,
+		},
+		ShutdownTimeout: 3 * time.Minute,
+	}
+
+	log.Info("started", map[string]interface{}{
+		"listen": cfg.Listen,
+	})
+
+	err = s.ListenAndServe()
+	if err != nil {
+		log.ErrorExit(err)
+	}
+
+	err = well.Wait()
+	if err != nil && !well.IsSignaled(err) {
+		log.ErrorExit(err)
+	}
+}

--- a/tools/etcdbackup/responses.go
+++ b/tools/etcdbackup/responses.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/cybozu-go/log"
+	"github.com/cybozu-go/well"
+)
+
+func renderJSON(w http.ResponseWriter, data interface{}, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	err := json.NewEncoder(w).Encode(data)
+	if err != nil {
+		log.Error("failed to output JSON", map[string]interface{}{
+			log.FnError: err.Error(),
+		})
+	}
+}
+
+func renderError(ctx context.Context, w http.ResponseWriter, e APIError) {
+	fields := well.FieldsFromContext(ctx)
+	fields["status"] = e.Status
+	fields[log.FnError] = e.Error()
+	log.Error(http.StatusText(e.Status), fields)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(e.Status)
+	err := json.NewEncoder(w).Encode(fields)
+	if err != nil {
+		log.Error("failed to output JSON", map[string]interface{}{
+			log.FnError: err.Error(),
+		})
+	}
+}

--- a/tools/etcdbackup/server.go
+++ b/tools/etcdbackup/server.go
@@ -1,0 +1,249 @@
+package main
+
+import (
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/pkg/fileutil"
+	"github.com/cybozu-go/etcdutil"
+)
+
+const (
+	backupSucceed       = "backup successfully"
+	snapshotFilePattern = "snapshot-*.db.gz"
+)
+
+// Server is etcdbackup server
+type Server struct {
+	cfg *Config
+}
+
+// NewServer returns etcd backup server
+func NewServer(cfg *Config) *Server {
+	return &Server{cfg}
+}
+
+func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if !strings.HasPrefix(r.URL.Path, "/api/v1/backup") {
+		renderError(ctx, w, APIErrNotFound)
+		return
+	}
+	p := r.URL.Path[len("/api/v1/backup"):]
+	switch r.Method {
+	case http.MethodGet:
+		if len(p) == 0 {
+			s.handleBackupList(w, r)
+			return
+		} else if strings.HasPrefix(p, "/") && len(p) > 1 {
+			s.handleBackupDownload(w, r, p[1:])
+			return
+		}
+	case http.MethodPost:
+		if len(p) == 0 {
+			s.handleBackupSave(w, r)
+			return
+		}
+	}
+	renderError(ctx, w, APIErrNotFound)
+}
+
+func (s Server) handleBackupList(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	matches, err := filepath.Glob(filepath.Join(s.cfg.BackupDir, snapshotFilePattern))
+	if err != nil {
+		renderError(ctx, w, InternalServerError(err))
+		return
+	}
+
+	var files []string
+	for _, f := range matches {
+		fi, err := os.Stat(f)
+		if err != nil {
+			renderError(ctx, w, InternalServerError(err))
+			return
+		}
+		if fi.IsDir() {
+			continue
+		}
+		files = append(files, path.Base(f))
+	}
+
+	renderJSON(w, files, http.StatusOK)
+}
+
+func (s Server) handleBackupDownload(w http.ResponseWriter, r *http.Request, filename string) {
+	ctx := r.Context()
+	matched, err := filepath.Match(snapshotFilePattern, filename)
+	if err != nil {
+		renderError(ctx, w, InternalServerError(err))
+		return
+	}
+	if !matched {
+		renderError(ctx, w, APIErrBadRequest)
+		return
+	}
+
+	target := filepath.Join(s.cfg.BackupDir, filename)
+	fi, err := os.Stat(target)
+	if os.IsNotExist(err) || fi.IsDir() {
+		renderError(ctx, w, APIErrNotFound)
+		return
+	}
+
+	f, err := os.Open(target)
+	if err != nil {
+		renderError(ctx, w, InternalServerError(err))
+		return
+	}
+	defer f.Close()
+	header := w.Header()
+	contentType := mime.TypeByExtension(filepath.Ext(filename))
+	header.Set("content-type", contentType)
+	http.ServeContent(w, r, fi.Name(), fi.ModTime(), f)
+}
+
+func (s Server) handleBackupSave(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	now := time.Now()
+	filename := filepath.Join(s.cfg.BackupDir, snapshotName(now))
+	cli, err := etcdutil.NewClient(s.cfg.Etcd)
+	if err != nil {
+		renderError(ctx, w, InternalServerError(err))
+		return
+	}
+	defer cli.Close()
+
+	bkName, bkSize, err := saveBackup(ctx, filename, cli)
+	if err != nil {
+		renderError(ctx, w, InternalServerError(err))
+		return
+	}
+
+	err = removeOldBackups(s.cfg.BackupDir, s.cfg.Rotate)
+	if err != nil {
+		renderError(ctx, w, InternalServerError(err))
+		return
+	}
+
+	renderJSON(w, map[string]interface{}{
+		"message":  backupSucceed,
+		"filename": bkName,
+		"filesize": bkSize,
+	}, http.StatusOK)
+}
+
+func snapshotName(date time.Time) string {
+	return fmt.Sprintf("snapshot-%s.db", date.Format("20060102_150405"))
+}
+
+func saveBackup(ctx context.Context, filename string, cli *clientv3.Client) (string, int64, error) {
+	// Take snapshot to temp file
+	partpath := filename + ".part"
+	defer os.RemoveAll(partpath)
+
+	fp, err := os.OpenFile(partpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fileutil.PrivateFileMode)
+	if err != nil {
+		return "", 0, err
+	}
+	var rd io.ReadCloser
+	rd, err = cli.Snapshot(ctx)
+	if err != nil {
+		return "", 0, err
+	}
+	_, err = io.Copy(fp, rd)
+	if err != nil {
+		return "", 0, err
+	}
+	err = fileutil.Fsync(fp)
+	if err != nil {
+		return "", 0, err
+	}
+	err = fp.Close()
+	if err != nil {
+		return "", 0, err
+	}
+
+	// Rename temp file to expected file name
+	err = os.Rename(partpath, filename)
+	if err != nil {
+		return "", 0, err
+	}
+
+	// Compress snapshot file
+	f, err := os.Open(filename)
+	if err != nil {
+		return "", 0, err
+	}
+
+	gzipName := filename + ".gz"
+	zf, err := os.Create(gzipName)
+	if err != nil {
+		return "", 0, err
+	}
+	zw := gzip.NewWriter(zf)
+
+	_, err = io.Copy(zw, f)
+	if err != nil {
+		return "", 0, err
+	}
+	defer os.Remove(filename)
+
+	err = zw.Close()
+	if err != nil {
+		return "", 0, err
+	}
+
+	fi, err := os.Stat(gzipName)
+	if err != nil {
+		return "", 0, err
+	}
+	return fi.Name(), fi.Size(), nil
+}
+
+func removeOldBackups(dir string, rotate int) error {
+	matches, err := filepath.Glob(filepath.Join(dir, snapshotFilePattern))
+	if err != nil {
+		return err
+	}
+
+	var snapshotFiles []os.FileInfo
+	for _, f := range matches {
+		fi, err := os.Stat(f)
+		if err != nil {
+			return err
+		}
+		snapshotFiles = append(snapshotFiles, fi)
+	}
+
+	if len(snapshotFiles) < rotate {
+		return nil
+	}
+
+	sort.Slice(snapshotFiles, func(i, j int) bool {
+		return snapshotFiles[i].ModTime().Unix() > snapshotFiles[j].ModTime().Unix()
+	})
+
+	removeFiles := snapshotFiles[rotate:]
+	for _, f := range removeFiles {
+		if f.IsDir() {
+			continue
+		}
+		err := os.Remove(filepath.Join(dir, f.Name()))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/tools/etcdbackup/server_test.go
+++ b/tools/etcdbackup/server_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testHandleBackup(t *testing.T) {
+	t.Parallel()
+
+	backupDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(backupDir)
+
+	cfg := NewConfig()
+	cfg.BackupDir = backupDir
+	cfg.Rotate = 1
+	s := NewServer(cfg)
+
+	// backupDir is empty
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/api/v1/backup", nil)
+	s.ServeHTTP(w, r)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Error("wrong status code:", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// Save
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("POST", "/api/v1/backup", nil)
+	s.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Error("wrong status code:", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/api/v1/backup", nil)
+	s.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Error("wrong status code:", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	var list []string
+	err = json.NewDecoder(resp.Body).Decode(&list)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 {
+		t.Error("len(list) != 1:", len(list))
+	}
+	if !strings.Contains(list[0], "snapshot-") {
+		t.Error("file does not contain \"snapshot-\"", list[0])
+	}
+	backup1 := list[0]
+
+	// Rotate backups
+	time.Sleep(time.Second)
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("POST", "/api/v1/backup", nil)
+	s.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Error("wrong status code:", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/api/v1/backup", nil)
+	s.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Error("wrong status code:", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&list)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 {
+		t.Error("len(list) != 1:", len(list))
+	}
+	if list[0] == backup1 {
+		t.Error("backup is not rotated", list[0])
+	}
+
+	// Download
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", path.Join("/api/v1/backup", list[0]), nil)
+	s.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Error("wrong status code:", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	files, err := ioutil.ReadDir(backupDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 {
+		t.Error("len(files) != 1:", len(files))
+	}
+	if files[0].Name() != list[0] {
+		t.Error("files[0].Name() != list[0]:", files[0].Name())
+	}
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/api/v1/backup/foobar", nil)
+	s.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Error("wrong status code:", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// File does not exist
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/api/v1/backup/snapshot-foobar.db.gz", nil)
+	s.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Error("wrong status code:", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	// File exists but directory
+	err = os.MkdirAll(filepath.Join(backupDir, "snapshot-foobar.db.gz"), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/api/v1/backup/snapshot-foobar.db.gz", nil)
+	s.ServeHTTP(w, r)
+
+	resp = w.Result()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Error("wrong status code:", resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
+func TestServer(t *testing.T) {
+	t.Run("Backup", testHandleBackup)
+}

--- a/tools/install-cni/main.go
+++ b/tools/install-cni/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+const (
+	hostBinDir = "/host/bin"
+	cniDir     = "/cni_plugins/bin"
+)
+
+func main() {
+	err := subMain()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func subMain() error {
+	files, err := ioutil.ReadDir(cniDir)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", cniDir, err)
+	}
+
+	for _, f := range files {
+		if err := copyFile(f.Name()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func copyFile(name string) error {
+	src := filepath.Join(cniDir, name)
+	f, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", src, err)
+	}
+	defer f.Close()
+
+	dest := filepath.Join(hostBinDir, name)
+	err = os.Remove(dest)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove %s: %w", dest, err)
+	}
+
+	o, err := os.Create(dest)
+	if err != nil {
+		return fmt.Errorf("failed to create %s: %w", dest, err)
+	}
+	defer o.Close()
+
+	_, err = io.Copy(o, f)
+	if err != nil {
+		return fmt.Errorf("failed to copy %s: %w", name, err)
+	}
+
+	if err := o.Sync(); err != nil {
+		return fmt.Errorf("failed to fsync %s: %w", dest, err)
+	}
+
+	return o.Chmod(0755)
+}

--- a/tools/make_directories/main.go
+++ b/tools/make_directories/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+var options struct {
+	mode string
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "make_directories DIR [DIR ...]",
+	Short: "make directories",
+	Long:  `make directories with given permission flags`,
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		return subMain(args)
+	},
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func subMain(dirs []string) error {
+	modeBits, err := strconv.ParseInt(options.mode, 8, 64)
+	if err != nil {
+		return fmt.Errorf("invalid mode %s: %w", options.mode, err)
+	}
+
+	for _, d := range dirs {
+		if !filepath.IsAbs(d) {
+			return fmt.Errorf("non-absolute path: %s", d)
+		}
+
+		if err := os.MkdirAll(d, os.FileMode(modeBits)); err != nil {
+			return fmt.Errorf("failed to create %s: %w", d, err)
+		}
+	}
+	return nil
+}
+
+func init() {
+	rootCmd.Flags().StringVar(&options.mode, "mode", "755", "permission bits for directories")
+}

--- a/tools/rivers/README.md
+++ b/tools/rivers/README.md
@@ -1,0 +1,25 @@
+rivers
+======
+
+Rivers is a simple TCP reverse proxy written in GO.
+
+Usage
+-----
+
+Launch rivers by docker as follows:
+
+```console
+$ ./rivers
+    --listen localhost:6443 \
+    --upstreams 10.0.0.100:6443,10.0.0.101:6443,10.0.0.102:6443
+```
+
+Rivers starts and waits for TCP connections on address and port specified by `--listen`.
+Rivers receives TCP packets, and forwards them to upstream servers specified by `--upstreams`.
+The upstream server is selected at random.
+
+Available options are following:
+
+- `--listen`: Listen address and port
+- `--upstreams`: Comma-separated upstream servers
+- `--shutdown-timeout`: Timeout for server shutting-down gracefully, or disable it if `0` is specified

--- a/tools/rivers/main.go
+++ b/tools/rivers/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/cybozu-go/log"
+	"github.com/cybozu-go/well"
+)
+
+var (
+	flgListen          = flag.String("listen", "", "Listen address and port (address:port)")
+	flgUpstreams       = flag.String("upstreams", "", "Comma-separated upstream servers (addr1:port1,addr2:port2")
+	flgShutdownTimeout = flag.String("shutdown-timeout", "0", "Timeout for server shutting-down gracefully (disabled if specified \"0\")")
+	flgDialTimeout     = flag.String("dial-timeout", "5s", "Timeout for dial to an upstream server")
+	flgDialKeepAlive   = flag.String("dial-keep-alive", "3m", "Timeout for dial keepalive to an upstream server")
+)
+
+func run() error {
+	if len(*flgUpstreams) == 0 {
+		return errors.New("--upstreams is blank")
+	}
+	upstreams := strings.Split(*flgUpstreams, ",")
+
+	var dialer = &net.Dialer{DualStack: true}
+	var err error
+	dialer.Timeout, err = time.ParseDuration(*flgDialTimeout)
+	if err != nil {
+		return err
+	}
+	dialer.KeepAlive, err = time.ParseDuration(*flgDialKeepAlive)
+	if err != nil {
+		return err
+	}
+
+	cfg := Config{Dialer: dialer}
+	cfg.ShutdownTimeout, err = time.ParseDuration(*flgShutdownTimeout)
+	if err != nil {
+		return err
+	}
+
+	if len(*flgListen) == 0 {
+		return errors.New("--listen is blank")
+	}
+	listen, err := net.Listen("tcp", *flgListen)
+	if err != nil {
+		return err
+	}
+
+	s := NewServer(upstreams, cfg)
+	s.Serve(listen)
+
+	return well.Wait()
+}
+
+func main() {
+	flag.Parse()
+	well.LogConfig{}.Apply()
+
+	err := run()
+	if err != nil && !well.IsSignaled(err) {
+		log.ErrorExit(err)
+	}
+}

--- a/tools/rivers/server.go
+++ b/tools/rivers/server.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"math/rand"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/cybozu-go/log"
+	"github.com/cybozu-go/netutil"
+	"github.com/cybozu-go/well"
+)
+
+const (
+	copyBufferSize = 64 << 10
+)
+
+// Config presents TCP servers
+type Config struct {
+	ShutdownTimeout time.Duration
+	Logger          *log.Logger
+	Dialer          *net.Dialer
+}
+
+// Server presents TCP proxy server
+type Server struct {
+	well.Server
+
+	upstreams []string
+	logger    *log.Logger
+	dialer    *net.Dialer
+	pool      sync.Pool
+}
+
+// NewServer creates a new Server
+func NewServer(upstreams []string, cfg Config) *Server {
+	dialer := cfg.Dialer
+	if dialer == nil {
+		dialer = &net.Dialer{}
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = log.DefaultLogger()
+	}
+
+	s := &Server{
+		Server: well.Server{
+			ShutdownTimeout: cfg.ShutdownTimeout,
+		},
+
+		upstreams: upstreams,
+		logger:    logger,
+		dialer:    dialer,
+		pool: sync.Pool{
+			New: func() interface{} {
+				buf := make([]byte, copyBufferSize)
+				return &buf
+			},
+		},
+	}
+	s.Server.Handler = s.handleConnection
+
+	return s
+}
+
+func (s *Server) handleConnection(ctx context.Context, conn net.Conn) {
+	fields := well.FieldsFromContext(ctx)
+	fields[log.FnType] = "access"
+	fields["client_addr"] = conn.RemoteAddr().String()
+
+	destConn, err := s.randomUpstream()
+	if err != nil {
+		fields[log.FnError] = err.Error()
+		s.logger.Error("failed to connect to upstream servers", fields)
+		return
+	}
+	defer destConn.Close()
+
+	tc, ok := conn.(*net.TCPConn)
+	if !ok {
+		s.logger.Error("non-TCP connection", map[string]interface{}{
+			"conn": conn,
+		})
+		return
+	}
+
+	st := time.Now()
+	env := well.NewEnvironment(ctx)
+	env.Go(func(ctx context.Context) error {
+		buf := s.pool.Get().(*[]byte)
+		_, err := io.CopyBuffer(destConn, tc, *buf)
+		s.pool.Put(buf)
+		if hc, ok := destConn.(netutil.HalfCloser); ok {
+			hc.CloseWrite()
+		}
+		tc.CloseRead()
+		return err
+	})
+	env.Go(func(ctx context.Context) error {
+		buf := s.pool.Get().(*[]byte)
+		_, err := io.CopyBuffer(tc, destConn, *buf)
+		s.pool.Put(buf)
+		tc.CloseWrite()
+		if hc, ok := destConn.(netutil.HalfCloser); ok {
+			hc.CloseRead()
+		}
+		return err
+	})
+	env.Stop()
+	err = env.Wait()
+
+	fields = well.FieldsFromContext(ctx)
+	fields["elapsed"] = time.Since(st).Seconds()
+	if err != nil {
+		fields[log.FnError] = err.Error()
+		s.logger.Error("proxy ends with an error", fields)
+		return
+	}
+	s.logger.Info("proxy ends", fields)
+}
+
+func (s *Server) randomUpstream() (net.Conn, error) {
+	ups := make([]string, len(s.upstreams))
+	copy(ups, s.upstreams)
+	rand.Shuffle(len(ups), func(i, j int) {
+		ups[i], ups[j] = ups[j], ups[i]
+	})
+	for _, u := range ups {
+		conn, err := s.dialer.Dial("tcp", u)
+		if err == nil {
+			return conn, nil
+		}
+
+		s.logger.Warn("failed to connect to proxy server", map[string]interface{}{
+			"upstream": u,
+		})
+	}
+	return nil, errors.New("no available upstreams servers")
+}

--- a/tools/write_files/main.go
+++ b/tools/write_files/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/spf13/cobra"
+)
+
+var options struct {
+	mode string
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "write_files DIR",
+	Short: "read TAR from stdin and write out the contents",
+	Long: `This command reads a TAR archive from stdin and extracts
+the contents under DIR.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		return subMain(args[0])
+	},
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+func subMain(prefix string) error {
+	modeBits, err := strconv.ParseInt(options.mode, 8, 64)
+	if err != nil {
+		return fmt.Errorf("invalid mode %s: %w", options.mode, err)
+	}
+
+	r := tar.NewReader(os.Stdin)
+	for {
+		hdr, err := r.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read tar: %w", err)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+
+		dest := filepath.Join(prefix, hdr.Name)
+		dir := filepath.Dir(dest)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to mkdir %s: %w", dir, err)
+		}
+
+		if err := copyFile(dest, r, os.FileMode(modeBits)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyFile(dest string, r io.Reader, mode os.FileMode) error {
+	t := dest + ".tmp"
+	f, err := os.OpenFile(t, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("failed to create %s: %w", t, err)
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, r); err != nil {
+		return fmt.Errorf("failed to write contents of %s: %w", t, err)
+	}
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("failed to fsync %s: %w", t, err)
+	}
+
+	return os.Rename(t, dest)
+}
+
+func init() {
+	rootCmd.Flags().StringVar(&options.mode, "mode", "644", "permission bits for extracted files")
+}


### PR DESCRIPTION
This PR moves the source code of cke-tools from [cybozu/neco-containers](https://github.com/cybozu/neco-containers) for better integrity.

Python and shell scripts are re-written in Go.
The new code is tested with a test image `quay.io/ymmt2005/cke-tools:dev` in d4e06e4628f63231c42bb41374a53653b7230623 .