### PR TITLE
Stop using deprecated --register-with-taints option

### DIFF
--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -211,7 +211,7 @@ Fields in the below table have default values:
 
 `TLSCertFile`, `TLSPrivateKeyFile`, `Authentication`, `Authorization`, and `ClusterDNS` are managed by CKE and are not configurable.
 `RegisterWithTaints` is managed by CKE when `boot_taints` exists in KubeletParams.
-When same taints are specified in both `boot_taints` (KubeletParams) and `RegisterWithTaints` (KubeletConfiguration), CKE respects `boot_taints`.
+When taints with the same key are specified in both `boot_taints` (KubeletParams) and `RegisterWithTaints` (KubeletConfiguration), CKE respects `boot_taints`.
 
 #### CNIConfFile
 

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -158,7 +158,7 @@ Options
 | `extra_binds` | false    | array                              | Extra bind mounts.  List of `Mount`.            |
 | `extra_env`   | false    | object                             | Extra environment variables.                    |
 
-`config` must be a partial [`v1alpha1.KubeProxyConfiguration`](https://pkg.go.dev/k8s.io/kube-proxy@v0.20.6/config/v1alpha1#KubeProxyConfiguration).
+`config` must be a partial [`v1alpha1.KubeProxyConfiguration`](https://pkg.go.dev/k8s.io/kube-proxy@v0.23.9/config/v1alpha1#KubeProxyConfiguration).
 Fields in the below table have default values:
 
 | Name                                                    | Value                                          |
@@ -192,11 +192,11 @@ Taints in `boot_taints` are added to a Node in the following cases:
 
 Those taints can be removed manually when they are no longer needed.
 Note that the second case happens when the physical node is rebooted without resource manipulation.
-If you want to add taints only at Node registration, use kubelet's `--register-with-taints` options in `extra_args`.
+If you want to add taints only at Node registration, use `RegisterWithTaints` field in KubeletConfiguration.
 
 #### KubeletConfiguration
 
-`config` must be a partial [`v1beta1.KubeletConfiguration`](https://pkg.go.dev/k8s.io/kubelet@v0.20.6/config/v1beta1#KubeletConfiguration).
+`config` must be a partial [`v1beta1.KubeletConfiguration`](https://pkg.go.dev/k8s.io/kubelet@v0.23.9/config/v1beta1#KubeletConfiguration).
 
 Fields that are described as _This field should not be updated without a full node reboot._ won't be updated on the running node for safety.  Such fields include `CgroupDriver` or `QOSReserved`.
 
@@ -210,6 +210,8 @@ Fields in the below table have default values:
 | `VolumePluginDir`       | `/opt/volume/bin` |
 
 `TLSCertFile`, `TLSPrivateKeyFile`, `Authentication`, `Authorization`, and `ClusterDNS` are managed by CKE and are not configurable.
+`RegisterWithTaints` is managed by CKE when `boot_taints` exists in KubeletParams.
+When same taints are specified in both `boot_taints` (KubeletParams) and `RegisterWithTaints` (KubeletConfiguration), CKE respects `boot_taints`.
 
 #### CNIConfFile
 
@@ -229,12 +231,12 @@ It should end with either `.conf` or `.conflist`.
 
 | Name          | Required | Type                                  | Description                                     |
 | ------------- | -------- | ------------------------------------- | ----------------------------------------------- |
-| `config`      | false    | `*v1beta1.KubeSchedulerConfiguration` | See below.                                      |
+| `config`      | false    | `*v1beta3.KubeSchedulerConfiguration` | See below.                                      |
 | `extra_args`  | false    | array                                 | Extra command-line arguments.  List of strings. |
 | `extra_binds` | false    | array                                 | Extra bind mounts.  List of `Mount`.            |
 | `extra_env`   | false    | object                                | Extra environment variables.                    |
 
-`config` must be a partial [`v1beta1.KubeSchedulerConfiguration`](https://pkg.go.dev/k8s.io/kube-scheduler@v0.20.6/config/v1beta1#KubeSchedulerConfiguration).
+`config` must be a partial [`v1beta3.KubeSchedulerConfiguration`](https://pkg.go.dev/k8s.io/kube-scheduler@v0.23.9/config/v1beta3#KubeSchedulerConfiguration).
 
 Fields in `config` may have default values.  Some fields are overwritten by CKE.
 Please see the source code for more details.

--- a/op/k8s/config.go
+++ b/op/k8s/config.go
@@ -163,6 +163,19 @@ func GenerateKubeletConfiguration(params cke.KubeletParams, nodeAddress string, 
 	c.Authorization = kubeletv1beta1.KubeletAuthorization{Mode: kubeletv1beta1.KubeletAuthorizationModeWebhook}
 	c.ClusterDNS = []string{nodeAddress}
 
+	taintIndex := map[string]int{}
+	for i, t := range c.RegisterWithTaints {
+		taintIndex[t.Key] = i
+	}
+	for _, t := range params.BootTaints {
+		if index, ok := taintIndex[t.Key]; ok {
+			// Overwrite the user-defined RegisterWithTaints when the same taint exists as boot taints.
+			c.RegisterWithTaints[index] = t
+		} else {
+			c.RegisterWithTaints = append(c.RegisterWithTaints, t)
+		}
+	}
+
 	if running != nil {
 		// Keep the running configurations while the node is running.
 		// All these fields are described as:

--- a/op/k8s/kubelet_boot.go
+++ b/op/k8s/kubelet_boot.go
@@ -3,9 +3,7 @@ package k8s
 import (
 	"context"
 	"errors"
-	"fmt"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/cybozu-go/cke"
@@ -101,14 +99,6 @@ func (o *kubeletBootOp) NextCommand() cke.Commander {
 		paramsMap := make(map[string]cke.ServiceParams)
 		for _, n := range o.nodes {
 			params := KubeletServiceParams(n, o.params)
-			if len(o.params.BootTaints) > 0 {
-				argl := make([]string, len(o.params.BootTaints))
-				for i, t := range o.params.BootTaints {
-					argl[i] = fmt.Sprintf("%s=%s:%s", t.Key, t.Value, t.Effect)
-				}
-				params.ExtraArguments = append(params.ExtraArguments,
-					"--register-with-taints="+strings.Join(argl, ","))
-			}
 			paramsMap[n.Address] = params
 		}
 		return common.RunContainerCommand(o.nodes, op.KubeletContainerName, cke.KubernetesImage,


### PR DESCRIPTION
part of https://github.com/cybozu-go/cke/issues/545

`--register-with-taints` option is deprecated, so use `RegisterWithTaints` of KubeletConfiguration instead.

kubelet uses the `RegisterWithTaints` field only when initializing Node resources.
After registration, this field does not affect Node resources.
So I fixed the kubelet_boot op to render the RegisterWithTaints at all times if `boot_taints` exists.
https://github.com/kubernetes/kubernetes/blob/v1.23.9/pkg/kubelet/kubelet_node_status.go#L311

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>