### PR TITLE
rivers: fix a bug in health checker

### DIFF
--- a/op/k8s/apiserver_restart.go
+++ b/op/k8s/apiserver_restart.go
@@ -257,14 +257,12 @@ func APIServerParams(controlPlanes []*cke.Node, advertiseAddress, serviceSubnet 
 		"--etcd-compaction-interval=0",
 
 		"--bind-address=0.0.0.0",
-		"--insecure-port=0",
 		"--client-ca-file=" + op.K8sPKIPath("ca.crt"),
 		"--tls-cert-file=" + op.K8sPKIPath("apiserver.crt"),
 		"--tls-private-key-file=" + op.K8sPKIPath("apiserver.key"),
 		"--kubelet-certificate-authority=" + op.K8sPKIPath("ca.crt"),
 		"--kubelet-client-certificate=" + op.K8sPKIPath("apiserver.crt"),
 		"--kubelet-client-key=" + op.K8sPKIPath("apiserver.key"),
-		"--kubelet-https=true",
 
 		"--enable-admission-plugins=" + strings.Join(admissionPlugins, ","),
 

--- a/op/k8s/kubelet_boot.go
+++ b/op/k8s/kubelet_boot.go
@@ -374,8 +374,10 @@ func KubeletServiceParams(n *cke.Node, params cke.KubeletParams) cke.ServicePara
 		"--config=/etc/kubernetes/kubelet/config.yml",
 		"--kubeconfig=/etc/kubernetes/kubelet/kubeconfig",
 		"--hostname-override=" + n.Nodename(),
-		"--pod-infra-container-image=" + cke.PauseImage.Name(),
 		"--network-plugin=cni",
+	}
+	if params.ContainerRuntime == "docker" {
+		args = append(args, "--pod-infra-container-image="+cke.PauseImage.Name())
 	}
 	if len(params.ContainerRuntime) != 0 {
 		args = append(args, "--container-runtime="+params.ContainerRuntime)

--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 cke-tools related changes.
 
+## 1.19.2 - 2021-02-09
+
+### Changed
+
+- rivers: fix a bug in health checker (#423)
+
 ## 1.19.1 - 2021-02-08
 
 ### Added

--- a/tools/rivers/health.go
+++ b/tools/rivers/health.go
@@ -67,7 +67,10 @@ func (hc *HealthChecker) doHealthCheck(ctx context.Context, first bool) {
 	var wg sync.WaitGroup
 	for _, tu := range hc.upstreams {
 		wg.Add(1)
+
 		go func(u *Upstream) {
+			defer wg.Done()
+
 			conn, err := hc.dialer.DialContext(ctx, "tcp", u.address)
 			if errors.Is(err, context.Canceled) {
 				return


### PR DESCRIPTION
I misedited `health.go` and removed `wg.Done()`.  This adds back it.

Also, deprecated command-line flags are removed from `kue-apiserver`.
`kubelet` specifies `--pod-infra-container-image` only for Docker runtime.