### PR TITLE
Update Endpoints/EndpointSlices when rebooting CP Node

### DIFF
--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -1125,6 +1125,20 @@ func TestDecideOps(t *testing.T) {
 			ExpectedOps: []string{"update-endpoints"},
 		},
 		{
+			Name: "MasterEndpointSliceUpdate1",
+			Input: newData().withK8sResourceReady().with(func(d testData) {
+				d.Status.Kubernetes.MasterEndpointSlice.Endpoints[0].Addresses = []string{}
+			}),
+			ExpectedOps: []string{"update-endpointslice"},
+		},
+		{
+			Name: "MasterEndpointSliceUpdate2",
+			Input: newData().withK8sResourceReady().with(func(d testData) {
+				d.Status.Kubernetes.MasterEndpointSlice.Ports[0] = discoveryv1.EndpointPort{}
+			}),
+			ExpectedOps: []string{"update-endpointslice"},
+		},
+		{
 			Name: "EtcdServiceUpdate",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.EtcdService.Spec.Ports = []corev1.ServicePort{}
@@ -1151,6 +1165,20 @@ func TestDecideOps(t *testing.T) {
 				d.Status.Kubernetes.EtcdEndpoints.Subsets[0].Addresses = []corev1.EndpointAddress{}
 			}),
 			ExpectedOps: []string{"update-endpoints"},
+		},
+		{
+			Name: "EtcdEndpointSliceUpdate1",
+			Input: newData().withK8sResourceReady().with(func(d testData) {
+				d.Status.Kubernetes.EtcdEndpointSlice.Endpoints[0].Addresses = []string{}
+			}),
+			ExpectedOps: []string{"update-endpointslice"},
+		},
+		{
+			Name: "EtcdEndpointSliceUpdate2",
+			Input: newData().withK8sResourceReady().with(func(d testData) {
+				d.Status.Kubernetes.EtcdEndpointSlice.Ports[0] = discoveryv1.EndpointPort{}
+			}),
+			ExpectedOps: []string{"update-endpointslice"},
 		},
 		{
 			Name: "UserResourceAdd",

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -1181,6 +1181,16 @@ func TestDecideOps(t *testing.T) {
 			ExpectedOps: []string{"update-endpointslice"},
 		},
 		{
+			Name: "EndpointsUpdateWithRebootEntry",
+			Input: newData().withK8sResourceReady().withRebootConfig().withRebootEntry(&cke.RebootQueueEntry{
+				Index:  1,
+				Nodes:  []string{nodeNames[2]},
+				Status: cke.RebootStatusQueued,
+			}),
+			ExpectedOps:        []string{"update-endpoints", "update-endpoints", "update-endpointslice", "update-endpointslice"},
+			ExpectedTargetNums: nil,
+		},
+		{
 			Name: "EndpointsWithRebootEntry",
 			Input: newData().withK8sResourceReady().withRebootConfig().withRebootEntry(&cke.RebootQueueEntry{
 				Index:  1,


### PR DESCRIPTION
This PR improves the CKE strategy to update `kubernetes`/`cke-etcd` Endpoints/EndpointSlices before/after rebooting a CP Node.
This PR also adds tests for the reconciliation of EndpointSlices.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>
