### PR TITLE
Write private key three times in SSH

### DIFF
--- a/pkg/ckecli/cmd/ssh.go
+++ b/pkg/ckecli/cmd/ssh.go
@@ -83,9 +83,11 @@ func sshPrivateKey(nodeName string) (string, error) {
 	}
 
 	go func() {
+		// OpenSSH reads the private key file three times, it need to write key three times.
 		writeToFifo(fifo, mykey.(string))
 		time.Sleep(100 * time.Millisecond)
-		// OpenSSH reads the private key file twice, it need to write key twice.
+		writeToFifo(fifo, mykey.(string))
+		time.Sleep(100 * time.Millisecond)
 		writeToFifo(fifo, mykey.(string))
 	}()
 


### PR DESCRIPTION
`ckecli ssh` uses a custom private key in its ssh connection. The key is specified via `-i` option of `ssh`.
The key is transferred to `ssh` via a FIFO file created at `~/.ssh/ckecli-ssh-key-<PID>`.
Since `ssh` reads the key multiple times, we need to write it the same time.

Previously `ssh` read the key twice, but OpenSSH 8.6p1 reads it three times. So this is the fix.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>