### PR TITLE
Bump version to 1.20.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project employs a versioning scheme described in [RELEASE.md](RELEASE.md#ve
 
 ## [Unreleased]
 
+## [1.20.3] - 2021-05-27
+
+- Use etcd 3.4.16 for Kubernetes cluster (#465)
+
 ## [1.20.2] - 2021-05-17
 
 - Update revision cke.cybozu.com/revision (#462)
@@ -44,7 +48,8 @@ No change from 1.20.0-rc.1
 - See [release-1.13/CHANGELOG.md](https://github.com/cybozu-go/cke/blob/release-1.13/CHANGELOG.md) for changes in CKE 1.13.
 - See [release-1.12/CHANGELOG.md](https://github.com/cybozu-go/cke/blob/release-1.12/CHANGELOG.md) for changes in CKE 1.12.
 
-[Unreleased]: https://github.com/cybozu-go/cke/compare/v1.20.2...HEAD
+[Unreleased]: https://github.com/cybozu-go/cke/compare/v1.20.3...HEAD
+[1.20.3]: https://github.com/cybozu-go/cke/compare/v1.20.2...v1.20.3
 [1.20.2]: https://github.com/cybozu-go/cke/compare/v1.20.1...v1.20.2
 [1.20.1]: https://github.com/cybozu-go/cke/compare/v1.20.0...v1.20.1
 [1.20.0]: https://github.com/cybozu-go/cke/compare/v1.20.0-rc.1...v1.20.0

--- a/version.go
+++ b/version.go
@@ -1,7 +1,7 @@
 package cke
 
 // Version represents current cke version
-const Version = "1.20.2"
+const Version = "1.20.3"
 
 // ConfigVersion represents the current configuration scheme
 // of how CKE constructs its Kubernetes cluster.


### PR DESCRIPTION
Release date is set to tomorrow because it is a bit late today.