### PR TITLE
Remove redundant list of plugins enabled by default

### DIFF
--- a/op/k8s/apiserver_restart.go
+++ b/op/k8s/apiserver_restart.go
@@ -14,22 +14,10 @@ import (
 const auditPolicyBasePath = "/etc/kubernetes/apiserver/audit-policy-%x.yaml"
 
 var (
-	// admissionPlugins is the recommended list of admission plugins.
+	// admissionPlugins is our recommended list of admission plugins in addition to the default ones.
 	// https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use
 	admissionPlugins = []string{
-		"NamespaceLifecycle",
-		"LimitRanger",
-		"ServiceAccount",
-		"Priority",
-		"DefaultTolerationSeconds",
-		"DefaultStorageClass",
-		"PersistentVolumeClaimResize",
-		"MutatingAdmissionWebhook",
-		"ValidatingAdmissionWebhook",
-		"ResourceQuota",
-		"StorageObjectInUseProtection",
-
-		// NodeRestriction is not in the list above, but added to restrict kubelet privilege.
+		// NodeRestriction restricts kubelet privilege.
 		"NodeRestriction",
 	}
 )


### PR DESCRIPTION
This PR removes a redundant list of the admission plugins which are enabled by default.
The list of default plugins is described in the subsection of `--enable-admission-plugins` in the [`kube-apiserver` options section](https://v1-21.docs.kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/#options).

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>
