### PR TITLE
Update user-defined resource applying logic

### DIFF
--- a/docs/user-resources.md
+++ b/docs/user-resources.md
@@ -41,11 +41,11 @@ The resources are applied in the following order according to their kind.
 
 ### Custom order
 
-Users can control the order of applying resources by annotating `cke.cybozu.com/rank`.
-In the case of cluster-scope resources, a rank value must be 0 ~ 1999.
-For namespace-scope resources, a rank value must be 2000 ~.
+Users can customize the order of applying resources by annotating `cke.cybozu.com/rank`.
+In the case of cluster-scoped resources, a rank value must be 0-1999.
+For namespace-scoped resources, a rank value must be 2000-.
 
-If `cke.cybozu.com/rank` is not set, the rank is assigned a value based on the abovementioned list.
+If `cke.cybozu.com/rank` is not set, the rank is defaulted to a value based on the aforementioned list.
 
 ## Annotations
 

--- a/docs/user-resources.md
+++ b/docs/user-resources.md
@@ -15,17 +15,37 @@ Custom resources (not `CustomResourceDefinition`s) are not supported.
 The resources are applied in the following order according to their kind.
 
 - Namespace
+  - rank: 10
 - ServiceAccount
+  - rank: 20
 - CustomResourceDefinition
+  - rank: 30
 - ClusterRole
+  - rank: 40
 - ClusterRoleBinding
+  - rank: 50
 - (Other cluster-scope resources)
+  - rank: 1000
 - Role
+  - rank: 2000
 - RoleBinding
+  - rank: 2010
 - NetworkPolicy
+  - rank: 2020
 - Secret
+  - rank: 2030
 - ConfigMap
+  - rank: 2040
 - (Other namespace-scoped resources)
+  - rank: 3000
+
+### Custom order
+
+Users can control the order of applying resources by annotating `cke.cybozu.com/rank`.
+In the case of cluster-scope resources, a rank value must be 0 ~ 1999.
+For namespace-scope resources, a rank value must be 2000 ~.
+
+If `cke.cybozu.com/rank` is not set, the rank is assigned a value based on the abovementioned list.
 
 ## Annotations
 

--- a/op/nop.go
+++ b/op/nop.go
@@ -1,0 +1,37 @@
+package op
+
+import (
+	"context"
+
+	"github.com/cybozu-go/cke"
+)
+
+type nopOp struct{}
+
+func NopOp() cke.Operator {
+	return &nopOp{}
+}
+
+func (o *nopOp) Name() string {
+	return "nop"
+}
+
+func (o *nopOp) NextCommand() cke.Commander {
+	return nil
+}
+
+func (o *nopOp) Targets() []string {
+	return nil
+}
+
+func (o *nopOp) Run(ctx context.Context, inf cke.Infrastructure, _ string) error {
+	// This function is never executed
+	return nil
+}
+
+func (o *nopOp) Command() cke.Command {
+	return cke.Command{
+		Name:   "nop",
+		Target: "",
+	}
+}

--- a/op/status.go
+++ b/op/status.go
@@ -473,6 +473,8 @@ func GetKubernetesClusterStatus(ctx context.Context, inf cke.Infrastructure, n *
 }
 
 func objStatus(desired, updated, available int64) bool {
+	// If we get the status immediately after applying the resource, the value of desired may be 0.
+	// In this case, we need to return false.
 	if desired == 0 {
 		return false
 	}

--- a/op/status.go
+++ b/op/status.go
@@ -437,6 +437,15 @@ func GetKubernetesClusterStatus(ctx context.Context, inf cke.Infrastructure, n *
 			return cke.KubernetesClusterStatus{}, err
 		}
 		if obj.GroupVersionKind().Kind == "DaemonSet" {
+			generation, _, err := unstructured.NestedInt64(obj.UnstructuredContent(), "metadata", "generation")
+			if err != nil {
+				return cke.KubernetesClusterStatus{}, err
+			}
+			observedGeneration, _, err := unstructured.NestedInt64(obj.UnstructuredContent(), "status", "observedGeneration")
+			if err != nil {
+				return cke.KubernetesClusterStatus{}, err
+			}
+
 			desired, _, err := unstructured.NestedInt64(obj.UnstructuredContent(), "status", "desiredNumberScheduled")
 			if err != nil {
 				return cke.KubernetesClusterStatus{}, err
@@ -449,8 +458,16 @@ func GetKubernetesClusterStatus(ctx context.Context, inf cke.Infrastructure, n *
 			if err != nil {
 				return cke.KubernetesClusterStatus{}, err
 			}
-			s.SetResourceStatus(res.Key, obj.GetAnnotations(), len(obj.GetManagedFields()) != 0, objStatus(desired, updated, available))
+			s.SetResourceStatus(res.Key, obj.GetAnnotations(), len(obj.GetManagedFields()) != 0, objStatus(generation, observedGeneration, desired, updated, available))
 		} else if obj.GroupVersionKind().Kind == "Deployment" {
+			generation, _, err := unstructured.NestedInt64(obj.UnstructuredContent(), "metadata", "generation")
+			if err != nil {
+				return cke.KubernetesClusterStatus{}, err
+			}
+			observedGeneration, _, err := unstructured.NestedInt64(obj.UnstructuredContent(), "status", "observedGeneration")
+			if err != nil {
+				return cke.KubernetesClusterStatus{}, err
+			}
 			desired, _, err := unstructured.NestedInt64(obj.UnstructuredContent(), "status", "readyReplicas")
 			if err != nil {
 				return cke.KubernetesClusterStatus{}, err
@@ -463,7 +480,7 @@ func GetKubernetesClusterStatus(ctx context.Context, inf cke.Infrastructure, n *
 			if err != nil {
 				return cke.KubernetesClusterStatus{}, err
 			}
-			s.SetResourceStatus(res.Key, obj.GetAnnotations(), len(obj.GetManagedFields()) != 0, objStatus(desired, updated, available))
+			s.SetResourceStatus(res.Key, obj.GetAnnotations(), len(obj.GetManagedFields()) != 0, objStatus(generation, observedGeneration, desired, updated, available))
 		} else {
 			s.SetResourceStatus(res.Key, obj.GetAnnotations(), len(obj.GetManagedFields()) != 0, true)
 		}
@@ -472,7 +489,10 @@ func GetKubernetesClusterStatus(ctx context.Context, inf cke.Infrastructure, n *
 	return s, nil
 }
 
-func objStatus(desired, updated, available int64) bool {
+func objStatus(generation, observedGeneration, desired, updated, available int64) bool {
+	if generation > observedGeneration {
+		return false
+	}
 	// If we get the status immediately after applying the resource, the value of desired may be 0.
 	// In this case, we need to return false.
 	if desired == 0 {

--- a/pkg/compile_resources/main.go
+++ b/pkg/compile_resources/main.go
@@ -94,6 +94,7 @@ func loadResources(fname string, images map[string]string) ([]cke.ResourceDefini
 				Annotations struct {
 					Revision int64  `json:"cke.cybozu.com/revision,string"`
 					Image    string `json:"cke.cybozu.com/image"`
+					Rank     uint32 `json:"cke.cybozu.com/rank,omitempty"`
 				} `json:"annotations"`
 			} `json:"metadata"`
 		}{}
@@ -105,6 +106,11 @@ func loadResources(fname string, images map[string]string) ([]cke.ResourceDefini
 			return nil, errors.New("static resources must declare cke.cybozu.com/revision in annotations")
 		}
 
+		rank, err := cke.DecideRank(kind, namespace, obj.Metadata.Annotations.Rank)
+		if err != nil {
+			return nil, err
+		}
+
 		res = append(res, cke.ResourceDefinition{
 			Key:        key,
 			Kind:       kind,
@@ -112,6 +118,7 @@ func loadResources(fname string, images map[string]string) ([]cke.ResourceDefini
 			Name:       name,
 			Revision:   rev,
 			Image:      obj.Metadata.Annotations.Image,
+			Rank:       rank,
 			Definition: data,
 		})
 	}

--- a/pkg/compile_resources/main.go
+++ b/pkg/compile_resources/main.go
@@ -143,6 +143,7 @@ var Resources = []cke.ResourceDefinition{
 		Name: {{ printf "%q" .Name }},
 		Revision: {{ .Revision }},
 		Image: {{ printf "%q" .Image }},
+		Rank: {{ .Rank }},
 		Definition: []byte({{ printf "%q" .Definition }}),
 	},
 	{{ end -}}

--- a/pkg/compile_resources/main.go
+++ b/pkg/compile_resources/main.go
@@ -94,7 +94,7 @@ func loadResources(fname string, images map[string]string) ([]cke.ResourceDefini
 				Annotations struct {
 					Revision int64  `json:"cke.cybozu.com/revision,string"`
 					Image    string `json:"cke.cybozu.com/image"`
-					Rank     uint32 `json:"cke.cybozu.com/rank,omitempty"`
+					Rank     uint32 `json:"cke.cybozu.com/rank,omitempty,string"`
 				} `json:"annotations"`
 			} `json:"metadata"`
 		}{}

--- a/resource.go
+++ b/resource.go
@@ -28,6 +28,7 @@ const (
 	AnnotationResourceRevision  = "cke.cybozu.com/revision"
 	AnnotationResourceInjectCA  = "cke.cybozu.com/inject-cacert"
 	AnnotationResourceIssueCert = "cke.cybozu.com/issue-cert"
+	AnnotationResourceRank      = "cke.cybozu.com/rank"
 )
 
 // kinds
@@ -36,6 +37,22 @@ const (
 	KindMutatingWebhookConfiguration   = "MutatingWebhookConfiguration"
 	KindSecret                         = "Secret"
 	KindValidatingWebhookConfiguration = "ValidatingWebhookConfiguration"
+)
+
+// rank
+const (
+	RankNamespace                     = 10
+	RankServiceAccount                = 20
+	RankCustomResourceDefinition      = 30
+	RankClusterRole                   = 40
+	RankClusterRoleBinding            = 50
+	RankClusterScopeResourceDefault   = 1000
+	RankRole                          = 2000
+	RankRoleBinding                   = 2010
+	RankNetworkPolicy                 = 2020
+	RankSecret                        = 2030
+	RankConfigMap                     = 2040
+	RankNamespaceScopeResourceDefault = 3000
 )
 
 var decUnstructured = yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
@@ -225,6 +242,48 @@ func ParseResource(data []byte) (string, error) {
 	return obj.GetKind() + "/" + obj.GetNamespace() + "/" + name, nil
 }
 
+func DecideRank(kind, namespace string, rank uint32) (uint32, error) {
+	if rank > 0 {
+		if namespace == "" && rank < 2000 {
+			return rank, nil
+		}
+		if namespace != "" && rank > 1999 {
+			return rank, nil
+		}
+		return 0, errors.New("invalid rank value")
+	}
+	// return default rank
+	switch kind {
+	case "Namespace":
+		return RankNamespace, nil
+	case "ServiceAccount":
+		return RankServiceAccount, nil
+	case "CustomResourceDefinition":
+		return RankCustomResourceDefinition, nil
+	case "ClusterRole":
+		return RankClusterRole, nil
+	case "ClusterRoleBinding":
+		return RankClusterRoleBinding, nil
+		// other cluster-scoped resources: 1000
+	case "Role":
+		return RankRole, nil
+	case "RoleBinding":
+		return RankRoleBinding, nil
+	case "NetworkPolicy":
+		return RankNetworkPolicy, nil
+	case "Secret":
+		return RankSecret, nil
+	case "ConfigMap":
+		return RankConfigMap, nil
+		// other namespace scoped resources: 3000
+	}
+
+	if namespace == "" {
+		return RankClusterScopeResourceDefault, nil
+	}
+	return RankNamespaceScopeResourceDefault, nil
+}
+
 // ResourceDefinition represents a CKE-managed kubernetes resource.
 type ResourceDefinition struct {
 	Key        string
@@ -233,6 +292,7 @@ type ResourceDefinition struct {
 	Name       string
 	Revision   int64
 	Image      string // may contains multiple images; we should not use this whole string as an image name.
+	Rank       uint32
 	Definition []byte
 }
 
@@ -266,45 +326,13 @@ func (d ResourceDefinition) NeedUpdate(rs *ResourceStatus) bool {
 	return curImage != d.Image
 }
 
-func (d ResourceDefinition) rank() int {
-	switch d.Kind {
-	case "Namespace":
-		return 10
-	case "ServiceAccount":
-		return 20
-	case "CustomResourceDefinition":
-		return 30
-	case "ClusterRole":
-		return 40
-	case "ClusterRoleBinding":
-		return 50
-		// other cluster-scoped resources: 1000
-	case "Role":
-		return 2000
-	case "RoleBinding":
-		return 2010
-	case "NetworkPolicy":
-		return 2020
-	case "Secret":
-		return 2030
-	case "ConfigMap":
-		return 2040
-		// other namespace scoped resources: 3000
-	}
-
-	if d.Namespace == "" {
-		return 1000
-	}
-	return 3000
-}
-
 // SortResources sort resources as defined order of creation.
 func SortResources(res []ResourceDefinition) {
 	less := func(i, j int) bool {
 		a := res[i]
 		b := res[j]
-		aRank := a.rank()
-		bRank := b.rank()
+		aRank := a.Rank
+		bRank := b.Rank
 
 		if aRank == bRank {
 			return a.Key < b.Key

--- a/resource.go
+++ b/resource.go
@@ -42,7 +42,7 @@ const (
 // rank
 const (
 	RankNamespace                      = 10
-	RankServiceAccount                 = 20
+	RankServiceAccount                 = 20 // ServiceAccount is namespace scoped
 	RankCustomResourceDefinition       = 30
 	RankClusterRole                    = 40
 	RankClusterRoleBinding             = 50

--- a/resource.go
+++ b/resource.go
@@ -41,18 +41,18 @@ const (
 
 // rank
 const (
-	RankNamespace                     = 10
-	RankServiceAccount                = 20
-	RankCustomResourceDefinition      = 30
-	RankClusterRole                   = 40
-	RankClusterRoleBinding            = 50
-	RankClusterScopeResourceDefault   = 1000
-	RankRole                          = 2000
-	RankRoleBinding                   = 2010
-	RankNetworkPolicy                 = 2020
-	RankSecret                        = 2030
-	RankConfigMap                     = 2040
-	RankNamespaceScopeResourceDefault = 3000
+	RankNamespace                      = 10
+	RankServiceAccount                 = 20
+	RankCustomResourceDefinition       = 30
+	RankClusterRole                    = 40
+	RankClusterRoleBinding             = 50
+	RankClusterScopedResourceDefault   = 1000
+	RankRole                           = 2000
+	RankRoleBinding                    = 2010
+	RankNetworkPolicy                  = 2020
+	RankSecret                         = 2030
+	RankConfigMap                      = 2040
+	RankNamespaceScopedResourceDefault = 3000
 )
 
 var decUnstructured = yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
@@ -279,9 +279,9 @@ func DecideRank(kind, namespace string, rank uint32) (uint32, error) {
 	}
 
 	if namespace == "" {
-		return RankClusterScopeResourceDefault, nil
+		return RankClusterScopedResourceDefault, nil
 	}
-	return RankNamespaceScopeResourceDefault, nil
+	return RankNamespaceScopedResourceDefault, nil
 }
 
 // ResourceDefinition represents a CKE-managed kubernetes resource.

--- a/server/control.go
+++ b/server/control.go
@@ -311,7 +311,6 @@ func (c Controller) runOnce(ctx context.Context, leaderKey string, tick <-chan t
 	if err != nil {
 		return err
 	}
-
 	rqEntries, err := inf.Storage().GetRebootsEntries(ctx)
 	if err != nil {
 		return err
@@ -390,6 +389,11 @@ func (c Controller) runOnce(ctx context.Context, leaderKey string, tick <-chan t
 }
 
 func runOp(ctx context.Context, op cke.Operator, leaderKey string, storage cke.Storage, inf cke.Infrastructure) error {
+	if op.Name() == "nop" {
+		log.Info("execute nop op", map[string]interface{}{})
+		return nil
+	}
+
 	// register operation record
 	id, err := storage.NextRecordID(ctx)
 	if err != nil {

--- a/server/control.go
+++ b/server/control.go
@@ -389,6 +389,7 @@ func (c Controller) runOnce(ctx context.Context, leaderKey string, tick <-chan t
 }
 
 func runOp(ctx context.Context, op cke.Operator, leaderKey string, storage cke.Storage, inf cke.Infrastructure) error {
+	// Not to register the nopOp log in the history
 	if op.Name() == "nop" {
 		log.Info("execute nop op", map[string]interface{}{})
 		return nil

--- a/server/strategy.go
+++ b/server/strategy.go
@@ -602,10 +602,12 @@ func decideResourceOps(apiServer *cke.Node, ks cke.KubernetesClusterStatus, reso
 		status, ok := ks.ResourceStatuses[res.Key]
 		if !ok {
 			ops = append(ops, op.ResourceApplyOp(apiServer, res, !status.HasBeenSSA))
+			// To wait for the completion to create or update, we avoid applying subsequent resources.
 			return ops
 		} else {
 			if res.NeedUpdate(&status) {
 				ops = append(ops, op.ResourceApplyOp(apiServer, res, !status.HasBeenSSA))
+				// To avoid applying subsequent resources not to wait the completion the update or creation
 				return ops
 			} else {
 				if !status.Completed {
@@ -616,6 +618,7 @@ func decideResourceOps(apiServer *cke.Node, ks cke.KubernetesClusterStatus, reso
 						"completed":          status.Completed,
 					})
 					ops = append(ops, op.NopOp())
+					// To avoid applying subsequent resources not to wait the completion the update or creation
 					return ops
 				}
 			}

--- a/server/strategy.go
+++ b/server/strategy.go
@@ -608,13 +608,12 @@ func decideResourceOps(apiServer *cke.Node, ks cke.KubernetesClusterStatus, reso
 				ops = append(ops, op.ResourceApplyOp(apiServer, res, !status.HasBeenSSA))
 				return ops
 			} else {
-				if status.NeedWait() {
+				if !status.Completed {
 					log.Info("need to wait", map[string]interface{}{
 						"resource_name":      res.Name,
 						"resource_namespace": res.Namespace,
 						"kind":               res.Kind,
-						"desired":            status.Desired,
-						"available":          status.Available,
+						"completed":          status.Completed,
 					})
 					ops = append(ops, op.NopOp())
 					return ops

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -166,7 +167,11 @@ func newData() testData {
 		NodeStatuses:  nodeStatuses,
 		Kubernetes: cke.KubernetesClusterStatus{
 			ResourceStatuses: map[string]cke.ResourceStatus{
-				"Namespace/foo": {Annotations: map[string]string{cke.AnnotationResourceRevision: "1"}},
+				"Namespace/foo": {
+					Annotations: map[string]string{cke.AnnotationResourceRevision: "1"},
+					Desired:     -1,
+					Available:   -1,
+				},
 			},
 			Nodes: nodeList,
 		},
@@ -187,6 +192,30 @@ func (d testData) with(f func(data testData)) testData {
 
 func (d testData) withResources(res []cke.ResourceDefinition) testData {
 	d.Resources = res
+	return d
+}
+
+func (d testData) withResourcesReady(res []cke.ResourceDefinition) testData {
+	ks := &d.Status.Kubernetes
+
+	d.Resources = append(d.Resources, res...)
+
+	for _, r := range res {
+		status := cke.ResourceStatus{
+			Annotations: map[string]string{cke.AnnotationResourceRevision: strconv.Itoa(int(r.Revision))},
+		}
+		if r.Image != "" {
+			status.Annotations[cke.AnnotationResourceImage] = r.Image
+		}
+		ks.ResourceStatuses[r.Key] = status
+	}
+	return d
+}
+
+func (d testData) withResourceStatus(statuses map[string]cke.ResourceStatus) testData {
+	for k, v := range statuses {
+		d.Status.Kubernetes.ResourceStatuses[k] = v
+	}
 	return d
 }
 
@@ -384,8 +413,15 @@ func (d testData) withK8sResourceReady() testData {
 	d.withK8sReady()
 	ks := &d.Status.Kubernetes
 	for _, res := range static.Resources {
+		desired, available := -1, -1
+		if res.Kind == "DaemonSet" || res.Kind == "Deployment" {
+			desired = 1
+			available = 1
+		}
 		ks.ResourceStatuses[res.Key] = cke.ResourceStatus{
 			Annotations: map[string]string{cke.AnnotationResourceRevision: "1"},
+			Desired:     desired,
+			Available:   available,
 		}
 	}
 	ks.ResourceStatuses["ClusterRole/system:cluster-dns"].Annotations[cke.AnnotationResourceRevision] = "2"
@@ -1091,14 +1127,6 @@ func TestDecideOps(t *testing.T) {
 				"create-endpointslice",
 				"create-etcd-service",
 				"resource-apply",
-				"resource-apply",
-				"resource-apply",
-				"resource-apply",
-				"resource-apply",
-				"resource-apply",
-				"resource-apply",
-				"resource-apply",
-				"resource-apply",
 			},
 		},
 		{
@@ -1311,27 +1339,169 @@ func TestDecideOps(t *testing.T) {
 		{
 			Name: "UserResourceAdd",
 			Input: newData().withK8sResourceReady().withResources(
-				append(testResources, cke.ResourceDefinition{
-					Key:        "ConfigMap/foo/bar",
-					Kind:       "ConfigMap",
-					Namespace:  "foo",
-					Name:       "bar",
-					Revision:   1,
-					Definition: []byte(`{"apiversion":"v1","kind":"ConfigMap","metadata":{"namespace":"foo","name":"bar"},"data":{"a":"b"}}`),
-				})),
-			ExpectedOps: []string{"resource-apply"},
+				append(testResources, []cke.ResourceDefinition{
+					{
+						Key:        "ConfigMap/foo/bar",
+						Kind:       "ConfigMap",
+						Namespace:  "foo",
+						Name:       "bar",
+						Revision:   1,
+						Definition: []byte(`{"apiversion":"v1","kind":"ConfigMap","metadata":{"namespace":"foo","name":"bar"},"data":{"a":"b"}}`),
+					},
+					{
+						Key:        "DaemonSet/foo/test-daemonset",
+						Kind:       "DaemonSet",
+						Namespace:  "foo",
+						Name:       "test-daemonset",
+						Image:      "test",
+						Revision:   1,
+						Definition: []byte(`{"apiVersion":"v1","kind":"DaemonSet","metadata":{"name":"test-daemonset", "namespace": "test"}}`),
+					},
+					{
+						Key:        "Deployment/foo/test-deployment",
+						Kind:       "Deployment",
+						Namespace:  "foo",
+						Name:       "test-deployment",
+						Image:      "test",
+						Revision:   1,
+						Definition: []byte(`{"apiVersion":"v1","kind":"Deployment","metadata":{"name":"test-deployment", "namespace": "test"}}`),
+					},
+				}...)).withResourceStatus(
+				map[string]cke.ResourceStatus{
+					"ConfigMap/foo/bar": {
+						Desired:   -1,
+						Available: -1,
+					},
+					"DaemonSet/foo/test-daemonset": {
+						Annotations: map[string]string{
+							cke.AnnotationResourceRevision: "1",
+							cke.AnnotationResourceImage:    "test",
+						},
+						Desired:   1,
+						Available: 0,
+					},
+				},
+			),
+			ExpectedOps: []string{
+				"resource-apply",
+			},
 		},
 		{
 			Name: "UserResourceUpdate",
-			Input: newData().withK8sResourceReady().withResources(
-				[]cke.ResourceDefinition{{
-					Key:        "Namespace/foo",
-					Kind:       "Namespace",
-					Name:       "foo",
+			Input: newData().withK8sResourceReady().withResourcesReady([]cke.ResourceDefinition{
+				{
+					Key:        "DaemonSet/foo/test-daemonset",
+					Kind:       "DaemonSet",
+					Namespace:  "foo",
+					Name:       "test-daemonset",
+					Image:      "test",
 					Revision:   2,
-					Definition: []byte(`{"apiversion":"v1","kind":"Namespace","metadata":{"name":"foo"}}`),
-				}}),
-			ExpectedOps: []string{"resource-apply"},
+					Definition: []byte(`{"apiVersion":"v1","kind":"DaemonSet","metadata":{"name":"test-daemonset", "namespace": "test"}}`),
+				},
+				{
+					Key:        "Deployment/foo/test-deployment",
+					Kind:       "Deployment",
+					Namespace:  "foo",
+					Name:       "test-deployment",
+					Image:      "test",
+					Revision:   1,
+					Definition: []byte(`{"apiVersion":"v1","kind":"Deployment","metadata":{"name":"test-deployment", "namespace": "test"}}`),
+				},
+			}).withResources(
+				[]cke.ResourceDefinition{
+					{
+						Key:        "Namespace/foo",
+						Kind:       "Namespace",
+						Name:       "foo",
+						Revision:   2,
+						Definition: []byte(`{"apiversion":"v1","kind":"Namespace","metadata":{"name":"foo"}}`),
+					},
+					{
+						Key:        "DaemonSet/foo/test-daemonset",
+						Kind:       "DaemonSet",
+						Namespace:  "foo",
+						Name:       "test-daemonset",
+						Image:      "test",
+						Revision:   2,
+						Definition: []byte(`{"apiVersion":"v1","kind":"DaemonSet","metadata":{"name":"test-daemonset", "namespace": "test"}}`),
+					},
+					{
+						Key:        "Deployment/foo/test-deployment",
+						Kind:       "Deployment",
+						Namespace:  "foo",
+						Name:       "test-deployment",
+						Image:      "test",
+						Revision:   2,
+						Definition: []byte(`{"apiVersion":"v1","kind":"Deployment","metadata":{"name":"test-deployment", "namespace": "test"}}`),
+					},
+				}).withResourceStatus(map[string]cke.ResourceStatus{
+				"Namespace/foo": {
+					Desired:   -1,
+					Available: -1,
+				},
+				"DaemonSet/foo/test-daemonset": {
+					Annotations: map[string]string{
+						cke.AnnotationResourceRevision: "2",
+						cke.AnnotationResourceImage:    "test",
+					},
+					Desired:   1,
+					Available: 0,
+				},
+				"Deployment/foo/test-deployment": {
+					Annotations: map[string]string{
+						cke.AnnotationResourceRevision: "1",
+						cke.AnnotationResourceImage:    "test",
+					},
+					Desired:   2,
+					Available: 1,
+				},
+			}),
+			ExpectedOps: []string{
+				"resource-apply",
+			},
+		},
+		{
+			Name: "UserResourceNop",
+			Input: newData().withK8sResourceReady().withResourcesReady([]cke.ResourceDefinition{
+				{
+					Key:        "DaemonSet/foo/test-daemonset",
+					Kind:       "DaemonSet",
+					Namespace:  "foo",
+					Name:       "test-daemonset",
+					Image:      "test",
+					Revision:   2,
+					Definition: []byte(`{"apiVersion":"v1","kind":"DaemonSet","metadata":{"name":"test-daemonset", "namespace": "test"}}`),
+				},
+				{
+					Key:        "Deployment/foo/test-deployment",
+					Kind:       "Deployment",
+					Namespace:  "foo",
+					Name:       "test-deployment",
+					Image:      "test",
+					Revision:   1,
+					Definition: []byte(`{"apiVersion":"v1","kind":"Deployment","metadata":{"name":"test-deployment", "namespace": "test"}}`),
+				},
+			}).withResourceStatus(map[string]cke.ResourceStatus{
+				"DaemonSet/foo/test-daemonset": {
+					Annotations: map[string]string{
+						cke.AnnotationResourceRevision: "2",
+						cke.AnnotationResourceImage:    "test",
+					},
+					Desired:   2,
+					Available: 0,
+				},
+				"Deployment/foo/test-deployment": {
+					Annotations: map[string]string{
+						cke.AnnotationResourceRevision: "1",
+						cke.AnnotationResourceImage:    "test",
+					},
+					Desired:   1,
+					Available: 0,
+				},
+			}),
+			ExpectedOps: []string{
+				"nop",
+			},
 		},
 		{
 			Name: "NodeLabel1",

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -169,8 +169,7 @@ func newData() testData {
 			ResourceStatuses: map[string]cke.ResourceStatus{
 				"Namespace/foo": {
 					Annotations: map[string]string{cke.AnnotationResourceRevision: "1"},
-					Desired:     -1,
-					Available:   -1,
+					Completed:   true,
 				},
 			},
 			Nodes: nodeList,
@@ -413,15 +412,9 @@ func (d testData) withK8sResourceReady() testData {
 	d.withK8sReady()
 	ks := &d.Status.Kubernetes
 	for _, res := range static.Resources {
-		desired, available := -1, -1
-		if res.Kind == "DaemonSet" || res.Kind == "Deployment" {
-			desired = 1
-			available = 1
-		}
 		ks.ResourceStatuses[res.Key] = cke.ResourceStatus{
 			Annotations: map[string]string{cke.AnnotationResourceRevision: "1"},
-			Desired:     desired,
-			Available:   available,
+			Completed:   true,
 		}
 	}
 	ks.ResourceStatuses["ClusterRole/system:cluster-dns"].Annotations[cke.AnnotationResourceRevision] = "2"
@@ -1369,16 +1362,14 @@ func TestDecideOps(t *testing.T) {
 				}...)).withResourceStatus(
 				map[string]cke.ResourceStatus{
 					"ConfigMap/foo/bar": {
-						Desired:   -1,
-						Available: -1,
+						Completed: true,
 					},
 					"DaemonSet/foo/test-daemonset": {
 						Annotations: map[string]string{
 							cke.AnnotationResourceRevision: "1",
 							cke.AnnotationResourceImage:    "test",
 						},
-						Desired:   1,
-						Available: 0,
+						Completed: false,
 					},
 				},
 			),
@@ -1436,24 +1427,21 @@ func TestDecideOps(t *testing.T) {
 					},
 				}).withResourceStatus(map[string]cke.ResourceStatus{
 				"Namespace/foo": {
-					Desired:   -1,
-					Available: -1,
+					Completed: true,
 				},
 				"DaemonSet/foo/test-daemonset": {
 					Annotations: map[string]string{
 						cke.AnnotationResourceRevision: "2",
 						cke.AnnotationResourceImage:    "test",
 					},
-					Desired:   1,
-					Available: 0,
+					Completed: false,
 				},
 				"Deployment/foo/test-deployment": {
 					Annotations: map[string]string{
 						cke.AnnotationResourceRevision: "1",
 						cke.AnnotationResourceImage:    "test",
 					},
-					Desired:   2,
-					Available: 1,
+					Completed: false,
 				},
 			}),
 			ExpectedOps: []string{
@@ -1487,16 +1475,14 @@ func TestDecideOps(t *testing.T) {
 						cke.AnnotationResourceRevision: "2",
 						cke.AnnotationResourceImage:    "test",
 					},
-					Desired:   2,
-					Available: 0,
+					Completed: false,
 				},
 				"Deployment/foo/test-deployment": {
 					Annotations: map[string]string{
 						cke.AnnotationResourceRevision: "1",
 						cke.AnnotationResourceImage:    "test",
 					},
-					Desired:   1,
-					Available: 0,
+					Completed: false,
 				},
 			}),
 			ExpectedOps: []string{

--- a/static/resources.go
+++ b/static/resources.go
@@ -16,6 +16,7 @@ var Resources = []cke.ResourceDefinition{
 		Name:       "cke-cluster-dns",
 		Revision:   1,
 		Image:      "",
+		Rank:       20,
 		Definition: []byte("apiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: cke-cluster-dns\n  namespace: kube-system\n  annotations:\n    cke.cybozu.com/revision: \"1\"\n"),
 	},
 	{
@@ -25,6 +26,7 @@ var Resources = []cke.ResourceDefinition{
 		Name:       "system:cluster-dns",
 		Revision:   2,
 		Image:      "",
+		Rank:       40,
 		Definition: []byte("\nkind: ClusterRole\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n  name: system:cluster-dns\n  labels:\n    kubernetes.io/bootstrapping: rbac-defaults\n  annotations:\n    cke.cybozu.com/revision: \"2\"\n    # turn on auto-reconciliation\n    # https://kubernetes.io/docs/reference/access-authn-authz/rbac/#auto-reconciliation\n    rbac.authorization.kubernetes.io/autoupdate: \"true\"\nrules:\n  - apiGroups:\n      - \"\"\n    resources:\n      - endpoints\n      - services\n      - pods\n      - namespaces\n    verbs:\n      - list\n      - watch\n  - apiGroups:\n      - discovery.k8s.io\n    resources:\n      - endpointslices\n    verbs:\n      - list\n      - watch\n"),
 	},
 	{
@@ -34,6 +36,7 @@ var Resources = []cke.ResourceDefinition{
 		Name:       "system:kube-apiserver-to-kubelet",
 		Revision:   1,
 		Image:      "",
+		Rank:       40,
 		Definition: []byte("kind: ClusterRole\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n  name: system:kube-apiserver-to-kubelet\n  labels:\n    kubernetes.io/bootstrapping: rbac-defaults\n  annotations:\n    cke.cybozu.com/revision: \"1\"\n    # turn on auto-reconciliation\n    # https://kubernetes.io/docs/reference/access-authn-authz/rbac/#auto-reconciliation\n    rbac.authorization.kubernetes.io/autoupdate: \"true\"\nrules:\n  - apiGroups: [\"\"]\n    resources:\n      - nodes/proxy\n      - nodes/stats\n      - nodes/log\n      - nodes/spec\n      - nodes/metrics\n    verbs: [\"*\"]\n"),
 	},
 	{
@@ -43,6 +46,7 @@ var Resources = []cke.ResourceDefinition{
 		Name:       "system:cluster-dns",
 		Revision:   1,
 		Image:      "",
+		Rank:       50,
 		Definition: []byte("\nkind: ClusterRoleBinding\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n  name: system:cluster-dns\n  labels:\n    kubernetes.io/bootstrapping: rbac-defaults\n  annotations:\n    cke.cybozu.com/revision: \"1\"\n    rbac.authorization.kubernetes.io/autoupdate: \"true\"\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: ClusterRole\n  name: system:cluster-dns\nsubjects:\n- kind: ServiceAccount\n  name: cke-cluster-dns\n  namespace: kube-system\n"),
 	},
 	{
@@ -52,6 +56,7 @@ var Resources = []cke.ResourceDefinition{
 		Name:       "system:kube-apiserver",
 		Revision:   1,
 		Image:      "",
+		Rank:       50,
 		Definition: []byte("kind: ClusterRoleBinding\napiVersion: rbac.authorization.k8s.io/v1\nmetadata:\n  name: system:kube-apiserver\n  labels:\n    kubernetes.io/bootstrapping: rbac-defaults\n  annotations:\n    cke.cybozu.com/revision: \"1\"\n    rbac.authorization.kubernetes.io/autoupdate: \"true\"\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: ClusterRole\n  name: system:kube-apiserver-to-kubelet\nsubjects:\n- kind: User\n  name: kubernetes\n"),
 	},
 	{
@@ -61,6 +66,7 @@ var Resources = []cke.ResourceDefinition{
 		Name:       "node-dns",
 		Revision:   4,
 		Image:      "quay.io/cybozu/unbound:1.17.1.3,quay.io/cybozu/unbound_exporter:0.4.1.5",
+		Rank:       3000,
 		Definition: []byte("kind: DaemonSet\napiVersion: apps/v1\nmetadata:\n  name: node-dns\n  namespace: kube-system\n  annotations:\n    cke.cybozu.com/image: \"quay.io/cybozu/unbound:1.17.1.3,quay.io/cybozu/unbound_exporter:0.4.1.5\"\n    cke.cybozu.com/revision: \"4\"\nspec:\n  selector:\n    matchLabels:\n      cke.cybozu.com/appname: node-dns\n  updateStrategy:\n    type: RollingUpdate\n    rollingUpdate:\n      maxSurge: 35%\n      maxUnavailable: 0\n  template:\n    metadata:\n      labels:\n        cke.cybozu.com/appname: node-dns\n    spec:\n      priorityClassName: system-node-critical\n      nodeSelector:\n        kubernetes.io/os: linux\n      hostNetwork: true\n      tolerations:\n        - operator: Exists\n      terminationGracePeriodSeconds: 1\n      containers:\n        - name: unbound\n          image: quay.io/cybozu/unbound:1.17.1.3\n          args:\n            - -c\n            - /etc/unbound/unbound.conf\n          securityContext:\n            allowPrivilegeEscalation: false\n            capabilities:\n              add:\n              - NET_BIND_SERVICE\n              drop:\n              - all\n            readOnlyRootFilesystem: true\n          readinessProbe:\n            tcpSocket:\n              port: 53\n              host: localhost\n            periodSeconds: 1\n          livenessProbe:\n            tcpSocket:\n              port: 53\n              host: localhost\n            periodSeconds: 1\n            initialDelaySeconds: 1\n            failureThreshold: 6\n          volumeMounts:\n            - name: config-volume\n              mountPath: /etc/unbound\n            - name: var-run-unbound\n              mountPath: /var/run/unbound\n        - name: reload\n          image: quay.io/cybozu/unbound:1.17.1.3\n          command:\n          - /usr/local/bin/reload-unbound\n          securityContext:\n            allowPrivilegeEscalation: false\n            capabilities:\n              drop:\n              - all\n            readOnlyRootFilesystem: true\n          volumeMounts:\n            - name: config-volume\n              mountPath: /etc/unbound\n            - name: var-run-unbound\n              mountPath: /var/run/unbound\n        - name: exporter\n          image: quay.io/cybozu/unbound_exporter:0.4.1.5\n          args:\n          # must be same with the path written in /op/nodedns/nodedns.go\n          - --unbound.host=unix:///var/run/unbound/unbound.sock\n          - --web.reuse-port=true\n          securityContext:\n            allowPrivilegeEscalation: false\n            capabilities:\n              drop:\n              - all\n            readOnlyRootFilesystem: true\n          volumeMounts:\n            - name: var-run-unbound\n              mountPath: /var/run/unbound\n      volumes:\n        - name: config-volume\n          configMap:\n            name: node-dns\n            items:\n            - key: unbound.conf\n              path: unbound.conf\n        - name: var-run-unbound\n          emptyDir: {}\n"),
 	},
 	{
@@ -70,6 +76,7 @@ var Resources = []cke.ResourceDefinition{
 		Name:       "cluster-dns",
 		Revision:   4,
 		Image:      "quay.io/cybozu/coredns:1.10.0.2",
+		Rank:       3000,
 		Definition: []byte("\nkind: Deployment\napiVersion: apps/v1\nmetadata:\n  name: cluster-dns\n  namespace: kube-system\n  annotations:\n    cke.cybozu.com/image: \"quay.io/cybozu/coredns:1.10.0.2\"\n    cke.cybozu.com/revision: \"4\"\nspec:\n  replicas: 2\n  strategy:\n    type: RollingUpdate\n    rollingUpdate:\n      maxUnavailable: 1\n  selector:\n    matchLabels:\n      cke.cybozu.com/appname: cluster-dns\n  template:\n    metadata:\n      labels:\n        cke.cybozu.com/appname: cluster-dns\n        k8s-app: coredns # sonobuoy requires\n      annotations:\n        prometheus.io/port: \"9153\"\n    spec:\n      priorityClassName: system-cluster-critical\n      serviceAccountName: cke-cluster-dns\n      tolerations:\n        - key: node-role.kubernetes.io/master\n          effect: NoSchedule\n        - key: \"CriticalAddonsOnly\"\n          operator: \"Exists\"\n        - key: kubernetes.io/e2e-evict-taint-key\n          operator: Exists\n          # for sonobuoy https://github.com/vmware-tanzu/sonobuoy/pull/878\n      containers:\n      - name: coredns\n        image: quay.io/cybozu/coredns:1.10.0.2\n        imagePullPolicy: IfNotPresent\n        resources:\n          requests:\n            cpu: 100m\n            memory: 70Mi\n        args: [ \"-conf\", \"/etc/coredns/Corefile\" ]\n        lifecycle:\n          preStop:\n            exec:\n              command: [\"sh\", \"-c\", \"sleep 5\"]\n        volumeMounts:\n        - name: config-volume\n          mountPath: /etc/coredns\n          readOnly: true\n        ports:\n        - containerPort: 1053\n          name: dns\n          protocol: UDP\n        - containerPort: 1053\n          name: dns-tcp\n          protocol: TCP\n        - containerPort: 9153\n          name: metrics\n          protocol: TCP\n        securityContext:\n          allowPrivilegeEscalation: false\n          capabilities:\n            drop:\n            - all\n          readOnlyRootFilesystem: true\n        readinessProbe:\n          httpGet:\n            path: /ready\n            port: 8181\n            scheme: HTTP\n        livenessProbe:\n          httpGet:\n            path: /health\n            port: 8080\n            scheme: HTTP\n          initialDelaySeconds: 60\n          timeoutSeconds: 5\n          successThreshold: 1\n          failureThreshold: 5\n      dnsPolicy: Default\n      volumes:\n        - name: config-volume\n          configMap:\n            name: cluster-dns\n            items:\n            - key: Corefile\n              path: Corefile\n      affinity:\n        podAntiAffinity:\n          requiredDuringSchedulingIgnoredDuringExecution:\n          - labelSelector:\n              matchLabels:\n                cke.cybozu.com/appname: cluster-dns\n            topologyKey: \"kubernetes.io/hostname\"\n"),
 	},
 	{
@@ -79,6 +86,7 @@ var Resources = []cke.ResourceDefinition{
 		Name:       "cluster-dns-pdb",
 		Revision:   1,
 		Image:      "",
+		Rank:       3000,
 		Definition: []byte("\napiVersion: policy/v1\nkind: PodDisruptionBudget\nmetadata:\n  name: cluster-dns-pdb\n  namespace: kube-system\n  annotations:\n    cke.cybozu.com/revision: \"1\"\nspec:\n  maxUnavailable: 1\n  selector:\n    matchLabels:\n      cke.cybozu.com/appname: cluster-dns\n"),
 	},
 	{
@@ -88,6 +96,7 @@ var Resources = []cke.ResourceDefinition{
 		Name:       "cluster-dns",
 		Revision:   1,
 		Image:      "",
+		Rank:       3000,
 		Definition: []byte("\nkind: Service\napiVersion: v1\nmetadata:\n  name: cluster-dns\n  namespace: kube-system\n  annotations:\n    cke.cybozu.com/revision: \"1\"\n  labels:\n    cke.cybozu.com/appname: cluster-dns\nspec:\n  selector:\n    cke.cybozu.com/appname: cluster-dns\n  ports:\n    - name: dns\n      port: 53\n      targetPort: 1053\n      protocol: UDP\n    - name: dns-tcp\n      port: 53\n      targetPort: 1053\n      protocol: TCP\n"),
 	},
 }

--- a/status.go
+++ b/status.go
@@ -48,6 +48,19 @@ type ResourceStatus struct {
 	Annotations map[string]string
 	// HasBeenSSA indicates that this resource has been already updated by server-side apply
 	HasBeenSSA bool
+	Desired    int
+	Available  int
+}
+
+func (r ResourceStatus) NeedWait() bool {
+	// return r.Desired != r.Available
+	if r.Desired == -1 {
+		return false
+	}
+	if r.Desired == 0 {
+		return true
+	}
+	return r.Desired > r.Available
 }
 
 // IsReady returns the cluster condition whether or not Pod can be scheduled
@@ -75,8 +88,8 @@ func (s KubernetesClusterStatus) IsReady(cluster *Cluster) bool {
 }
 
 // SetResourceStatus sets status of the resource.
-func (s KubernetesClusterStatus) SetResourceStatus(rkey string, ann map[string]string, isManaged bool) {
-	s.ResourceStatuses[rkey] = ResourceStatus{Annotations: ann, HasBeenSSA: isManaged}
+func (s KubernetesClusterStatus) SetResourceStatus(rkey string, ann map[string]string, isManaged bool, desired, available int) {
+	s.ResourceStatuses[rkey] = ResourceStatus{Annotations: ann, HasBeenSSA: isManaged, Desired: desired, Available: available}
 }
 
 // ClusterStatus represents the working cluster status.

--- a/status.go
+++ b/status.go
@@ -48,19 +48,7 @@ type ResourceStatus struct {
 	Annotations map[string]string
 	// HasBeenSSA indicates that this resource has been already updated by server-side apply
 	HasBeenSSA bool
-	Desired    int
-	Available  int
-}
-
-func (r ResourceStatus) NeedWait() bool {
-	// return r.Desired != r.Available
-	if r.Desired == -1 {
-		return false
-	}
-	if r.Desired == 0 {
-		return true
-	}
-	return r.Desired > r.Available
+	Completed  bool
 }
 
 // IsReady returns the cluster condition whether or not Pod can be scheduled
@@ -88,8 +76,8 @@ func (s KubernetesClusterStatus) IsReady(cluster *Cluster) bool {
 }
 
 // SetResourceStatus sets status of the resource.
-func (s KubernetesClusterStatus) SetResourceStatus(rkey string, ann map[string]string, isManaged bool, desired, available int) {
-	s.ResourceStatuses[rkey] = ResourceStatus{Annotations: ann, HasBeenSSA: isManaged, Desired: desired, Available: available}
+func (s KubernetesClusterStatus) SetResourceStatus(rkey string, ann map[string]string, isManaged, completed bool) {
+	s.ResourceStatuses[rkey] = ResourceStatus{Annotations: ann, HasBeenSSA: isManaged, Completed: completed}
 }
 
 // ClusterStatus represents the working cluster status.

--- a/storage.go
+++ b/storage.go
@@ -563,12 +563,18 @@ func (s Storage) GetAllResources(ctx context.Context) ([]ResourceDefinition, err
 			return nil, errors.New("invalid resource key: " + key)
 		}
 
+		rank, err := DecideRank(kind, namespace, 0)
+		if err != nil {
+			return nil, err
+		}
+
 		rcs = append(rcs, ResourceDefinition{
 			Key:        key,
 			Kind:       kind,
 			Namespace:  namespace,
 			Name:       name,
 			Revision:   kv.ModRevision,
+			Rank:       rank,
 			Definition: kv.Value,
 		})
 	}

--- a/storage.go
+++ b/storage.go
@@ -12,6 +12,7 @@ import (
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/clientv3util"
+	"sigs.k8s.io/yaml"
 )
 
 // Storage provides operations to store/retrieve CKE data in etcd.
@@ -563,7 +564,20 @@ func (s Storage) GetAllResources(ctx context.Context) ([]ResourceDefinition, err
 			return nil, errors.New("invalid resource key: " + key)
 		}
 
-		rank, err := DecideRank(kind, namespace, 0)
+		obj := struct {
+			Metadata struct {
+				Annotations struct {
+					Revision int64  `json:"cke.cybozu.com/revision,string"`
+					Image    string `json:"cke.cybozu.com/image"`
+					Rank     uint32 `json:"cke.cybozu.com/rank,string"`
+				} `json:"annotations"`
+			} `json:"metadata"`
+		}{}
+		if err := yaml.Unmarshal(kv.Value, &obj); err != nil {
+			return nil, err
+		}
+
+		rank, err := DecideRank(kind, namespace, obj.Metadata.Annotations.Rank)
 		if err != nil {
 			return nil, err
 		}

--- a/storage_test.go
+++ b/storage_test.go
@@ -467,12 +467,22 @@ func testStorageResource(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	err = storage.SetResource(ctx, "Deployment/foo/deploy1", "\nkind: Deployment\napiVersion: apps/v1\nmetadata:\n  name: cluster-dns\n  namespace: kube-system\n  annotations:\n    cke.cybozu.com/image: \"quay.io/cybozu/coredns:1.10.0.1\"\n    cke.cybozu.com/revision: \"4\"\n    cke.cybozu.com/rank: \"2100\"\nspec:\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = storage.SetResource(ctx, "DaemonSet/foo/ds1", "kind: DaemonSet\napiVersion: apps/v1\nmetadata:\n  name: node-dns\n  namespace: kube-system\n  annotations:\n    cke.cybozu.com/image: \"quay.io/cybozu/unbound:1.17.1.1,quay.io/cybozu/unbound_exporter:0.4.1.4\"\n    cke.cybozu.com/revision: \"4\"\n    cke.cybozu.com/rank: \"2200\"\nspec:\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	resources, err := storage.GetAllResources(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	expected := []string{"Namespace/foo", "ServiceAccount/foo/sa1", "ConfigMap/foo/conf1", "Pod/foo/pod1"}
+	expected := []string{"Namespace/foo", "ServiceAccount/foo/sa1", "ConfigMap/foo/conf1", "DaemonSet/foo/ds1", "Deployment/foo/deploy1", "Pod/foo/pod1"}
 	actual := make([]string, len(resources))
 	for i, r := range resources {
 		actual[i] = r.Key

--- a/storage_test.go
+++ b/storage_test.go
@@ -430,7 +430,7 @@ func testStorageResource(t *testing.T) {
 		t.Error(`err != ErrNotFound,`, err)
 	}
 
-	err = storage.SetResource(ctx, "Namespace/foo", "bar")
+	err = storage.SetResource(ctx, "Namespace/foo", "kind: Namespace\napiVersion: v1\nmetadata:\n  name: foo\n")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -439,11 +439,11 @@ func testStorageResource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(fooVal) != "bar" {
-		t.Error(`string(fooVal) != "bar",`, string(fooVal))
+	if string(fooVal) != "kind: Namespace\napiVersion: v1\nmetadata:\n  name: foo\n" {
+		t.Error(`string(fooVal) != "kind: Namespace\napiVersion: v1\nmetadata:\n  name: foo\n",`, string(fooVal))
 	}
 
-	err = storage.SetResource(ctx, "Pod/foo/pod1", "test")
+	err = storage.SetResource(ctx, "Pod/foo/pod1", "kind: Pod\napiVersion: v1\nmetadata:\n  name: pod1\n  namespace: foo\n")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -457,22 +457,22 @@ func testStorageResource(t *testing.T) {
 		t.Error("unexpected list result:", cmp.Diff(expectedKeys, keys))
 	}
 
-	err = storage.SetResource(ctx, "ConfigMap/foo/conf1", "test")
+	err = storage.SetResource(ctx, "ConfigMap/foo/conf1", "kind: ConfigMap\napiVersion: v1\nmetadata:\n  name: conf1\n  namespace: foo\n")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = storage.SetResource(ctx, "ServiceAccount/foo/sa1", "test")
+	err = storage.SetResource(ctx, "ServiceAccount/foo/sa1", "kind: ConfigMap\napiVersion: v1\nmetadata:\n  name: sa1\n  namespace: foo\n")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = storage.SetResource(ctx, "Deployment/foo/deploy1", "\nkind: Deployment\napiVersion: apps/v1\nmetadata:\n  name: cluster-dns\n  namespace: kube-system\n  annotations:\n    cke.cybozu.com/image: \"quay.io/cybozu/coredns:1.10.0.1\"\n    cke.cybozu.com/revision: \"4\"\n    cke.cybozu.com/rank: \"2100\"\nspec:\n")
+	err = storage.SetResource(ctx, "Deployment/foo/deploy1", "\nkind: Deployment\napiVersion: apps/v1\nmetadata:\n  name: cluster-dns\n  namespace: kube-system\n  annotations:\n    cke.cybozu.com/image: \"quay.io/cybozu/coredns:1.10.0.1\"\n    cke.cybozu.com/revision: \"4\"\n    cke.cybozu.com/rank: \"2200\"\nspec:\n")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = storage.SetResource(ctx, "DaemonSet/foo/ds1", "kind: DaemonSet\napiVersion: apps/v1\nmetadata:\n  name: node-dns\n  namespace: kube-system\n  annotations:\n    cke.cybozu.com/image: \"quay.io/cybozu/unbound:1.17.1.1,quay.io/cybozu/unbound_exporter:0.4.1.4\"\n    cke.cybozu.com/revision: \"4\"\n    cke.cybozu.com/rank: \"2200\"\nspec:\n")
+	err = storage.SetResource(ctx, "DaemonSet/foo/ds1", "kind: DaemonSet\napiVersion: apps/v1\nmetadata:\n  name: node-dns\n  namespace: kube-system\n  annotations:\n    cke.cybozu.com/image: \"quay.io/cybozu/unbound:1.17.1.1,quay.io/cybozu/unbound_exporter:0.4.1.4\"\n    cke.cybozu.com/revision: \"4\"\n    cke.cybozu.com/rank: \"2100\"\nspec:\n")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR adds two features described below.

1. We can customize the order of applying resources.
2. When applying Deployment and Daemonset resources, cke waits to complete the creation or update.


We can specify the resource application order using the `cke.cybozu.com/rank` annotation. 
Please see [docs/user-resources.md](https://github.com/cybozu-go/cke/pull/617/files#diff-6bbb0727cc2dd5e0e6ed4fdc2ed3af852e555c27972e71d1f3ae052ccda095ed) for detail.

And When we create or update Deployment or DaemonSet resources, cke checks if the update or creation is completed.
If it is not completed, cke runs the `nopOp` that does nothing to wait.