### PR TITLE
server: add AuditLogPath

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -111,6 +111,7 @@ type APIServerParams struct {
 	ServiceParams   `json:",inline"`
 	AuditLogEnabled bool   `json:"audit_log_enabled"`
 	AuditLogPolicy  string `json:"audit_log_policy"`
+	AuditLogPath    string `json:"audit_log_path"`
 }
 
 // CNIConfFile is a config file for CNI plugin deployed on worker nodes by CKE.

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -139,13 +139,14 @@ Options
 
 ### APIServerParams
 
-| Name                | Required | Type   | Description                                           |
-| ------------------- | -------- | ------ | ----------------------------------------------------- |
-| `audit_log_enabled` | false    | bool   | If true, audit log will be logged to standard output. |
-| `audit_log_policy`  | false    | string | Audit policy configuration in yaml format.            |
-| `extra_args`        | false    | array  | Extra command-line arguments.  List of strings.       |
-| `extra_binds`       | false    | array  | Extra bind mounts.  List of `Mount`.                  |
-| `extra_env`         | false    | object | Extra environment variables.                          |
+| Name                | Required | Type   | Description                                              |
+| ------------------- | -------- | ------ | -------------------------------------------------------- |
+| `audit_log_enabled` | false    | bool   | If true, audit log will be logged to the specified path. |
+| `audit_log_policy`  | false    | string | Audit policy configuration in yaml format.               |
+| `audit_log_path`    | false    | string | Audit log output path. Default is standard output.       |
+| `extra_args`        | false    | array  | Extra command-line arguments.  List of strings.          |
+| `extra_binds`       | false    | array  | Extra bind mounts.  List of `Mount`.                     |
+| `extra_env`         | false    | object | Extra environment variables.                             |
 
 ### ProxyParams
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -28,7 +28,9 @@ To view general logs of a apiserver, use `journalctl` as follows:
 $ sudo journalctl CONTAINER_NAME=kube-apiserver -p 3
 ```
 
-To view audit-logs of a apiserver, use `journalctl` as follows:
+You can send the audit log of a apiserver to either of journal log or file.
+
+If the log is sent to journal log, you can see it using `journalctl` as follows:
 
 ```console
 $ sudo journalctl CONTAINER_NAME=kube-apiserver -p 6..6

--- a/mtest/cke-cluster.yml
+++ b/mtest/cke-cluster.yml
@@ -20,6 +20,10 @@ options:
   kube-api:
     extra_args:
     - --enable-admission-plugins=PodSecurityPolicy
+    extra_binds:
+    - source: /var/log/audit
+      destination: /var/log/audit
+      read_only: false
   kube-scheduler:
     config:
       apiVersion: kubescheduler.config.k8s.io/v1beta1

--- a/op/k8s/apiserver_restart.go
+++ b/op/k8s/apiserver_restart.go
@@ -84,7 +84,7 @@ func (o *apiServerRestartOp) NextCommand() cke.Commander {
 		}
 		paramsMap := make(map[string]cke.ServiceParams)
 		for _, n := range o.nodes {
-			paramsMap[n.Address] = APIServerParams(o.cps, n.Address, o.serviceSubnet, o.params.AuditLogEnabled, o.params.AuditLogPolicy)
+			paramsMap[n.Address] = APIServerParams(o.cps, n.Address, o.serviceSubnet, o.params.AuditLogEnabled, o.params.AuditLogPolicy, o.params.AuditLogPath)
 		}
 		return common.RunContainerCommand(o.nodes,
 			op.KubeAPIServerContainerName, cke.KubernetesImage,
@@ -245,7 +245,7 @@ func auditPolicyFilePath(policy string) string {
 }
 
 // APIServerParams returns parameters for API server.
-func APIServerParams(controlPlanes []*cke.Node, advertiseAddress, serviceSubnet string, auditLogEnabeled bool, auditLogPolicy string) cke.ServiceParams {
+func APIServerParams(controlPlanes []*cke.Node, advertiseAddress, serviceSubnet string, auditLogEnabeled bool, auditLogPolicy string, auditLogPath string) cke.ServiceParams {
 	args := []string{
 		"kube-apiserver",
 		"--allow-privileged",
@@ -290,7 +290,11 @@ func APIServerParams(controlPlanes []*cke.Node, advertiseAddress, serviceSubnet 
 		"--encryption-provider-config=" + encryptionConfigFile,
 	}
 	if auditLogEnabeled {
-		args = append(args, "--audit-log-path=-")
+		logPath := "-"
+		if auditLogPath != "" {
+			logPath = auditLogPath
+		}
+		args = append(args, "--audit-log-path="+logPath)
 		args = append(args, "--audit-policy-file="+auditPolicyFilePath(auditLogPolicy))
 	}
 

--- a/server/node_filter.go
+++ b/server/node_filter.go
@@ -298,7 +298,7 @@ func (nf *NodeFilter) APIServerOutdatedNodes() (nodes []*cke.Node) {
 	for _, n := range nf.cp {
 		st := nf.nodeStatus(n).APIServer
 		currentBuiltIn := k8s.APIServerParams(nf.ControlPlane(), n.Address, nf.cluster.ServiceSubnet,
-			currentExtra.AuditLogEnabled, currentExtra.AuditLogPolicy)
+			currentExtra.AuditLogEnabled, currentExtra.AuditLogPolicy, currentExtra.AuditLogPath)
 		switch {
 		case !st.Running:
 			// stopped nodes are excluded

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -252,7 +252,7 @@ func (d testData) withAPIServer(serviceSubnet string) testData {
 		st.Running = true
 		st.IsHealthy = true
 		st.Image = cke.KubernetesImage.Name()
-		st.BuiltInParams = k8s.APIServerParams(d.ControlPlane(), n.Address, serviceSubnet, false, "")
+		st.BuiltInParams = k8s.APIServerParams(d.ControlPlane(), n.Address, serviceSubnet, false, "", "")
 	}
 	return d
 }


### PR DESCRIPTION
This PR adds `audit_log_path` to `APIServerParams`.
Audit logs can be sent to either of journal log or file.
- `audit_log_path` is empty -> journal log
- `audit_log_path` is set -> specified file

`--audit-log-maxage`, `--audit-log-maxbackup`, `--audit-log-maxsize` can be set using `extra_args`.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>