### PR TITLE
 Fix added-but-not-marked etcd members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project employs a versioning scheme described in [RELEASE.md](RELEASE.md#ve
 
 - Fix node filter to check etcd in-sync status properly [#599](https://github.com/cybozu-go/cke/pull/599)
 - Fix added-but-not-marked etcd members [#600](https://github.com/cybozu-go/cke/pull/600)
+- Don't select bootstrap of etcd if data volume exists [#600](https://github.com/cybozu-go/cke/pull/600)
 
 ## [1.24.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project employs a versioning scheme described in [RELEASE.md](RELEASE.md#ve
 ### Fixed
 
 - Fix node filter to check etcd in-sync status properly [#599](https://github.com/cybozu-go/cke/pull/599)
+- Fix added-but-not-marked etcd members [#600](https://github.com/cybozu-go/cke/pull/600)
 
 ## [1.24.1]
 

--- a/op/etcd/mark.go
+++ b/op/etcd/mark.go
@@ -1,0 +1,40 @@
+package etcd
+
+import (
+	"github.com/cybozu-go/cke"
+	"github.com/cybozu-go/cke/op"
+	"github.com/cybozu-go/cke/op/common"
+)
+
+type markMemberOp struct {
+	nodes    []*cke.Node
+	executed bool
+}
+
+// MarkMemberOp returns an Operator to mark nodes as added members.
+func MarkMemberOp(nodes []*cke.Node) cke.Operator {
+	return &markMemberOp{
+		nodes: nodes,
+	}
+}
+
+func (o *markMemberOp) Name() string {
+	return "etcd-mark-member"
+}
+
+func (o *markMemberOp) NextCommand() cke.Commander {
+	if o.executed {
+		return nil
+	}
+	o.executed = true
+
+	return common.VolumeCreateCommand(o.nodes, op.EtcdAddedMemberVolumeName)
+}
+
+func (o *markMemberOp) Targets() []string {
+	ips := make([]string, len(o.nodes))
+	for i, n := range o.nodes {
+		ips[i] = n.Address
+	}
+	return ips
+}

--- a/op/status.go
+++ b/op/status.go
@@ -68,7 +68,8 @@ func GetNodeStatus(ctx context.Context, inf cke.Infrastructure, node *cke.Node, 
 
 	status.Etcd = cke.EtcdStatus{
 		ServiceStatus: ss[EtcdContainerName],
-		HasData:       etcdVolumeExists && isAddedmember,
+		HasData:       etcdVolumeExists,
+		IsAddedMember: etcdVolumeExists && isAddedmember,
 	}
 	status.Rivers = ss[RiversContainerName]
 	status.EtcdRivers = ss[EtcdRiversContainerName]

--- a/server/get_status.go
+++ b/server/get_status.go
@@ -48,7 +48,7 @@ func (c Controller) GetClusterStatus(ctx context.Context, cluster *cke.Cluster, 
 	var etcdRunning bool
 	for _, n := range cke.ControlPlanes(cluster.Nodes) {
 		ns := statuses[n.Address]
-		if ns.Etcd.HasData {
+		if ns.Etcd.IsAddedMember {
 			etcdRunning = true
 			break
 		}

--- a/server/node_filter.go
+++ b/server/node_filter.go
@@ -160,7 +160,7 @@ func (nf *NodeFilter) EtcdStoppedMembers() (nodes []*cke.Node) {
 		if st.Running {
 			continue
 		}
-		if !st.HasData {
+		if !st.IsAddedMember {
 			continue
 		}
 		nodes = append(nodes, n)
@@ -239,7 +239,7 @@ func (nf *NodeFilter) EtcdUnmarkedMembers() (nodes []*cke.Node) {
 		if !n.ControlPlane {
 			continue
 		}
-		if nf.nodeStatus(n).Etcd.HasData {
+		if nf.nodeStatus(n).Etcd.IsAddedMember {
 			continue
 		}
 		nodes = append(nodes, n)

--- a/server/node_filter.go
+++ b/server/node_filter.go
@@ -224,6 +224,29 @@ func (nf *NodeFilter) EtcdUnstartedMembers() (nodes []*cke.Node) {
 	return nodes
 }
 
+// EtcdUnmarkedMembers returns nodes that are working as in-sync members
+// of the etcd cluster but not marked as added members.
+func (nf *NodeFilter) EtcdUnmarkedMembers() (nodes []*cke.Node) {
+	st := nf.status.Etcd
+	for k, v := range st.InSyncMembers {
+		if !v {
+			continue
+		}
+		n, ok := nf.nodeMap[k]
+		if !ok {
+			continue
+		}
+		if !n.ControlPlane {
+			continue
+		}
+		if nf.nodeStatus(n).Etcd.HasData {
+			continue
+		}
+		nodes = append(nodes, n)
+	}
+	return nodes
+}
+
 // EtcdNewMembers returns control plane nodes to be added to the etcd cluster.
 func (nf *NodeFilter) EtcdNewMembers() (nodes []*cke.Node) {
 	members := nf.status.Etcd.Members

--- a/server/strategy.go
+++ b/server/strategy.go
@@ -179,6 +179,9 @@ func etcdMaintOp(c *cke.Cluster, nf *NodeFilter) cke.Operator {
 	if nodes := nf.EtcdUnstartedMembers(); len(nodes) > 0 {
 		return etcd.AddMemberOp(nf.ControlPlane(), nodes[0], c.Options.Etcd)
 	}
+	if nodes := nf.EtcdUnmarkedMembers(); len(nodes) > 0 {
+		return etcd.MarkMemberOp(nodes)
+	}
 
 	if !nf.EtcdIsGood() {
 		log.Warn("etcd is not good for maintenance", nil)

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -1933,6 +1933,13 @@ func TestDecideOps(t *testing.T) {
 			ExpectedOps: []string{"etcd-add-member"},
 		},
 		{
+			Name: "EtcdMark",
+			Input: newData().withAllServices().with(func(d testData) {
+				d.Status.NodeStatuses["10.0.0.13"].Etcd.HasData = false
+			}),
+			ExpectedOps: []string{"etcd-mark-member"},
+		},
+		{
 			Name: "EtcdIsNotGood",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				// a node is to be added

--- a/status.go
+++ b/status.go
@@ -118,7 +118,8 @@ type ServiceStatus struct {
 // EtcdStatus is the status of kubelet.
 type EtcdStatus struct {
 	ServiceStatus
-	HasData bool
+	HasData       bool
+	IsAddedMember bool
 }
 
 // KubeComponentStatus represents service status and endpoint's health


### PR DESCRIPTION
This PR adds a decision step of the CKE strategy to maintain half-added etcd members.
See the issue #579 for the details of "half-added members."
This PR also changes a node filter to not try to initialize half-added etcd members.

Fixes: #579 
Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>