### PR TITLE
Add buildvcs option to fix build error

### DIFF
--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -81,7 +81,7 @@ jobs:
           tar xzf ./sonobuoy.tar.gz -C /tmp/upload --strip-components=4 plugins/e2e/results/global/e2e.log plugins/e2e/results/global/junit_01.xml
           sed "s/vX\.Y\.Z/v${{ env.tag }}/" sonobuoy/README.md > /tmp/upload/README.md
           sed "s/vX\.Y\.Z/v${{ env.tag }}/" sonobuoy/PRODUCT.yaml > /tmp/upload/PRODUCT.yaml
-          GOBIN=/tmp/upload CGO_ENABLED=0 go install ./pkg/cke ./pkg/ckecli
+          GOBIN=/tmp/upload CGO_ENABLED=0 go install -buildvcs=false ./pkg/cke ./pkg/ckecli
       - name: Create release
         run: |
           OWNER=$(echo ${{ github.repository }} | cut -d '/' -f 1)


### PR DESCRIPTION
When releasing 1.25 of cke, the binary generation failed and the release could not be made.
The reason for the binary generation failure was that the setting to embed vcs status was enabled.
Since there is no need to embed debug information in the binaries, disable vcs status.
https://github.com/cybozu-go/cke/actions/runs/4260149159/jobs/7414496154
zeroalphat <taichi-takemura@cybozu.co.jp>