### PR TITLE
Fix release-image workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,10 +22,10 @@ jobs:
             make static
             cmp /tmp/resources.go ./static/resources.go
       - run: docker run -d --network host quay.io/coreos/etcd:v3.3
-      - run: make test-tools
-      - run: make test GOBIN=$(pwd)/docker
-      - name: build-image
-        run: docker build -t quay.io/cybozu/cke:latest ./docker
+      - run: make lint
+      - run: make test
+      - run: make install GOBIN=$(pwd)/docker
+      - run: docker build -t quay.io/cybozu/cke:latest ./docker
   mtest:
     name: Mtest
     runs-on: ubuntu-20.04

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,6 @@ jobs:
             make static
             cmp /tmp/resources.go ./static/resources.go
       - run: docker run -d --network host quay.io/coreos/etcd:v3.3
-      - run: make lint
       - run: make test
       - run: make install GOBIN=$(pwd)/docker
       - run: docker build -t quay.io/cybozu/cke:latest ./docker

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -49,13 +49,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ env.go-version }}
-      - name: Check static resources
-        run: |
-            cp ./static/resources.go /tmp/resources.go
-            make static
-            cmp /tmp/resources.go ./static/resources.go
-      - run: make test-tools
-      - run: make test GOBIN=$(pwd)/docker
+      - run: make install GOBIN=$(pwd)/docker
       - run: docker build -t quay.io/cybozu/cke:latest ./docker
       - name: Push docker image to Quay.io
         run: |

--- a/Makefile
+++ b/Makefile
@@ -9,16 +9,13 @@ all: test
 setup:
 	curl -fsL https://github.com/etcd-io/etcd/releases/download/v$(ETCD_VERSION)/etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz | sudo tar -xzf - --strip-components=1 -C /usr/local/bin etcd-v$(ETCD_VERSION)-linux-amd64/etcd etcd-v$(ETCD_VERSION)-linux-amd64/etcdctl
 
-.PHONY: lint
-lint: lint-tools
+.PHONY: test
+test: test-tools
 	test -z "$$(gofmt -s -l . | tee /dev/stderr)"
 	staticcheck ./...
 	test -z "$$(nilerr ./... 2>&1 | tee /dev/stderr)"
 	test -z "$$(custom-checker -restrictpkg.packages=html/template,log ./... 2>&1 | tee /dev/stderr)"
 	go vet ./...
-
-.PHONY: test
-test:
 	go test -race -v ./...
 
 .PHONY: install
@@ -30,8 +27,8 @@ static: goimports
 	go generate ./static
 	git add ./static/resources.go
 
-.PHONY: lint-tools
-lint-tools: staticcheck nilerr goimports custom-checker
+.PHONY: test-tools
+test-tools: staticcheck nilerr goimports custom-checker
 
 .PHONY: staticcheck
 staticcheck:

--- a/Makefile
+++ b/Makefile
@@ -9,23 +9,29 @@ all: test
 setup:
 	curl -fsL https://github.com/etcd-io/etcd/releases/download/v$(ETCD_VERSION)/etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz | sudo tar -xzf - --strip-components=1 -C /usr/local/bin etcd-v$(ETCD_VERSION)-linux-amd64/etcd etcd-v$(ETCD_VERSION)-linux-amd64/etcdctl
 
-.PHONY: test
-test: test-tools
+.PHONY: lint
+lint: lint-tools
 	test -z "$$(gofmt -s -l . | tee /dev/stderr)"
 	staticcheck ./...
 	test -z "$$(nilerr ./... 2>&1 | tee /dev/stderr)"
 	test -z "$$(custom-checker -restrictpkg.packages=html/template,log ./... 2>&1 | tee /dev/stderr)"
-	go install ./pkg/...
-	go test -race -v ./...
 	go vet ./...
+
+.PHONY: test
+test:
+	go test -race -v ./...
+
+.PHONY: install
+install:
+	go install ./pkg/...
 
 .PHONY: static
 static: goimports
 	go generate ./static
 	git add ./static/resources.go
 
-.PHONY: test-tools
-test-tools: staticcheck nilerr goimports custom-checker
+.PHONY: lint-tools
+lint-tools: staticcheck nilerr goimports custom-checker
 
 .PHONY: staticcheck
 staticcheck:


### PR DESCRIPTION
release-image workflow failed
https://github.com/cybozu-go/cke/runs/2162971053?check_suite_focus=true

This failure was caused by testing without running etcd container.
However, as the test is redundant, this PR deletes the test.

Signed-off-by: binoue <banji-inoue@cybozu.co.jp>