### PR TITLE
Fix Calico manifest to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project employs a versioning scheme described in [RELEASE.md](RELEASE.md#ve
 
 ## [1.25.2]
 
+### Fixed
+
+- Fix Calico manifest to latest version [#627](https://github.com/cybozu-go/cke/pull/627)
+ 
 ### Changed
 
 - Update for Kubernetes 1.25.9 [#624](https://github.com/cybozu-go/cke/pull/624)

--- a/example/kustomization.yaml
+++ b/example/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://raw.githubusercontent.com/projectcalico/calico/master/manifests/calico.yaml 
+- https://raw.githubusercontent.com/projectcalico/calico/v3.25.1/manifests/calico.yaml


### PR DESCRIPTION
The Calico manifest currently used in CKE testing is from the master branch and contains pre-release changes.
Since CKE does not need to use the pre-relase manifest of Calico, I have changed the file to use the manifest of the latest version of Calico.