### PR TITLE
follow behavior change between `sonobuoy e2e` and `sonobuoy run --rerun-failed`

### DIFF
--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -33,7 +33,7 @@ jobs:
         timeout-minutes: 240
       - name: Check failures
         run: |
-          grep "failed tests: 0" /tmp/e2e-check.log
+          grep -F 'no tests failed for plugin "e2e" in tarball' /tmp/e2e-check.log
       - name: Upload sonobuoy test result
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/sonobuoy.yaml
+++ b/.github/workflows/sonobuoy.yaml
@@ -25,4 +25,4 @@ jobs:
         timeout-minutes: 240
       - name: Check failures
         run: |
-          grep "failed tests: 0" /tmp/e2e-check.log
+          grep -F 'no tests failed for plugin "e2e" in tarball' /tmp/e2e-check.log


### PR DESCRIPTION
part of https://github.com/cybozu-go/cke/issues/516

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>