### PR TITLE
Fix node filter to check etcd in-sync status properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project employs a versioning scheme described in [RELEASE.md](RELEASE.md#ve
 
 - Add `cke_node_reboot_status` metrics [#590](https://github.com/cybozu-go/cke/pull/590)
 
+### Fixed
+
+- Fix node filter to check etcd in-sync status properly [#599](https://github.com/cybozu-go/cke/pull/599)
+
 ## [1.24.0]
 
 ### Changed

--- a/server/node_filter.go
+++ b/server/node_filter.go
@@ -142,7 +142,12 @@ func (nf *NodeFilter) EtcdIsGood() bool {
 	if !st.IsHealthy {
 		return false
 	}
-	return len(st.Members) == len(st.InSyncMembers)
+	for k := range st.Members {
+		if !st.InSyncMembers[k] {
+			return false
+		}
+	}
+	return true
 }
 
 // EtcdStoppedMembers returns control plane nodes that are not running etcd.

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -1893,6 +1893,7 @@ func TestDecideOps(t *testing.T) {
 			Name: "EtcdRemoveNonClusterMember",
 			Input: newData().withAllServices().with(func(d testData) {
 				d.Status.Etcd.Members["10.0.0.100"] = &etcdserverpb.Member{Name: "10.0.0.100", ID: 3}
+				d.Status.Etcd.InSyncMembers["10.0.0.100"] = false
 			}),
 			ExpectedOps: []string{"etcd-remove-member"},
 		},
@@ -1900,6 +1901,7 @@ func TestDecideOps(t *testing.T) {
 			Name: "SkipEtcdRemoveNonClusterMember",
 			Input: newData().withAllServices().with(func(d testData) {
 				d.Status.Etcd.Members["10.0.0.100"] = &etcdserverpb.Member{Name: "10.0.0.100", ID: 3}
+				d.Status.Etcd.InSyncMembers["10.0.0.100"] = false
 			}).withSSHNotConnectedNodes(),
 			ExpectedOps: []string{"wait-kubernetes"},
 		},
@@ -1907,6 +1909,7 @@ func TestDecideOps(t *testing.T) {
 			Name: "EtcdDestroyNonCPMember",
 			Input: newData().withAllServices().with(func(d testData) {
 				d.Status.Etcd.Members["10.0.0.14"] = &etcdserverpb.Member{Name: "10.0.0.14", ID: 3}
+				d.Status.Etcd.InSyncMembers["10.0.0.14"] = false
 			}),
 			ExpectedOps:        []string{"etcd-destroy-member"},
 			ExpectedTargetNums: map[string]int{"etcd-destroy-member": 1},
@@ -1915,6 +1918,7 @@ func TestDecideOps(t *testing.T) {
 			Name: "EtcdDestroyNonCPMemberSSHNotConnected",
 			Input: newData().withAllServices().with(func(d testData) {
 				d.Status.Etcd.Members["10.0.0.14"] = &etcdserverpb.Member{Name: "10.0.0.14", ID: 3}
+				d.Status.Etcd.InSyncMembers["10.0.0.14"] = false
 			}).withSSHNotConnectedNonCPWorker(3),
 			ExpectedOps:        []string{"etcd-destroy-member"},
 			ExpectedTargetNums: map[string]int{"etcd-destroy-member": 0},
@@ -1924,6 +1928,7 @@ func TestDecideOps(t *testing.T) {
 			Input: newData().withAllServices().with(func(d testData) {
 				d.Status.Etcd.Members["10.0.0.13"].Name = ""
 				d.Status.Etcd.Members["10.0.0.13"].ID = 0
+				d.Status.Etcd.InSyncMembers["10.0.0.13"] = false
 			}),
 			ExpectedOps: []string{"etcd-add-member"},
 		},
@@ -1934,7 +1939,7 @@ func TestDecideOps(t *testing.T) {
 				delete(d.Status.Etcd.Members, "10.0.0.13")
 				delete(d.Status.Etcd.InSyncMembers, "10.0.0.13")
 				// but the cluster is not good enough
-				delete(d.Status.Etcd.InSyncMembers, "10.0.0.12")
+				d.Status.Etcd.InSyncMembers["10.0.0.12"] = false
 			}),
 			ExpectedOps: nil,
 		},
@@ -2214,7 +2219,7 @@ func TestDecideOps(t *testing.T) {
 					Status: cke.RebootStatusQueued,
 				},
 			}).with(func(d testData) {
-				delete(d.Status.Etcd.InSyncMembers, "10.0.0.11")
+				d.Status.Etcd.InSyncMembers["10.0.0.11"] = false
 			}),
 			ExpectedOps:        nil,
 			ExpectedTargetNums: nil,


### PR DESCRIPTION
The map `cke.EtcdClusterStatus.InSyncMembers` is filled by `GetEtcdClusterStatus()` in `op/status.go`.
It holds not only in-sync members but also not-in-sync members and its length is always equal to the length of `cke.EtcdClusterStatus.Members`.
This PR fixes a node filter for checking whether all etcd members are in-sync or not.
This PR also fixes the test of the CKE strategy by updating input data closer to the real.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>