### PR TITLE
Watch session and leader key

### DIFF
--- a/pkg/cke/main.go
+++ b/pkg/cke/main.go
@@ -93,7 +93,15 @@ func main() {
 	if err != nil {
 		log.ErrorExit(err)
 	}
-	defer session.Close()
+	defer func() {
+		// Checking the session to avoid an error caused by duplicated closing.
+		select {
+		case <-session.Done():
+			return
+		default:
+			session.Close()
+		}
+	}()
 
 	timeout, err := time.ParseDuration(cfg.Timeout)
 	if err != nil {

--- a/storage.go
+++ b/storage.go
@@ -481,15 +481,6 @@ func (s Storage) maintRecords(ctx context.Context, leaderKey string, max int64) 
 	return err
 }
 
-// IsLeader returns true if the specified leader key is valid.
-func (s Storage) IsLeader(ctx context.Context, leaderKey string) (bool, error) {
-	resp, err := s.Get(ctx, leaderKey, clientv3.WithKeysOnly())
-	if err != nil {
-		return false, err
-	}
-	return len(resp.Kvs) > 0, nil
-}
-
 // GetLeaderHostname returns the current leader's host name.
 // It returns non-nil error when there is no leader.
 func (s Storage) GetLeaderHostname(ctx context.Context) (string, error) {

--- a/storage_test.go
+++ b/storage_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/google/go-cmp/cmp"
 )
@@ -123,6 +124,14 @@ func testStorageConstraints(t *testing.T) {
 	}
 }
 
+func checkLeaderKey(ctx context.Context, s Storage, leaderKey string) (bool, error) {
+	resp, err := s.Get(ctx, leaderKey, clientv3.WithKeysOnly())
+	if err != nil {
+		return false, err
+	}
+	return len(resp.Kvs) > 0, nil
+}
+
 func testStorageRecord(t *testing.T) {
 	t.Parallel()
 
@@ -152,7 +161,7 @@ func testStorageRecord(t *testing.T) {
 
 	leaderKey := e.Key()
 
-	isLeader, err := storage.IsLeader(ctx, leaderKey)
+	isLeader, err := checkLeaderKey(ctx, storage, leaderKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,7 +330,7 @@ func testStorageRecord(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	isLeader, err = storage.IsLeader(ctx, leaderKey)
+	isLeader, err = checkLeaderKey(ctx, storage, leaderKey)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
see https://github.com/cybozu-go/cke/issues/441

When the etcd process which connected from clients stops, `concurrency.Session` in the clients is closed.
But some clientv3 functions in the clients are not canceled. This behavior cause hangs on the clients. 

So we need to check the closing of `concurrency.Session`. And cancel contexts if the session is closed.

In CKE server, there are 2 probrems.

1. `election.Campaign` in standby CKE servers hang.
2. The leader server cannot detect the loss of his leadership.

This PR will monitor the closing of `concurrency.Session` and terminate the CKE process.
This will solve the above problems.