### PR TITLE
Add "mode" option for kube-proxy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,6 +211,10 @@ jobs:
             - sonobuoy.tar.gz
       - store_artifacts:
           path: /tmp/sonobuoy.tar.gz
+      - run:
+          name: Check failures
+          command: |
+            grep "failed tests: 0" /tmp/e2e-check.log
   github-release:
     docker:
       - image: quay.io/cybozu/golang:1.15-focal

--- a/bin/run-sonobuoy.sh
+++ b/bin/run-sonobuoy.sh
@@ -73,7 +73,7 @@ cd sonobuoy
 make setup
 make run
 make sonobuoy
-mv sonobuoy.tar.gz /tmp
+mv sonobuoy.tar.gz e2e-check.log /tmp
 EOF
 chmod +x run.sh
 
@@ -92,6 +92,7 @@ $GCLOUD compute ssh --zone=${ZONE} cybozu@${INSTANCE_NAME}-0 --command='sudo -H 
 RET=$?
 if [ "$RET" -eq 0 ]; then
   $GCLOUD compute scp --zone=${ZONE} cybozu@${INSTANCE_NAME}-0:/tmp/sonobuoy.tar.gz /tmp/sonobuoy.tar.gz
+  $GCLOUD compute scp --zone=${ZONE} cybozu@${INSTANCE_NAME}-0:/tmp/e2e-check.log /tmp/e2e-check.log
 fi
 
 exit $RET

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -144,6 +144,10 @@ rules:
 		t.Error(`*kubeSchedulerConfig.Profiles[0].Plugins.Score.Enabled[0].Weight != int32(500)`)
 	}
 
+	if c.Options.Proxy.Mode != ProxyModeIptables {
+		t.Error(`c.Options.Proxy.Mode != ProxyModeIptables`)
+	}
+
 	if c.Options.Kubelet.ContainerRuntime != "remote" {
 		t.Error(`c.Options.Kubelet.ContainerRuntime != "remote"`)
 	}
@@ -289,6 +293,19 @@ rules:
 				},
 			},
 			false,
+		},
+		{
+			"invalid proxy mode",
+			Cluster{
+				Name:          "testcluster",
+				ServiceSubnet: "10.0.0.0/14",
+				Options: Options{
+					Proxy: ProxyParams{
+						Mode: "foo",
+					},
+				},
+			},
+			true,
 		},
 		{
 			"invalid domain",
@@ -513,6 +530,9 @@ rules:
 				ServiceSubnet: "10.0.0.0/14",
 				DNSService:    "kube-system/dns",
 				Options: Options{
+					Proxy: ProxyParams{
+						Mode: ProxyModeIptables,
+					},
 					Kubelet: KubeletParams{
 						BootTaints: []corev1.Taint{
 							{

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -13,6 +13,7 @@ a YAML or JSON object with these fields:
   - [Mount](#mount)
   - [EtcdParams](#etcdparams)
   - [APIServerParams](#apiserverparams)
+  - [ProxyParams](#proxyparams)
   - [KubeletParams](#kubeletparams)
   - [SchedulerParams](#schedulerparams)
 
@@ -100,7 +101,7 @@ Options
 | `kube-api`                | false    | `APIServerParams` | Extra arguments for API server.         |
 | `kube-controller-manager` | false    | `ServiceParams`   | Extra arguments for controller manager. |
 | `kube-scheduler`          | false    | `SchedulerParams` | Extra arguments for scheduler.          |
-| `kube-proxy`              | false    | `ServiceParams`   | Extra arguments for kube-proxy.         |
+| `kube-proxy`              | false    | `ProxyParams`     | Extra arguments for kube-proxy.         |
 | `kubelet`                 | false    | `KubeletParams`   | Extra arguments for kubelet.            |
 
 ### ServiceParams
@@ -145,6 +146,17 @@ Options
 | `extra_args`        | false    | array  | Extra command-line arguments.  List of strings.       |
 | `extra_binds`       | false    | array  | Extra bind mounts.  List of `Mount`.                  |
 | `extra_env`         | false    | object | Extra environment variables.                          |
+
+### ProxyParams
+
+| Name          | Required | Type   | Description                                          |
+| ------------- | -------- | ------ | ---------------------------------------------------- |
+| `mode`        | false    | string | One of `userspace`, `iptables`, or `ipvs` (default). |
+| `extra_args`  | false    | array  | Extra command-line arguments.  List of strings.      |
+| `extra_binds` | false    | array  | Extra bind mounts.  List of `Mount`.                 |
+| `extra_env`   | false    | object | Extra environment variables.                         |
+
+Changing `mode` requires full node restarts.
 
 ### KubeletParams
 

--- a/op/k8s/proxy_restart.go
+++ b/op/k8s/proxy_restart.go
@@ -10,14 +10,14 @@ type kubeProxyRestartOp struct {
 	nodes []*cke.Node
 
 	cluster string
-	params  cke.ServiceParams
+	params  cke.ProxyParams
 
 	step  int
 	files *common.FilesBuilder
 }
 
 // KubeProxyRestartOp returns an Operator to restart kube-proxy.
-func KubeProxyRestartOp(nodes []*cke.Node, cluster string, params cke.ServiceParams) cke.Operator {
+func KubeProxyRestartOp(nodes []*cke.Node, cluster string, params cke.ProxyParams) cke.Operator {
 	return &kubeProxyRestartOp{
 		nodes:   nodes,
 		cluster: cluster,
@@ -49,13 +49,13 @@ func (o *kubeProxyRestartOp) NextCommand() cke.Commander {
 		}
 		paramsMap := make(map[string]cke.ServiceParams)
 		for _, n := range o.nodes {
-			params := ProxyParams(n)
+			params := ProxyParams(n, string(o.params.GetMode()))
 			paramsMap[n.Address] = params
 		}
 		return common.RunContainerCommand(o.nodes, op.KubeProxyContainerName, cke.KubernetesImage,
 			common.WithOpts(opts),
 			common.WithParamsMap(paramsMap),
-			common.WithExtra(o.params),
+			common.WithExtra(o.params.ServiceParams),
 			common.WithRestart())
 	default:
 		return nil

--- a/server/node_filter.go
+++ b/server/node_filter.go
@@ -560,7 +560,7 @@ func (nf *NodeFilter) ProxyOutdatedNodes() (nodes []*cke.Node) {
 
 	for _, n := range nf.cluster.Nodes {
 		st := nf.nodeStatus(n).Proxy
-		currentBuiltIn := k8s.ProxyParams(n)
+		currentBuiltIn := k8s.ProxyParams(n, string(currentExtra.GetMode()))
 		switch {
 		case !st.Running:
 			// stopped nodes are excluded

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -327,7 +327,7 @@ func (d testData) withProxy() testData {
 		st.Running = true
 		st.IsHealthy = true
 		st.Image = cke.KubernetesImage.Name()
-		st.BuiltInParams = k8s.ProxyParams(n)
+		st.BuiltInParams = k8s.ProxyParams(n, "ipvs")
 	}
 	return d
 }

--- a/sonobuoy/Makefile
+++ b/sonobuoy/Makefile
@@ -60,7 +60,7 @@ sonobuoy: bin/sonobuoy
 	$(CKECLI) kubernetes issue --ttl=10h > .kubeconfig
 	time ./bin/sonobuoy run --mode=certified-conformance --timeout=14400 --wait
 	outfile=$$(./bin/sonobuoy retrieve) && mv $$outfile sonobuoy.tar.gz
-	-./bin/sonobuoy e2e sonobuoy.tar.gz
+	./bin/sonobuoy e2e sonobuoy.tar.gz 2>&1 | tee e2e-check.log
 	./bin/sonobuoy delete
 
 clean:

--- a/sonobuoy/cke-cluster.yml.template
+++ b/sonobuoy/cke-cluster.yml.template
@@ -19,3 +19,5 @@ options:
     extra_args:
       - "--allocate-node-cidrs=true"
       - "--cluster-cidr=192.168.0.0/16"
+  kube-proxy:
+    mode: iptables

--- a/testdata/cluster.yaml
+++ b/testdata/cluster.yaml
@@ -59,6 +59,7 @@ options:
       extra_args:
       - arg1
   kube-proxy:
+    mode: iptables
     extra_args:
       - arg1
   kubelet:


### PR DESCRIPTION
CKE has run kube-proxy only in IPVS mode.
It now allows users to run kube-proxy in any supported mode.

This PR also contains a commit for the sonobuoy test to work around https://github.com/kubernetes/kubernetes/pull/94968