### PR TITLE
cke-tools: Update CNI plugins to v1.2.0

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
 env:
-  go-version: 1.17
+  go-version: 1.19
   filename: "main.yaml"
 jobs:
   build:

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -4,7 +4,7 @@ on:
     tags:
       - 'v*'
 env:
-  go-version: 1.17
+  go-version: 1.19
   tag: ${GITHUB_REF#refs/tags/v}
   prerelease: ${{ contains(github.ref, '-') }}
 jobs:

--- a/.github/workflows/release-tools.yaml
+++ b/.github/workflows/release-tools.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.19
       - name: Build CKE tools
         run: |
           cd tools

--- a/.github/workflows/sonobuoy.yaml
+++ b/.github/workflows/sonobuoy.yaml
@@ -2,7 +2,7 @@ name: sonobuoy
 on:
   workflow_dispatch:
 env:
-  go-version: 1.17
+  go-version: 1.19
 jobs:
   sonobuoy:
     name: Run sonobuoy

--- a/mtest/Makefile
+++ b/mtest/Makefile
@@ -115,7 +115,7 @@ $(DATA_DIR)/vault: $(VAULT_ARCHIVE)
 $(OUTPUT)/cke $(OUTPUT)/ckecli $(OUTPUT)/cke-localproxy: FORCE
 	mkdir -p $(OUTPUT)
 	cd ..; gofail enable op/etcd && \
-		if GOBIN=$(realpath $(OUTPUT)) go install ./pkg/$(notdir $@); then \
+		if CGO_ENABLED=0 GOBIN=$(realpath $(OUTPUT)) go install ./pkg/$(notdir $@); then \
 			gofail disable op/etcd; \
 		else \
 			gofail disable op/etcd; \

--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -2,13 +2,18 @@
 
 cke-tools related changes.
 
+## 1.25.0 - 2023-02-14
+
+- Update CNI plugins to 1.2.0[#609](https://github.com/cybozu-go/cke/pull/609)
+- Update go to 1.19 [#609](https://github.com/cybozu-go/cke/pull/609)
+
 ## 1.24.0 - 2022-11-28
 
 - nothing changed
 
 ## 1.23.0 - 2022-08-02
 
-- Update CNI plugins to 1.1.1(#553)
+- Update CNI plugins to 1.1.1[#553](https://github.com/cybozu-go/cke/pull/#553)
 
 ## 1.22.0 - 2021-12-16
 
@@ -16,25 +21,25 @@ cke-tools related changes.
 
 ## 1.21.0 - 2021-09-30
 
-- Update CNI plugins to 1.0.1(#483)
+- Update CNI plugins to 1.0.1[#483](https://github.com/cybozu-go/cke/pull/#483)
 
 ## 1.20.0 - 2021-04-26
 
 ### Changed
 
-- Update CNI plugin to 0.9.1 (#452)
+- Update CNI plugin to 0.9.1 [#452](https://github.com/cybozu-go/cke/pull/#452)
 
 ## 1.19.2 - 2021-02-09
 
 ### Changed
 
-- rivers: fix a bug in health checker (#423)
+- rivers: fix a bug in health checker [#423](https://github.com/cybozu-go/cke/pull/#423)
 
 ## 1.19.1 - 2021-02-08
 
 ### Added
 
-- rivers: health check for upstream servers (#418)
+- rivers: health check for upstream servers [#418](https://github.com/cybozu-go/cke/pull/#418)
 
 ## 1.19.0
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,4 +1,4 @@
-CNI_PLUGIN_VERSION = 1.1.1
+CNI_PLUGIN_VERSION = 1.2.0
 TAG = quay.io/cybozu/cke-tools:dev
 GOBUILD = CGO_ENABLED=0 go build -ldflags="-w -s"
 


### PR DESCRIPTION
- Update go to 1.19 to fail the CKE test case
- Update CNI plugins to 1.2.0
Signed-off-by: zeroalphat <taichi-takemura@cybozu.co.jp>
