### PR TITLE
Add cke-localproxy

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,7 +29,6 @@ jobs:
   mtest:
     name: Mtest
     runs-on: ubuntu-20.04
-    needs: build
     strategy:
       matrix:
         suite: [functions, robustness, operators]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project employs a versioning scheme described in [RELEASE.md](RELEASE.md#ve
 
 ## [Unreleased]
 
+### Added
+- New optional service `cke-localproxy` (#433)
+
 ## [1.19.5] - 2021-03-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ This repository contains these programs:
 
 * `cke`: the service.
 * `ckecli`: CLI tool for `cke`.
+* `cke-localproxy`: an optional service to run kube-proxy on the same host as CKE.
 
 To see their usage, run them with `-h` option.
 
@@ -136,7 +137,7 @@ $ docker run -d --read-only \
     quay.io/cybozu/cke:1.18 [options...]
 ```
 
-### Install `ckecli` to host file system
+### Install `ckecli` and `cke-localproxy` to a host directory
 
 ```console
 $ docker run --rm -u root:root \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,7 @@ FROM quay.io/cybozu/ubuntu:20.04
 
 COPY cke /usr/local/cke/bin/cke
 COPY ckecli /usr/local/cke/bin/ckecli
+COPY cke-localproxy /usr/local/cke/bin/cke-localproxy
 COPY install-tools /usr/local/cke/install-tools
 
 RUN chmod -R +xr /usr/local/cke

--- a/docker/install-tools
+++ b/docker/install-tools
@@ -3,4 +3,5 @@
 DEST=/host
 
 cp --remove-destination /usr/local/cke/bin/ckecli $DEST/ckecli
-chmod 755 $DEST/ckecli
+cp --remove-destination /usr/local/cke/bin/cke-localproxy $DEST/cke-localproxy
+chmod 755 $DEST/ckecli $DEST/cke-localproxy

--- a/docs/cke-localproxy.md
+++ b/docs/cke-localproxy.md
@@ -1,0 +1,35 @@
+# cke-localproxy command reference
+
+`cke-localproxy` is an optional service that runs on the same host as CKE.
+
+It runs `kube-proxy` and a node local DNS service to allow programs running
+on the same host to access Kubernetes Services.
+
+## Prerequisites
+
+`cke-localproxy` depends on Docker.
+The user account that runs `cke-localproxy` therefore should be granted to use Docker.
+
+In order to run the local DNS service, you may need to disable `systemd-resolved.service`.
+
+To access Kubernetes Services, the host needs to be able to communicates with Kubernetes Pods.
+
+## Configuration
+
+To resolve Service DNS names, configure `/etc/resolv.conf` like this:
+
+```
+nameserver 127.0.0.1
+search cluster.local
+```
+
+## Synopsis
+
+```
+Usage of cke-localproxy:
+      --config string       configuration file path (default "/etc/cke/config.yml")
+      --interval duration   check interval (default 1m0s)
+      --logfile string      Log filename
+      --logformat string    Log format [plain,logfmt,json]
+      --loglevel string     Log level [critical,error,warning,info,debug]
+```

--- a/docs/cke-localproxy.md
+++ b/docs/cke-localproxy.md
@@ -12,7 +12,7 @@ The user account that runs `cke-localproxy` therefore should be granted to use D
 
 In order to run the local DNS service, you may need to disable `systemd-resolved.service`.
 
-To access Kubernetes Services, the host needs to be able to communicates with Kubernetes Pods.
+To access Kubernetes Services, the host needs to be able to communicate with Kubernetes Pods.
 
 ## Configuration
 
@@ -21,6 +21,7 @@ To resolve Service DNS names, configure `/etc/resolv.conf` like this:
 ```
 nameserver 127.0.0.1
 search cluster.local
+options ndots:3
 ```
 
 ## Synopsis

--- a/docs/cke.md
+++ b/docs/cke.md
@@ -1,6 +1,9 @@
 cke command reference
 =====================
 
+`cke` installs and maintains a Kubernetes cluster.
+It uses etcd as data storage and to elect a leader instance.
+
 Usage
 -----
 

--- a/localproxy/infrastructure.go
+++ b/localproxy/infrastructure.go
@@ -1,0 +1,331 @@
+package localproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/cybozu-go/cke"
+	"github.com/cybozu-go/well"
+	vault "github.com/hashicorp/vault/api"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+var kubeHTTP cke.KubeHTTP
+
+type localInfra struct {
+	storage cke.Storage
+	vc      *vault.Client
+}
+
+var _ cke.Infrastructure = &localInfra{}
+
+func newInfrastructure(storage cke.Storage) cke.Infrastructure {
+	return &localInfra{storage: storage}
+}
+
+func (i *localInfra) Close() {}
+
+func (i *localInfra) Agent(addr string) cke.Agent {
+	panic("not implemented") // TODO: Implement
+}
+
+func (i *localInfra) Engine(addr string) cke.ContainerEngine {
+	return localDocker{}
+}
+
+func (i *localInfra) Vault() (*vault.Client, error) {
+	if i.vc != nil {
+		return i.vc, nil
+	}
+
+	cfg, err := i.Storage().GetVaultConfig(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	vc, _, err := cke.VaultClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	i.vc = vc
+	return vc, nil
+}
+
+func (i *localInfra) Storage() cke.Storage {
+	return i.storage
+}
+
+func (i *localInfra) NewEtcdClient(ctx context.Context, endpoints []string) (*clientv3.Client, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (i *localInfra) K8sConfig(ctx context.Context, n *cke.Node) (*rest.Config, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (i *localInfra) K8sClient(ctx context.Context, n *cke.Node) (*kubernetes.Clientset, error) {
+	if err := kubeHTTP.Init(ctx, i); err != nil {
+		return nil, err
+	}
+
+	c, k, err := kubeHTTP.GetCert(ctx, i)
+	if err != nil {
+		return nil, err
+	}
+	tlsCfg := rest.TLSClientConfig{
+		CertData: []byte(c),
+		KeyData:  []byte(k),
+		CAData:   []byte(kubeHTTP.CACert()),
+	}
+	cfg := &rest.Config{
+		Host:            "https://" + n.Address + ":6443",
+		TLSClientConfig: tlsCfg,
+		Timeout:         5 * time.Second,
+	}
+	return kubernetes.NewForConfig(cfg)
+}
+
+func (i *localInfra) HTTPClient() *well.HTTPClient {
+	panic("not implemented") // TODO: Implement
+}
+
+func (i *localInfra) HTTPSClient(ctx context.Context) (*well.HTTPClient, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+type localDocker struct{}
+
+var _ cke.ContainerEngine = localDocker{}
+
+// PullImage pulls an image.
+func (l localDocker) PullImage(img cke.Image) error {
+	cmd := exec.Command("docker", "image", "list", "--format={{.Repository}}:{{.Tag}}")
+	stdout, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to execute docker image list: %w", err)
+	}
+
+	for _, i := range strings.Fields(string(stdout)) {
+		if img.Name() == i {
+			return nil
+		}
+	}
+
+	return exec.Command("docker", "image", "pull", img.Name()).Run()
+}
+
+// Run runs a container as a foreground process.
+func (l localDocker) Run(img cke.Image, binds []cke.Mount, command string, args ...string) error {
+	runArgs := []string{
+		"run",
+		"--log-driver=journald",
+		"--rm",
+		"--network=host",
+		"--uts=host",
+		"--read-only",
+	}
+	for _, m := range binds {
+		o := "rw"
+		if m.ReadOnly {
+			o = "ro"
+		}
+		runArgs = append(runArgs, fmt.Sprintf("--volume=%s:%s:%s", m.Source, m.Destination, o))
+	}
+	runArgs = append(runArgs, img.Name(), command)
+	runArgs = append(runArgs, args...)
+
+	out, err := exec.Command("docker", runArgs...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run %s: %s: %w", img.Name(), out, err)
+	}
+	return nil
+}
+
+// RunWithInput runs a container as a foreground process with stdin as a string.
+func (l localDocker) RunWithInput(img cke.Image, binds []cke.Mount, command, input string, args ...string) error {
+	runArgs := []string{
+		"run",
+		"--log-driver=journald",
+		"--rm",
+		"-i",
+		"--network=host",
+		"--uts=host",
+		"--read-only",
+	}
+	for _, m := range binds {
+		o := "rw"
+		if m.ReadOnly {
+			o = "ro"
+		}
+		runArgs = append(runArgs, fmt.Sprintf("--volume=%s:%s:%s", m.Source, m.Destination, o))
+	}
+	runArgs = append(runArgs, img.Name(), command)
+	runArgs = append(runArgs, args...)
+
+	cmd := exec.Command("docker", runArgs...)
+	cmd.Stdin = bytes.NewReader([]byte(input))
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run %s: %s: %w", img.Name(), out, err)
+	}
+	return nil
+}
+
+/// RunWithOutput runs a container as a foreground process and get stdout and stderr.
+func (l localDocker) RunWithOutput(img cke.Image, binds []cke.Mount, command string, args ...string) ([]byte, []byte, error) {
+	runArgs := []string{
+		"run",
+		"--log-driver=journald",
+		"--rm",
+		"--network=host",
+		"--uts=host",
+		"--read-only",
+	}
+	for _, m := range binds {
+		o := "rw"
+		if m.ReadOnly {
+			o = "ro"
+		}
+		runArgs = append(runArgs, fmt.Sprintf("--volume=%s:%s:%s", m.Source, m.Destination, o))
+	}
+	runArgs = append(runArgs, img.Name(), command)
+	runArgs = append(runArgs, args...)
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd := exec.Command("docker", runArgs...)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	err := cmd.Run()
+	return stdout.Bytes(), stderr.Bytes(), err
+}
+
+// RunSystem runs the named container as a system service.
+func (l localDocker) RunSystem(name string, img cke.Image, opts []string, params cke.ServiceParams, extra cke.ServiceParams) error {
+	args := []string{
+		"run",
+		"--rm",
+		"--log-driver=journald",
+		"-d",
+		"--name=" + name,
+		"--read-only",
+		"--network=host",
+		"--uts=host",
+	}
+	args = append(args, opts...)
+
+	for _, m := range append(params.ExtraBinds, extra.ExtraBinds...) {
+		var opts []string
+		if m.ReadOnly {
+			opts = append(opts, "ro")
+		}
+		if len(m.Propagation) > 0 {
+			opts = append(opts, m.Propagation.String())
+		}
+		if len(m.Label) > 0 {
+			opts = append(opts, m.Label.String())
+		}
+		args = append(args, fmt.Sprintf("--volume=%s:%s:%s", m.Source, m.Destination, strings.Join(opts, ",")))
+	}
+	for k, v := range params.ExtraEnvvar {
+		args = append(args, "-e", fmt.Sprintf("%s=%s", k, v))
+	}
+	for k, v := range extra.ExtraEnvvar {
+		args = append(args, "-e", fmt.Sprintf("%s=%s", k, v))
+	}
+
+	type ckeLabel struct {
+		BuiltInParams cke.ServiceParams `json:"builtin"`
+		ExtraParams   cke.ServiceParams `json:"extra"`
+	}
+
+	label := ckeLabel{
+		BuiltInParams: params,
+		ExtraParams:   extra,
+	}
+	data, err := json.Marshal(label)
+	if err != nil {
+		return err
+	}
+	labelFile, err := os.CreateTemp("", "cke-")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		labelFile.Close()
+		os.Remove(labelFile.Name())
+	}()
+	if _, err := io.WriteString(labelFile, cke.CKELabelName+"="+string(data)); err != nil {
+		return err
+	}
+	args = append(args, "--label-file="+labelFile.Name())
+
+	args = append(args, img.Name())
+
+	args = append(args, params.ExtraArguments...)
+	args = append(args, extra.ExtraArguments...)
+
+	out, err := exec.Command("docker", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to docker run %s: %s: %w", img.Name(), out, err)
+	}
+	return nil
+}
+
+// Exists returns if named system container exists.
+func (l localDocker) Exists(name string) (bool, error) {
+	args := []string{
+		"ps", "-a", "--no-trunc", "--filter=name=^/" + name + "$", "--format={{.ID}}",
+	}
+	stdout, err := exec.Command("docker", args...).Output()
+	if err != nil {
+		return false, fmt.Errorf("failed to run docker ps: %w", err)
+	}
+	return len(bytes.TrimSpace(stdout)) > 0, nil
+}
+
+// Stop stops the named system container.
+func (l localDocker) Stop(name string) error {
+	return exec.Command("docker", "container", "stop", name).Run()
+}
+
+// Kill kills the named system container.
+func (l localDocker) Kill(name string) error {
+	return exec.Command("docker", "container", "kill", name).Run()
+}
+
+// Remove removes the named system container.
+func (l localDocker) Remove(name string) error {
+	return exec.Command("docker", "container", "rm", name).Run()
+}
+
+// Inspect returns ServiceStatus for the named container.
+func (l localDocker) Inspect(name []string) (map[string]cke.ServiceStatus, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+// VolumeCreate creates a local volume.
+func (l localDocker) VolumeCreate(name string) error {
+	panic("not implemented") // TODO: Implement
+}
+
+// VolumeRemove creates a local volume.
+func (l localDocker) VolumeRemove(name string) error {
+	panic("not implemented") // TODO: Implement
+}
+
+// VolumeExists returns true if the named volume exists.
+func (l localDocker) VolumeExists(name string) (bool, error) {
+	panic("not implemented") // TODO: Implement
+}

--- a/localproxy/op.go
+++ b/localproxy/op.go
@@ -1,0 +1,117 @@
+package localproxy
+
+import (
+	"context"
+
+	"github.com/cybozu-go/cke"
+	"github.com/cybozu-go/cke/op/common"
+)
+
+type unboundBootOp struct {
+	conf []byte
+
+	step int
+}
+
+var localNode = &cke.Node{
+	Address: "localhost",
+}
+
+var ckeNodes = []*cke.Node{localNode}
+
+var _ cke.Operator = &unboundBootOp{}
+
+const unboundContainerName = "cke-unbound"
+
+// Name returns the operation name.
+func (o *unboundBootOp) Name() string {
+	return "unbound-boot-op"
+}
+
+// NextCommand returns the next command or nil if completed.
+func (o *unboundBootOp) NextCommand() cke.Commander {
+	defer func() { o.step++ }()
+
+	switch o.step {
+	case 0:
+		return common.ImagePullCommand(ckeNodes, cke.UnboundImage)
+	case 1:
+		files := common.NewFilesBuilder(ckeNodes)
+		files.AddFile(context.Background(), "/etc/unbound/unbound.conf", func(context.Context, *cke.Node) ([]byte, error) {
+			return o.conf, nil
+		})
+		return files
+	case 2:
+		return common.RunContainerCommand(ckeNodes, unboundContainerName, cke.UnboundImage,
+			common.WithOpts([]string{"--cap-add=NET_BIND_SERVICE"}),
+			common.WithParams(cke.ServiceParams{
+				ExtraArguments: []string{"-c", "/etc/unbound/unbound.conf"},
+				ExtraBinds: []cke.Mount{
+					{
+						Source:      "/etc/unbound",
+						Destination: "/etc/unbound",
+						ReadOnly:    true,
+					},
+				},
+			}),
+		)
+	default:
+		return nil
+	}
+}
+
+// Targets returns the ip which will be affected by the operation
+func (o *unboundBootOp) Targets() []string {
+	return []string{"localhost"}
+}
+
+type unboundRestartOp struct {
+	conf []byte
+
+	step int
+}
+
+var _ cke.Operator = &unboundRestartOp{}
+
+// Name returns the operation name.
+func (o *unboundRestartOp) Name() string {
+	return "unbound-restart-op"
+}
+
+// NextCommand returns the next command or nil if completed.
+func (o *unboundRestartOp) NextCommand() cke.Commander {
+	defer func() { o.step++ }()
+
+	switch o.step {
+	case 0:
+		return common.ImagePullCommand(ckeNodes, cke.UnboundImage)
+	case 1:
+		files := common.NewFilesBuilder(ckeNodes)
+		files.AddFile(context.Background(), "/etc/unbound/unbound.conf", func(context.Context, *cke.Node) ([]byte, error) {
+			return o.conf, nil
+		})
+		return files
+	case 2:
+		return common.RunContainerCommand(ckeNodes, unboundContainerName, cke.UnboundImage,
+			common.WithOpts([]string{"--cap-add=NET_BIND_SERVICE"}),
+			common.WithParams(cke.ServiceParams{
+				ExtraArguments: []string{"-c", "/etc/unbound/unbound.conf"},
+				ExtraBinds: []cke.Mount{
+					{
+						Source:      "/etc/unbound",
+						Destination: "/etc/unbound",
+						ReadOnly:    true,
+					},
+				},
+			}),
+			common.WithRestart(),
+		)
+	default:
+		return nil
+	}
+}
+
+// Targets returns the ip which will be affected by the operation
+func (o *unboundRestartOp) Targets() []string {
+	return []string{"localhost"}
+}

--- a/localproxy/run.go
+++ b/localproxy/run.go
@@ -1,0 +1,119 @@
+package localproxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/cybozu-go/cke"
+	"github.com/cybozu-go/log"
+)
+
+// LocalProxy is the controller of kube-proxy and unbound running on the same server as CKE.
+type LocalProxy struct {
+	Interval time.Duration
+	Storage  cke.Storage
+
+	currentAP string
+}
+
+// Run starts the controller.
+func (c *LocalProxy) Run(ctx context.Context) error {
+	tick := time.NewTicker(c.Interval)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-tick.C:
+			if err := c.runOnce(ctx); err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (c *LocalProxy) runOnce(ctx context.Context) error {
+	inf := newInfrastructure(c.Storage)
+	defer inf.Close()
+
+	cluster, err := c.Storage.GetCluster(ctx)
+	if errors.Is(err, cke.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get cluster: %w", err)
+	}
+
+	st, err := getStatus(ctx, inf)
+	if err != nil {
+		log.Error("failed to get status", map[string]interface{}{
+			log.FnError: err,
+		})
+		//lint:ignore nilerr intentional
+		return nil
+	}
+
+	ap, ops := decideOps(cluster, c.currentAP, st)
+	if len(ops) == 0 {
+		return nil
+	}
+
+	c.currentAP = ap
+
+	for _, op := range ops {
+		if err := runOp(ctx, op, inf); err != nil {
+			log.Error("failed to run an operation", map[string]interface{}{
+				"op":        op.Name(),
+				log.FnError: err,
+			})
+		}
+	}
+	return nil
+}
+
+func runOp(ctx context.Context, op cke.Operator, inf cke.Infrastructure) error {
+	log.Info("begin new operation", map[string]interface{}{
+		"op": op.Name(),
+	})
+
+	for {
+		commander := op.NextCommand()
+		if commander == nil {
+			break
+		}
+
+		// check the context before proceed
+		select {
+		case <-ctx.Done():
+			log.Info("interrupt the operation due to cancellation", map[string]interface{}{
+				"op": op.Name(),
+			})
+			return nil
+		default:
+		}
+
+		log.Info("execute a command", map[string]interface{}{
+			"op":      op.Name(),
+			"command": commander.Command().String(),
+		})
+		err := commander.Run(ctx, inf, "")
+		if err == nil {
+			continue
+		}
+		log.Error("command failed", map[string]interface{}{
+			log.FnError: err,
+			"op":        op.Name(),
+			"command":   commander.Command().String(),
+		})
+		return err
+	}
+
+	log.Info("operation completed", map[string]interface{}{
+		"op": op.Name(),
+	})
+	return nil
+
+}

--- a/localproxy/status.go
+++ b/localproxy/status.go
@@ -1,0 +1,142 @@
+package localproxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/cybozu-go/cke"
+	"github.com/cybozu-go/cke/op/k8s"
+	"github.com/cybozu-go/cke/op/nodedns"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// the current status for running local proxy
+type status struct {
+	apiServers   []string
+	proxyRunning bool
+	proxyImage   string
+
+	unboundConf        []byte
+	desiredUnboundConf []byte
+	unboundRunning     bool
+	unboundImage       string
+}
+
+var dialer = &net.Dialer{
+	Timeout: 5 * time.Second,
+}
+
+func isRunning(name string) (bool, string, error) {
+	stdout, err := exec.Command("docker", "ps", "--format={{.Names}} {{.Image}}").Output()
+	if err != nil {
+		return false, "", fmt.Errorf("failed to run docker ps: %w", err)
+	}
+
+	for _, line := range strings.Split(string(stdout), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		if fields[0] != name {
+			continue
+		}
+		return true, fields[1], nil
+	}
+	return false, "", nil
+}
+
+func getStatus(ctx context.Context, inf cke.Infrastructure) (*status, error) {
+	cluster, err := inf.Storage().GetCluster(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var apiServer *cke.Node
+	var apiServers []string
+	for _, n := range cluster.Nodes {
+		if !n.ControlPlane {
+			continue
+		}
+		conn, err := dialer.DialContext(ctx, "tcp", n.Address+":6443")
+		if err != nil {
+			continue
+		}
+		conn.Close()
+		if apiServer == nil {
+			apiServer = n
+		}
+		apiServers = append(apiServers, n.Address)
+	}
+
+	if len(apiServers) == 0 {
+		return nil, errors.New("no kube-apiserver is available")
+	}
+
+	proxyRunning, proxyImage, err := isRunning("kube-proxy")
+	if err != nil {
+		return nil, err
+	}
+
+	unboundConf, err := os.ReadFile("/etc/unbound/unbound.conf")
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	cs, err := inf.K8sClient(ctx, apiServer)
+	if err != nil {
+		return nil, err
+	}
+
+	clusterDNS, err := cs.CoreV1().Services("kube-system").Get(ctx, "cluster-dns", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cluster-dns service: %w", err)
+	}
+	if len(clusterDNS.Spec.ClusterIP) == 0 {
+		return nil, errors.New("no clusterIP has been assigned to cluster-dns")
+	}
+
+	kubeletConfig := k8s.GenerateKubeletConfiguration(cluster.Options.Kubelet, "0.0.0.0", nil)
+	domain := kubeletConfig.ClusterDomain
+
+	dnsServers := cluster.DNSServers
+	if cluster.DNSService != "" {
+		fields := strings.Split(cluster.DNSService, "/")
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("invalid service reference in cluster config: %s", cluster.DNSService)
+		}
+
+		svc, err := cs.CoreV1().Services(fields[0]).Get(ctx, fields[1], metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get public dns service %s: %w", cluster.DNSService, err)
+		}
+		if len(svc.Spec.ClusterIP) == 0 {
+			dnsServers = nil
+		} else {
+			dnsServers = []string{svc.Spec.ClusterIP}
+		}
+	}
+
+	unboundConfigMap := nodedns.ConfigMap(clusterDNS.Spec.ClusterIP, domain, dnsServers)
+
+	unboundRunning, unboundImage, err := isRunning("cke-unbound")
+	if err != nil {
+		return nil, err
+	}
+
+	return &status{
+		apiServers:   apiServers,
+		proxyRunning: proxyRunning,
+		proxyImage:   proxyImage,
+
+		unboundConf:        unboundConf,
+		desiredUnboundConf: []byte(unboundConfigMap.Data["unbound.conf"]),
+		unboundRunning:     unboundRunning,
+		unboundImage:       unboundImage,
+	}, nil
+}

--- a/localproxy/strategy.go
+++ b/localproxy/strategy.go
@@ -1,0 +1,44 @@
+package localproxy
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/cybozu-go/cke"
+	"github.com/cybozu-go/cke/op/k8s"
+)
+
+func decideOps(c *cke.Cluster, currentAP string, st *status) (newAP string, ops []cke.Operator) {
+	if len(st.apiServers) == 0 {
+		return
+	}
+
+	newAP = st.apiServers[0]
+	for _, n := range st.apiServers {
+		if n == currentAP {
+			newAP = currentAP
+			break
+		}
+	}
+
+	apURL := fmt.Sprintf("https://%s:6443", newAP)
+
+	if !st.proxyRunning {
+		ops = append(ops, k8s.KubeProxyBootOp(ckeNodes, c.Name, apURL, c.Options.Proxy))
+	} else {
+		if newAP != currentAP || st.proxyImage != cke.KubernetesImage.Name() {
+			ops = append(ops, k8s.KubeProxyRestartOp(ckeNodes, c.Name, apURL, c.Options.Proxy))
+		}
+	}
+
+	if !st.unboundRunning {
+		ops = append(ops, &unboundBootOp{conf: st.desiredUnboundConf})
+		return
+	}
+
+	if !bytes.Equal(st.unboundConf, st.desiredUnboundConf) || st.unboundImage != cke.UnboundImage.Name() {
+		ops = append(ops, &unboundRestartOp{conf: st.desiredUnboundConf})
+	}
+
+	return
+}

--- a/mtest/Makefile
+++ b/mtest/Makefile
@@ -115,7 +115,7 @@ $(DATA_DIR)/vault: $(VAULT_ARCHIVE)
 	unzip $< -d $(DATA_DIR)
 	touch $@
 
-$(OUTPUT)/cke $(OUTPUT)/ckecli: FORCE
+$(OUTPUT)/cke $(OUTPUT)/ckecli $(OUTPUT)/cke-localproxy: FORCE
 	mkdir -p $(OUTPUT)
 	cd ..; gofail enable op/etcd && \
 		if GOBIN=$(realpath $(OUTPUT)) go install ./pkg/$(notdir $@); then \
@@ -125,10 +125,11 @@ $(OUTPUT)/cke $(OUTPUT)/ckecli: FORCE
 			exit 1; \
 		fi
 
-$(OUTPUT)/cke.img: $(OUTPUT)/cke $(OUTPUT)/ckecli
+$(OUTPUT)/cke.img: $(OUTPUT)/cke $(OUTPUT)/ckecli $(OUTPUT)/cke-localproxy
 	cp ../LICENSE $(shell pwd)/../docker
 	cp $(OUTPUT)/cke ../docker/
 	cp $(OUTPUT)/ckecli ../docker/
+	cp $(OUTPUT)/cke-localproxy ../docker/
 	sudo docker build --no-cache --rm=false -t $(CKE_IMAGE_URL) ../docker/
 	mkdir -p $(OUTPUT)
 	rm -f $@
@@ -150,6 +151,7 @@ $(DATA_DIR)/setup-cke.sh: setup-cke.sh
 $(DATA_DIR)/mtest_key: $(SSH_PRIVKEY)
 	mkdir -p $(DATA_DIR)
 	cp $< $@
+	chmod 644 $@
 
 $(OUTPUT)/cluster.yml: cluster.yml
 	mkdir -p $(OUTPUT)

--- a/mtest/host.ign
+++ b/mtest/host.ign
@@ -16,6 +16,12 @@
       },
       {
         "filesystem": "root",
+        "path": "/etc/resolv.conf",
+        "mode": 420,
+        "contents": { "source": "data:,nameserver%208.8.8.8%0A" }
+      },
+      {
+        "filesystem": "root",
         "path": "/etc/cke/config.yml",
         "mode": 420,
         "contents": { "source": "data:,endpoints%3a%0d%0a%20%20%2d%20http%3a%2f%2f__HOST1__%3a2379%0d%0a" }
@@ -56,6 +62,10 @@
       {
         "mask": true,
         "name": "locksmithd.service"
+      },
+      {
+        "mask": true,
+        "name": "systemd-resolved.service"
       },
       {
         "name": "data.mount",

--- a/mtest/localproxy_test.go
+++ b/mtest/localproxy_test.go
@@ -33,7 +33,7 @@ func testLocalProxy() {
 		Consistently(func() error {
 			stdout, stderr, err := execAt(host1, "docker", "ps", "--format={{.Names}}")
 			if err != nil {
-				return fmt.Errorf("ipvsadm failed: %s: %w", stderr, err)
+				return fmt.Errorf("docker ps failed: %s: %w", stderr, err)
 			}
 
 			if bytes.Contains(stdout, []byte("cke-unbound")) {

--- a/mtest/localproxy_test.go
+++ b/mtest/localproxy_test.go
@@ -1,0 +1,45 @@
+package mtest
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func testLocalProxy() {
+	It("should run kube-localproxy on a boot server", func() {
+		execSafeAt(host1, "sudo", "systemd-run", "-u", "cke-localproxy",
+			"/opt/bin/cke-localproxy", "--interval=5s")
+	})
+
+	It("should run kube-proxy", func() {
+		Eventually(func() error {
+			stdout, stderr, err := execAt(host1, "sudo", "ipvsadm", "-L", "-n")
+			if err != nil {
+				return fmt.Errorf("ipvsadm failed: %s: %w", stderr, err)
+			}
+
+			if bytes.Contains(stdout, []byte("10.34.56.1:443")) {
+				return nil
+			}
+			return errors.New("kube-proxy has not configured proxy rules yet")
+		}).Should(Succeed())
+	})
+
+	It("should run unbound", func() {
+		Consistently(func() error {
+			stdout, stderr, err := execAt(host1, "docker", "ps", "--format={{.Names}}")
+			if err != nil {
+				return fmt.Errorf("ipvsadm failed: %s: %w", stderr, err)
+			}
+
+			if bytes.Contains(stdout, []byte("cke-unbound")) {
+				return nil
+			}
+			return errors.New("cke-unbound service is not running")
+		}, 5, 0.1).Should(Succeed())
+	})
+}

--- a/mtest/run_test.go
+++ b/mtest/run_test.go
@@ -388,10 +388,7 @@ func ckecliClusterSet(cluster *cke.Cluster) (time.Time, error) {
 		return time.Time{}, err
 	}
 
-	// TODO: remove this workaround added in #334
-	data := string(y) + "\npod_subnet: 10.1.0.0/16"
-
-	rf := remoteTempFile(data)
+	rf := remoteTempFile(string(y))
 	stdout, stderr, err := ckecli("cluster", "set", rf)
 	if err != nil {
 		return time.Now(), fmt.Errorf("failed to execute cluster set command. stdout: %v, stderr: %v, err: %v", string(stdout), string(stderr), err)

--- a/mtest/suite_test.go
+++ b/mtest/suite_test.go
@@ -138,6 +138,7 @@ var _ = Describe("Test CKE", func() {
 	switch testSuite {
 	case "functions":
 		Context("ckecli", testCKECLI)
+		Context("local-proxy", testLocalProxy)
 		Context("kubernetes", testKubernetes)
 	case "operators":
 		Context("operators", func() {

--- a/op/common/mkdirs.go
+++ b/op/common/mkdirs.go
@@ -46,17 +46,13 @@ func (c makeDirsCommand) Run(ctx context.Context, inf cke.Infrastructure, _ stri
 		binds = append(binds, m)
 	}
 
-	args := append([]string{
-		"make_directories",
-		"--mode=" + c.mode,
-	}, dests...)
-	arg := strings.Join(args, " ")
+	args := append([]string{"--mode=" + c.mode}, dests...)
 
 	env := well.NewEnvironment(ctx)
 	for _, n := range c.nodes {
 		ce := inf.Engine(n.Address)
 		env.Go(func(ctx context.Context) error {
-			return ce.Run(cke.ToolsImage, binds, arg)
+			return ce.Run(cke.ToolsImage, binds, "make_directories", args...)
 		})
 	}
 	env.Stop()

--- a/op/common/mkfiles.go
+++ b/op/common/mkfiles.go
@@ -137,9 +137,8 @@ func (c *FilesBuilder) Run(ctx context.Context, inf cke.Infrastructure, _ string
 			}
 			data := buf.String()
 
-			arg := "write_files /mnt"
 			ce := inf.Engine(n.Address)
-			return ce.RunWithInput(cke.ToolsImage, binds, arg, data)
+			return ce.RunWithInput(cke.ToolsImage, binds, "write_files", data, "/mnt")
 		})
 	}
 	env.Stop()

--- a/op/k8s/config.go
+++ b/op/k8s/config.go
@@ -75,8 +75,11 @@ func GenerateSchedulerConfiguration(params cke.SchedulerParams) *schedulerv1beta
 	return c
 }
 
-func proxyKubeconfig(cluster string, ca, clientCrt, clientKey string) *api.Config {
-	return cke.Kubeconfig(cluster, "system:kube-proxy", ca, clientCrt, clientKey)
+func proxyKubeconfig(cluster, ca, clientCrt, clientKey, server string) *api.Config {
+	if server == "" {
+		return cke.Kubeconfig(cluster, "system:kube-proxy", ca, clientCrt, clientKey)
+	}
+	return cke.UserKubeconfig(cluster, "system:kube-proxy", ca, clientCrt, clientKey, server)
 }
 
 func kubeletKubeconfig(cluster string, n *cke.Node, caPath, certPath, keyPath string) *api.Config {

--- a/op/k8s/proxy_restart.go
+++ b/op/k8s/proxy_restart.go
@@ -10,6 +10,7 @@ type kubeProxyRestartOp struct {
 	nodes []*cke.Node
 
 	cluster string
+	ap      string
 	params  cke.ProxyParams
 
 	step  int
@@ -17,10 +18,11 @@ type kubeProxyRestartOp struct {
 }
 
 // KubeProxyRestartOp returns an Operator to restart kube-proxy.
-func KubeProxyRestartOp(nodes []*cke.Node, cluster string, params cke.ProxyParams) cke.Operator {
+func KubeProxyRestartOp(nodes []*cke.Node, cluster, ap string, params cke.ProxyParams) cke.Operator {
 	return &kubeProxyRestartOp{
 		nodes:   nodes,
 		cluster: cluster,
+		ap:      ap,
 		params:  params,
 		files:   common.NewFilesBuilder(nodes),
 	}
@@ -37,7 +39,7 @@ func (o *kubeProxyRestartOp) NextCommand() cke.Commander {
 		return common.ImagePullCommand(o.nodes, cke.KubernetesImage)
 	case 1:
 		o.step++
-		return prepareProxyFilesCommand{o.cluster, o.files}
+		return prepareProxyFilesCommand{o.cluster, o.ap, o.files}
 	case 2:
 		o.step++
 		return o.files

--- a/pkg/cke-localproxy/main.go
+++ b/pkg/cke-localproxy/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"os"
+	"time"
+
+	"github.com/cybozu-go/cke"
+	"github.com/cybozu-go/cke/localproxy"
+	"github.com/cybozu-go/etcdutil"
+	"github.com/cybozu-go/log"
+	"github.com/cybozu-go/well"
+	"github.com/spf13/pflag"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	flgConfigPath = pflag.String("config", "/etc/cke/config.yml", "configuration file path")
+	flgInterval   = pflag.Duration("interval", 1*time.Minute, "check interval")
+)
+
+func loadConfig(p string) (*etcdutil.Config, error) {
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return nil, err
+	}
+	cfg := cke.NewEtcdConfig()
+	err = yaml.Unmarshal(b, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+func main() {
+	pflag.Parse()
+	well.LogConfig{}.Apply()
+
+	cfg, err := loadConfig(*flgConfigPath)
+	if err != nil {
+		log.ErrorExit(err)
+	}
+
+	etcd, err := etcdutil.NewClient(cfg)
+	if err != nil {
+		log.ErrorExit(err)
+	}
+	defer etcd.Close()
+
+	// Controller
+	controller := localproxy.LocalProxy{Interval: *flgInterval, Storage: cke.Storage{Client: etcd}}
+	well.Go(controller.Run)
+
+	err = well.Wait()
+	if err != nil && !well.IsSignaled(err) {
+		log.ErrorExit(err)
+	}
+}

--- a/pkg/ckecli/cmd/kubernetes_issue.go
+++ b/pkg/ckecli/cmd/kubernetes_issue.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 
 	"github.com/cybozu-go/cke"
 	"github.com/cybozu-go/well"
@@ -29,12 +30,15 @@ var kubernetesIssueCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			cpNodes := cke.ControlPlanes(cluster.Nodes)
-			if len(cpNodes) == 0 {
-				return errors.New("no control plane")
-			}
 
-			server := "https://" + cpNodes[0].Address + ":6443"
+			server := "https://kubernetes.default.svc"
+			if _, err := net.LookupHost("kubernetes.default.svc"); err != nil {
+				cpNodes := cke.ControlPlanes(cluster.Nodes)
+				if len(cpNodes) == 0 {
+					return errors.New("no control plane")
+				}
+				server = "https://" + cpNodes[0].Address + ":6443"
+			}
 
 			cacert, err := storage.GetCACertificate(ctx, cke.CAKubernetes)
 			if err != nil {

--- a/server/strategy.go
+++ b/server/strategy.go
@@ -148,10 +148,10 @@ func k8sOps(c *cke.Cluster, nf *NodeFilter, cs *cke.ClusterStatus) (ops []cke.Op
 		ops = append(ops, k8s.KubeletRestartOp(nodes, c.Name, c.Options.Kubelet, cs.NodeStatuses))
 	}
 	if nodes := nf.SSHConnectedNodes(nf.ProxyStoppedNodes(), true, true); len(nodes) > 0 {
-		ops = append(ops, k8s.KubeProxyBootOp(nodes, c.Name, c.Options.Proxy))
+		ops = append(ops, k8s.KubeProxyBootOp(nodes, c.Name, "", c.Options.Proxy))
 	}
 	if nodes := nf.SSHConnectedNodes(nf.ProxyOutdatedNodes(), true, true); len(nodes) > 0 {
-		ops = append(ops, k8s.KubeProxyRestartOp(nodes, c.Name, c.Options.Proxy))
+		ops = append(ops, k8s.KubeProxyRestartOp(nodes, c.Name, "", c.Options.Proxy))
 	}
 	return ops
 }


### PR DESCRIPTION
`cke-localproxy` is a controller for running kube-proxy and unbound on the same server as CKE.

`cke-localproxy` allows programs and users on that servers to connect Kubernetes Services.

`cke-localproxy` depends on Docker.
The user account that runs `cke-localproxy` therefore needs to be able to use Docker.