### PR TITLE
Mount directories related to CNI on kubelet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ This project employs a versioning scheme described in [RELEASE.md](RELEASE.md#ve
 ## [Unreleased]
 
 ### Changed
+
 - Update Kubernetes to v1.24.9 [#591](https://github.com/cybozu-go/cke/pull/591)
+- Mount directories related to CNI on kubelet [#592](https://github.com/cybozu-go/cke/pull/592)
 
 ## [1.24.0-rc.1]
 

--- a/op/k8s/kubelet_boot.go
+++ b/op/k8s/kubelet_boot.go
@@ -450,6 +450,27 @@ func KubeletServiceParams(n *cke.Node, params cke.KubeletParams) cke.ServicePara
 				Propagation: "",
 				Label:       "",
 			},
+			{
+				Source:      cniBinDir,
+				Destination: cniBinDir,
+				ReadOnly:    true,
+				Propagation: "",
+				Label:       cke.LabelShared,
+			},
+			{
+				Source:      cniConfDir,
+				Destination: cniConfDir,
+				ReadOnly:    true,
+				Propagation: "",
+				Label:       cke.LabelShared,
+			},
+			{
+				Source:      cniVarDir,
+				Destination: cniVarDir,
+				ReadOnly:    false,
+				Propagation: "",
+				Label:       cke.LabelShared,
+			},
 		},
 	}
 }


### PR DESCRIPTION
In #584 I removed the mount of directories related to CNI.
However, during validation with neco, I found that it was necessary to mount it on the pod with HostPath, so I'm reverting it back.

- coild: https://github.com/cybozu-go/neco/blob/ece450914fa84e9bb62203ff743815a18044203b/etc/coil.yaml#L8491-L8496
- cilium: https://github.com/cybozu-go/neco/blob/ece450914fa84e9bb62203ff743815a18044203b/etc/cilium.yaml#L1245-L1252

Signed-off-by: kouki <kouworld0123@gmail.com>