### PR TITLE
Fixed sonobuoy test failing.

### DIFF
--- a/example/wait-up.sh
+++ b/example/wait-up.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 for i in {1..10}; do
-  if docker-compose ps setup | grep -q "Exit 0"; then
+  if $(docker inspect setup | jq 'any(.Name == "/setup" and .State.Status == "exited" and .State.ExitCode == 0)'); then
     exit 0
   fi
   sleep 1

--- a/sonobuoy/Makefile
+++ b/sonobuoy/Makefile
@@ -14,7 +14,7 @@ endif
 
 SONOBUOY_URL = https://github.com/vmware-tanzu/sonobuoy/releases/download/v$(SONOBUOY_VERSION)/sonobuoy_$(SONOBUOY_VERSION)_linux_amd64.tar.gz
 KUBECTL_URL = https://storage.googleapis.com/kubernetes-release/release/v$(KUBECTL_VERSION)/bin/linux/amd64/kubectl
-DOCKER_COMPOSE_URL = https://github.com/docker/compose/releases/download/$(DOCKER_COMPOSE_VERSION)/docker-compose-Linux-x86_64
+DOCKER_COMPOSE_URL = https://github.com/docker/compose/releases/download/v$(DOCKER_COMPOSE_VERSION)/docker-compose-Linux-x86_64
 CKECLI = ./bin/ckecli --config=./cke.config
 KUBECONFIG := $(shell pwd)/.kubeconfig
 CT = $(shell pwd)/bin/ct


### PR DESCRIPTION
part of https://github.com/cybozu-go/cke/issues/556, https://github.com/cybozu-go/neco/issues/2114

- Fix docker-compose download URL
- Fix confirmation of container exit status
  - before
    ```
    ❯ docker-compose ps setup 
    Name          Command         State    Ports
    --------------------------------------------
    setup   /opt/setup/setup.sh   Exit 0
    ```
  - after
    ```
    ❯ docker-compose ps setup
    NAME                COMMAND                 SERVICE             STATUS              PORTS
    setup               "/opt/setup/setup.sh"   setup               exited (0) 
    ```
  - Changed to check container exit code from `docker inspect` instead of the text information in `docker-compose ps`.

Signed-off-by: kouki <kouworld0123@gmail.com>