### PR TITLE
sonobuoy test: follow flatcar 3227.2.0

### DIFF
--- a/sonobuoy/worker-ign.yml
+++ b/sonobuoy/worker-ign.yml
@@ -43,3 +43,5 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
+  - name: locksmithd.service
+    mask: true

--- a/sonobuoy/worker-ign.yml
+++ b/sonobuoy/worker-ign.yml
@@ -24,6 +24,14 @@ storage:
           iptables -w -A INPUT -p tcp -j ACCEPT
           iptables -w -A INPUT -p udp -j ACCEPT
       mode: 0755
+    - path: "/opt/bin/replace-resolv-conf"
+      # For some reason, if we let ignition replace resolv.conf directly, it results empty file.
+      filesystem: root
+      contents:
+        inline: |
+          #!/bin/sh
+          echo nameserver 8.8.8.8 > /etc/resolv.conf
+      mode: 0755
 systemd:
   units:
   - name: systemd-resolved.service
@@ -45,3 +53,18 @@ systemd:
         WantedBy=multi-user.target
   - name: locksmithd.service
     mask: true
+  - name: replace-resolv-conf.service
+    enabled: true
+    contents: |
+      [Unit]
+        Description=Replace resolv.conf
+        After=network-online.target
+        Wants=network-online.target
+
+        [Service]
+        Type=oneshot
+        ExecStart=/opt/bin/replace-resolv-conf
+        RemainAfterExit=yes
+
+        [Install]
+        WantedBy=multi-user.target


### PR DESCRIPTION
The GCE image of flatcar 3227.2.0 (the latest version when this PR is submitted) has different resolv.conf content from older versions.
CKE cannot bootstrap worker nodes because `docker pull` from public repo fails on worker nodes due to the difference.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>