### PR TITLE
Implement ckecli rq cancel-all

### DIFF
--- a/docs/ckecli.md
+++ b/docs/ckecli.md
@@ -46,6 +46,7 @@ $ ckecli [--config FILE] <subcommand> args...
   - [`ckecli reboot-queue add FILE`](#ckecli-reboot-queue-add-file)
   - [`ckecli reboot-queue list`](#ckecli-reboot-queue-list)
   - [`ckecli reboot-queue cancel INDEX`](#ckecli-reboot-queue-cancel-index)
+  - [`ckecli reboot-queue cancel-all`](#ckecli-reboot-queue-cancel-all)
 - [`ckecli sabakan`](#ckecli-sabakan)
   - [`ckecli sabakan enable|disable`](#ckecli-sabakan-enabledisable)
   - [`ckecli sabakan is-enabled`](#ckecli-sabakan-is-enabled)
@@ -293,6 +294,10 @@ The output is a list of [entries](reboot.md#rebootqueueentry) formatted in JSON.
 ### `ckecli reboot-queue cancel INDEX`
 
 Cancel the specified reboot queue entry.
+
+### `ckecli reboot-queue cancel-all`
+
+Cancel all the reboot queue entries.
 
 ## `ckecli sabakan`
 

--- a/pkg/ckecli/cmd/reboot_queue_cancel_all.go
+++ b/pkg/ckecli/cmd/reboot_queue_cancel_all.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/cybozu-go/cke"
+	"github.com/cybozu-go/well"
+	"github.com/spf13/cobra"
+)
+
+var rebootQueueCancelAllCmd = &cobra.Command{
+	Use:   "cancel-all",
+	Short: "cancel all the reboot queue entries",
+	Long:  `Cancel all the reboot queue entries.`,
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		well.Go(func(ctx context.Context) error {
+			entries, err := storage.GetRebootsEntries(ctx)
+			if err != nil {
+				return err
+			}
+
+			for _, entry := range entries {
+				if entry.Status == cke.RebootStatusCancelled {
+					continue
+				}
+
+				entry.Status = cke.RebootStatusCancelled
+				err := storage.UpdateRebootsEntry(ctx, entry)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		well.Stop()
+		return well.Wait()
+	},
+}
+
+func init() {
+	rebootQueueCmd.AddCommand(rebootQueueCancelAllCmd)
+}

--- a/pkg/ckecli/cmd/reboot_queue_cancel_all.go
+++ b/pkg/ckecli/cmd/reboot_queue_cancel_all.go
@@ -27,6 +27,10 @@ var rebootQueueCancelAllCmd = &cobra.Command{
 
 				entry.Status = cke.RebootStatusCancelled
 				err := storage.UpdateRebootsEntry(ctx, entry)
+				if err == cke.ErrNotFound {
+					// The entry has just finished
+					continue
+				}
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
This PR adds `ckecli reboot-queue cancel-all` command.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>