### PR TITLE
Revert "Use policy/v1 PodDisruptionBudget instead of policy/v1beta1"

### DIFF
--- a/mtest/reboot-deployment.yaml
+++ b/mtest/reboot-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         - name: ubuntu
           image: quay.io/cybozu/testhttpd:0
 ---
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   namespace: reboot-test

--- a/static/cluster-dns.yml
+++ b/static/cluster-dns.yml
@@ -175,7 +175,7 @@ spec:
       protocol: TCP
 ---
 
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: cluster-dns-pdb

--- a/static/resources.go
+++ b/static/resources.go
@@ -79,7 +79,7 @@ var Resources = []cke.ResourceDefinition{
 		Name:       "cluster-dns-pdb",
 		Revision:   1,
 		Image:      "",
-		Definition: []byte("\napiVersion: policy/v1\nkind: PodDisruptionBudget\nmetadata:\n  name: cluster-dns-pdb\n  namespace: kube-system\n  annotations:\n    cke.cybozu.com/revision: \"1\"\nspec:\n  maxUnavailable: 1\n  selector:\n    matchLabels:\n      cke.cybozu.com/appname: cluster-dns\n"),
+		Definition: []byte("\napiVersion: policy/v1beta1\nkind: PodDisruptionBudget\nmetadata:\n  name: cluster-dns-pdb\n  namespace: kube-system\n  annotations:\n    cke.cybozu.com/revision: \"1\"\nspec:\n  maxUnavailable: 1\n  selector:\n    matchLabels:\n      cke.cybozu.com/appname: cluster-dns\n"),
 	},
 	{
 		Key:        "Service/kube-system/cluster-dns",


### PR DESCRIPTION
This reverts commit bdf7f08e18bb14fec0f4f6c20c74ff6cd1131cb5.
When upgrading, the new resource is injected into old Kubernetes system and causes an error due to lack of REST mapping.