### PR TITLE
Add `--experimental-initial-corrupt-check` flag for etcd

### DIFF
--- a/op/etcd/common.go
+++ b/op/etcd/common.go
@@ -64,6 +64,10 @@ func BuiltInParams(node *cke.Node, initialCluster []string, state string) cke.Se
 		// value if the value is less than 1 hour.
 		// https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/maintenance.md#auto-compaction
 		"--auto-compaction-retention=5m",
+		// etcd 3.5.[0-2] has data inconsistency issue.
+		// https://groups.google.com/a/kubernetes.io/g/dev/c/B7gJs88XtQc/m/rSgNOzV2BwAJ
+		// This flag can detect an inconsistency.
+		"--experimental-initial-corrupt-check",
 	}
 	if len(initialCluster) > 0 {
 		args = append(args,


### PR DESCRIPTION
etcd 3.5.[0-2] has data inconsistency issue.
https://groups.google.com/a/kubernetes.io/g/dev/c/B7gJs88XtQc/m/rSgNOzV2BwAJ

Signed-off-by: zoetrope <a.ikezoe@gmail.com>