### PR TITLE
Improve agent connection handling during rebooting

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -11,8 +11,10 @@ import (
 )
 
 const (
-	defaultDialTimeout = 30 * time.Second
-	defaultKeepAlive   = 5 * time.Second
+	// defaultDialTimeout is the default timeout value for net.Dialer.Dial() and ssh.Client.NewSession().
+	defaultDialTimeout = 5 * time.Second
+	// defaultKeepAlive is the default keepalive interval for agent connection.
+	defaultKeepAlive = 5 * time.Second
 
 	// DefaultRunTimeout is the timeout value for Agent.Run().
 	DefaultRunTimeout = 10 * time.Minute

--- a/agent.go
+++ b/agent.go
@@ -126,7 +126,7 @@ func (a *sshAgent) RunWithInput(command, input string) error {
 
 func (a *sshAgent) RunWithTimeout(command, input string, timeout time.Duration) ([]byte, []byte, error) {
 	if timeout > 0 {
-		err := a.conn.SetDeadline(time.Now().Add(timeout))
+		err := a.conn.SetDeadline(time.Now().Add(defaultDialTimeout))
 		if err != nil {
 			return nil, nil, err
 		}
@@ -142,6 +142,13 @@ func (a *sshAgent) RunWithTimeout(command, input string, timeout time.Duration) 
 		return nil, nil, err
 	}
 	defer session.Close()
+
+	if timeout > 0 {
+		err := a.conn.SetDeadline(time.Now().Add(timeout))
+		if err != nil {
+			return nil, nil, err
+		}
+	}
 
 	if len(input) > 0 {
 		session.Stdin = strings.NewReader(input)

--- a/infrastructure.go
+++ b/infrastructure.go
@@ -139,6 +139,8 @@ type Infrastructure interface {
 	K8sClient(ctx context.Context, n *Node) (*kubernetes.Clientset, error)
 	HTTPClient() *well.HTTPClient
 	HTTPSClient(ctx context.Context) (*well.HTTPClient, error)
+
+	ReleaseAgent(addrs string)
 }
 
 var kubeHTTP KubeHTTP
@@ -329,4 +331,14 @@ func (i *ckeInfrastructure) HTTPSClient(ctx context.Context) (*well.HTTPClient, 
 		return nil, err
 	}
 	return kubeHTTP.Client(), nil
+}
+
+func (i *ckeInfrastructure) ReleaseAgent(addr string) {
+	a := i.agents[addr]
+	if a != nil {
+		delete(i.agents, addr)
+		go func() {
+			a.Close()
+		}()
+	}
 }

--- a/localproxy/infrastructure.go
+++ b/localproxy/infrastructure.go
@@ -103,6 +103,10 @@ func (i *localInfra) HTTPSClient(ctx context.Context) (*well.HTTPClient, error) 
 	panic("not implemented") // TODO: Implement
 }
 
+func (i *localInfra) ReleaseAgent(addr string) {
+	panic("not implemented") // TODO: Implement
+}
+
 type localDocker struct{}
 
 var _ cke.ContainerEngine = localDocker{}

--- a/op/reboot.go
+++ b/op/reboot.go
@@ -243,6 +243,8 @@ func (c rebootRebootCommand) Run(ctx context.Context, inf cke.Infrastructure, _ 
 		defer cancel()
 	}
 
+	var mu sync.Mutex
+
 	env := well.NewEnvironment(ctx)
 	for _, entry := range c.entries {
 		entry := entry // save loop variable for goroutine
@@ -254,6 +256,10 @@ func (c rebootRebootCommand) Run(ctx context.Context, inf cke.Infrastructure, _ 
 			if err != nil {
 				return err
 			}
+
+			mu.Lock()
+			inf.ReleaseAgent(entry.Node)
+			mu.Unlock()
 
 			args := append(c.command[1:], entry.Node)
 			command := well.CommandContext(ctx, c.command[0], args...)

--- a/pkg/ckecli/cmd/infrastructure.go
+++ b/pkg/ckecli/cmd/infrastructure.go
@@ -139,3 +139,6 @@ func (i *cliInfrastructure) Agent(addr string) cke.Agent {
 func (i *cliInfrastructure) Engine(addr string) cke.ContainerEngine {
 	panic("not implemented")
 }
+func (i *cliInfrastructure) ReleaseAgent(addr string) {
+	panic("not implemented")
+}


### PR DESCRIPTION
- release agent connection immediately after the node's state transition to `rebooting`
- apply dial timeout to ssh session creation
- shorten dial timeout

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>