### PR TITLE
use `sonobuoy run --rerun-failed` instead of obsoleted `sonobuoy e2e`

### DIFF
--- a/sonobuoy/Makefile
+++ b/sonobuoy/Makefile
@@ -61,7 +61,7 @@ sonobuoy: bin/sonobuoy
 	$(CKECLI) kubernetes issue --ttl=10h > .kubeconfig
 	time ./bin/sonobuoy run --mode=certified-conformance --timeout=14400 --wait
 	outfile=$$(./bin/sonobuoy retrieve) && mv $$outfile sonobuoy.tar.gz
-	./bin/sonobuoy e2e sonobuoy.tar.gz 2>&1 | tee e2e-check.log
+	./bin/sonobuoy run --rerun-failed sonobuoy.tar.gz 2>&1 | tee e2e-check.log
 	./bin/sonobuoy delete
 
 .PHONY: clean


### PR DESCRIPTION
part of https://github.com/cybozu-go/cke/issues/516

`--rerun-failed` flag is addded to `run` subcommand at v0.54.0 and is meant to be a replacement of `e2e` subcommand.
https://github.com/vmware-tanzu/sonobuoy/releases/tag/v0.54.0

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>