### PR TITLE
Limit the number of components (kubelet, kube-proxy and rivers) that can be updated simultaneously

### DIFF
--- a/bin/env
+++ b/bin/env
@@ -1,5 +1,5 @@
 PROJECT=neco-test
-ZONE=asia-northeast1-c
+ZONE=asia-northeast2-c
 SERVICE_ACCOUNT=neco-test@neco-test.iam.gserviceaccount.com
 MACHINE_TYPE=c2-standard-30
 DISK_TYPE=pd-ssd

--- a/bin/env-sonobuoy
+++ b/bin/env-sonobuoy
@@ -1,5 +1,5 @@
 PROJECT=neco-test
-ZONE=asia-northeast1-c
+ZONE=asia-northeast2-c
 SERVICE_ACCOUNT=neco-test@neco-test.iam.gserviceaccount.com
 MACHINE_TYPE_SONOBUOY=c2-standard-4
 MACHINE_TYPE_WORKER=c2-standard-8

--- a/docs/cke.md
+++ b/docs/cke.md
@@ -11,15 +11,16 @@ Usage
 
 ```console
 Usage of ./cke:
-      --certs-gc-interval string   tidy interval for expired certificates (default "1h")
-      --config string              configuration file path (default "/etc/cke/config.yml")
-      --debug-sabakan              debug sabakan integration
-      --http string                <Listen IP>:<Port number> (default "0.0.0.0:10180")
-      --interval string            check interval (default "1m")
-      --logfile string             Log filename
-      --logformat string           Log format [plain,logfmt,json]
-      --loglevel string            Log level [critical,error,warning,info,debug]
-      --session-ttl string         leader session's TTL (default "60s")
+      --certs-gc-interval string     tidy interval for expired certificates (default "1h")  
+      --config string                configuration file path (default "/etc/cke/config.yml")
+      --debug-sabakan                debug sabakan integration                              
+      --http string                  <Listen IP>:<Port number> (default "0.0.0.0:10180")    
+      --interval string              check interval (default "1m")
+      --logfile string               Log filename
+      --logformat string             Log format [plain,logfmt,json]
+      --loglevel string              Log level [critical,error,warning,info,debug]
+      --max-concurrent-updates int   the maximum number of components that can be updated simultaneously (default 10)
+      --session-ttl string           leader session's TTL (default "60s")
 ```
 
 Configuration file

--- a/docs/cluster_overview.md
+++ b/docs/cluster_overview.md
@@ -53,6 +53,10 @@ components connect to kube-apiservers via it
 
 ![Worker Nodes](http://www.plantuml.com/plantuml/png/bP5FYuCm4CNl-HI3fzs31yVx8ko7sEEIwb2ACP4nwHzAltjD6a75XdfxlFVcyOEf1YlPkau9mLHRgO-A8Firsh9Hq2kfAGCvGFro_eDJxEZYZcufX3RDsFipt1A7mYN80ku2OBRKkWCfig4ITR5iz6okjv07vTElR-3JcNWOtQYyFTr3xlhyPnQ4mxNzU0k97q1Y4XAt8RqztIzeS89SsHuoyiPWzRz4YAcmZ26cPZ4rYzkpeYBTk4uz0G00)
 
+CKE deploys each worker-node component concurrently on multiple nodes.
+You can control the deployment concurrency by specifying the `max-concurrent-updates`
+command-line option.
+
 Control Plane Nodes
 -------------------
 

--- a/mtest/run_test.go
+++ b/mtest/run_test.go
@@ -341,7 +341,7 @@ func connectEtcd() (*clientv3.Client, error) {
 }
 
 func getClusterStatus(cluster *cke.Cluster) (*cke.ClusterStatus, []cke.ResourceDefinition, error) {
-	controller := server.NewController(nil, 0, time.Hour, time.Second*2, nil)
+	controller := server.NewController(nil, 0, time.Hour, time.Second*2, nil, 10)
 
 	etcd, err := connectEtcd()
 	if err != nil {

--- a/pkg/cke/main.go
+++ b/pkg/cke/main.go
@@ -19,12 +19,13 @@ import (
 )
 
 var (
-	flgHTTP            = pflag.String("http", "0.0.0.0:10180", "<Listen IP>:<Port number>")
-	flgConfigPath      = pflag.String("config", "/etc/cke/config.yml", "configuration file path")
-	flgInterval        = pflag.String("interval", "1m", "check interval")
-	flgCertsGCInterval = pflag.String("certs-gc-interval", "1h", "tidy interval for expired certificates")
-	flgSessionTTL      = pflag.String("session-ttl", "60s", "leader session's TTL")
-	flgDebugSabakan    = pflag.Bool("debug-sabakan", false, "debug sabakan integration")
+	flgHTTP                         = pflag.String("http", "0.0.0.0:10180", "<Listen IP>:<Port number>")
+	flgConfigPath                   = pflag.String("config", "/etc/cke/config.yml", "configuration file path")
+	flgInterval                     = pflag.String("interval", "1m", "check interval")
+	flgCertsGCInterval              = pflag.String("certs-gc-interval", "1h", "tidy interval for expired certificates")
+	flgSessionTTL                   = pflag.String("session-ttl", "60s", "leader session's TTL")
+	flgDebugSabakan                 = pflag.Bool("debug-sabakan", false, "debug sabakan integration")
+	flgMaxConcurrentKubeletRestarts = pflag.Int("max-concurrent-kubelet-restarts", 10, "the maximum number of Kubelet instances that can be restarted simultaneously")
 )
 
 func loadConfig(p string) (*etcdutil.Config, error) {
@@ -109,7 +110,7 @@ func main() {
 	}
 
 	// Controller
-	controller := server.NewController(session, interval, gcInterval, timeout, addon)
+	controller := server.NewController(session, interval, gcInterval, timeout, addon, *flgMaxConcurrentKubeletRestarts)
 	well.Go(controller.Run)
 
 	// API server

--- a/pkg/cke/main.go
+++ b/pkg/cke/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"os"
 	"time"
@@ -19,13 +20,13 @@ import (
 )
 
 var (
-	flgHTTP                         = pflag.String("http", "0.0.0.0:10180", "<Listen IP>:<Port number>")
-	flgConfigPath                   = pflag.String("config", "/etc/cke/config.yml", "configuration file path")
-	flgInterval                     = pflag.String("interval", "1m", "check interval")
-	flgCertsGCInterval              = pflag.String("certs-gc-interval", "1h", "tidy interval for expired certificates")
-	flgSessionTTL                   = pflag.String("session-ttl", "60s", "leader session's TTL")
-	flgDebugSabakan                 = pflag.Bool("debug-sabakan", false, "debug sabakan integration")
-	flgMaxConcurrentKubeletRestarts = pflag.Int("max-concurrent-kubelet-restarts", 10, "the maximum number of Kubelet instances that can be restarted simultaneously")
+	flgHTTP                 = pflag.String("http", "0.0.0.0:10180", "<Listen IP>:<Port number>")
+	flgConfigPath           = pflag.String("config", "/etc/cke/config.yml", "configuration file path")
+	flgInterval             = pflag.String("interval", "1m", "check interval")
+	flgCertsGCInterval      = pflag.String("certs-gc-interval", "1h", "tidy interval for expired certificates")
+	flgSessionTTL           = pflag.String("session-ttl", "60s", "leader session's TTL")
+	flgDebugSabakan         = pflag.Bool("debug-sabakan", false, "debug sabakan integration")
+	flgMaxConcurrentUpdates = pflag.Int("max-concurrent-updates", 10, "the maximum number of components that can be updated simultaneously")
 )
 
 func loadConfig(p string) (*etcdutil.Config, error) {
@@ -109,8 +110,13 @@ func main() {
 		log.ErrorExit(err)
 	}
 
+	maxConcurrentUpdates := *flgMaxConcurrentUpdates
+	if maxConcurrentUpdates <= 0 {
+		log.ErrorExit(errors.New("max-concurrent-updates must be greater than 0"))
+	}
+
 	// Controller
-	controller := server.NewController(session, interval, gcInterval, timeout, addon, *flgMaxConcurrentKubeletRestarts)
+	controller := server.NewController(session, interval, gcInterval, timeout, addon, maxConcurrentUpdates)
 	well.Go(controller.Run)
 
 	// API server

--- a/server/control.go
+++ b/server/control.go
@@ -23,17 +23,17 @@ var (
 
 // Controller manage operations
 type Controller struct {
-	session                      *concurrency.Session
-	interval                     time.Duration
-	certsGCInterval              time.Duration
-	timeout                      time.Duration
-	addon                        Integrator
-	maxConcurrentKubeletRestarts int
+	session              *concurrency.Session
+	interval             time.Duration
+	certsGCInterval      time.Duration
+	timeout              time.Duration
+	addon                Integrator
+	maxConcurrentUpdates int
 }
 
 // NewController construct controller instance
-func NewController(s *concurrency.Session, interval, gcInterval, timeout time.Duration, addon Integrator, maxConcurrentKubeletRestarts int) Controller {
-	return Controller{s, interval, gcInterval, timeout, addon, maxConcurrentKubeletRestarts}
+func NewController(s *concurrency.Session, interval, gcInterval, timeout time.Duration, addon Integrator, maxConcurrentUpdates int) Controller {
+	return Controller{s, interval, gcInterval, timeout, addon, maxConcurrentUpdates}
 }
 
 // Run execute procedures with leader elections
@@ -346,7 +346,7 @@ func (c Controller) runOnce(ctx context.Context, leaderKey string, tick <-chan t
 		DrainCompleted: drainCompleted,
 		DrainTimedout:  drainTimedout,
 		RebootDequeued: rebootDequeued,
-	}, c.maxConcurrentKubeletRestarts)
+	}, c.maxConcurrentUpdates)
 
 	st := &cke.ServerStatus{
 		Phase:     phase,

--- a/server/control.go
+++ b/server/control.go
@@ -23,16 +23,17 @@ var (
 
 // Controller manage operations
 type Controller struct {
-	session         *concurrency.Session
-	interval        time.Duration
-	certsGCInterval time.Duration
-	timeout         time.Duration
-	addon           Integrator
+	session                      *concurrency.Session
+	interval                     time.Duration
+	certsGCInterval              time.Duration
+	timeout                      time.Duration
+	addon                        Integrator
+	maxConcurrentKubeletRestarts int
 }
 
 // NewController construct controller instance
-func NewController(s *concurrency.Session, interval, gcInterval, timeout time.Duration, addon Integrator) Controller {
-	return Controller{s, interval, gcInterval, timeout, addon}
+func NewController(s *concurrency.Session, interval, gcInterval, timeout time.Duration, addon Integrator, maxConcurrentKubeletRestarts int) Controller {
+	return Controller{s, interval, gcInterval, timeout, addon, maxConcurrentKubeletRestarts}
 }
 
 // Run execute procedures with leader elections
@@ -345,7 +346,7 @@ func (c Controller) runOnce(ctx context.Context, leaderKey string, tick <-chan t
 		DrainCompleted: drainCompleted,
 		DrainTimedout:  drainTimedout,
 		RebootDequeued: rebootDequeued,
-	})
+	}, c.maxConcurrentKubeletRestarts)
 
 	st := &cke.ServerStatus{
 		Phase:     phase,

--- a/server/node_filter.go
+++ b/server/node_filter.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"math"
 	"strings"
 
 	"github.com/cybozu-go/cke"
@@ -422,32 +423,38 @@ func (nf *NodeFilter) SchedulerOutdatedNodes(params cke.SchedulerParams) (nodes 
 }
 
 // KubeletStoppedNodes returns nodes that are not running kubelet.
-func (nf *NodeFilter) KubeletStoppedNodes() (nodes []*cke.Node) {
+func (nf *NodeFilter) KubeletStoppedNodes(maxConcurrentKubeletRestarts int) (nodes []*cke.Node) {
 	for _, n := range nf.cluster.Nodes {
 		if !nf.nodeStatus(n).Kubelet.Running {
 			nodes = append(nodes, n)
+		}
+		if len(nodes) >= maxConcurrentKubeletRestarts {
+			break
 		}
 	}
 	return nodes
 }
 
 // KubeletStoppedRegisteredNodes returns nodes that are not running kubelet and are registered on Kubernetes.
-func (nf *NodeFilter) KubeletStoppedRegisteredNodes() (nodes []*cke.Node) {
+func (nf *NodeFilter) KubeletStoppedRegisteredNodes(maxConcurrentKubeletRestarts int) (nodes []*cke.Node) {
 	registered := make(map[string]bool)
 	for _, kn := range nf.status.Kubernetes.Nodes {
 		registered[kn.Name] = true
 	}
 
-	for _, n := range nf.KubeletStoppedNodes() {
+	for _, n := range nf.KubeletStoppedNodes(math.MaxInt) {
 		if registered[n.Nodename()] {
 			nodes = append(nodes, n)
+		}
+		if len(nodes) >= maxConcurrentKubeletRestarts {
+			break
 		}
 	}
 	return nodes
 }
 
 // KubeletOutdatedNodes returns nodes that are running kubelet with outdated image or params.
-func (nf *NodeFilter) KubeletOutdatedNodes() (nodes []*cke.Node) {
+func (nf *NodeFilter) KubeletOutdatedNodes(maxConcurrentKubeletRestarts int) (nodes []*cke.Node) {
 	currentOpts := nf.cluster.Options.Kubelet
 	currentExtra := nf.cluster.Options.Kubelet.ServiceParams
 
@@ -484,15 +491,21 @@ func (nf *NodeFilter) KubeletOutdatedNodes() (nodes []*cke.Node) {
 			})
 			nodes = append(nodes, n)
 		}
+		if len(nodes) >= maxConcurrentKubeletRestarts {
+			break
+		}
 	}
 	return nodes
 }
 
 // KubeletUnrecognizedNodes returns nodes of which kubelet is still running but not recognized by k8s.
-func (nf *NodeFilter) KubeletUnrecognizedNodes() (nodes []*cke.Node) {
+func (nf *NodeFilter) KubeletUnrecognizedNodes(maxConcurrentKubeletRestarts int) (nodes []*cke.Node) {
 	for _, n := range nf.cluster.Nodes {
 		if nf.nodeStatus(n).Kubelet.Running && !nf.existsNodeResource(n.Nodename()) {
 			nodes = append(nodes, n)
+			if len(nodes) >= maxConcurrentKubeletRestarts {
+				break
+			}
 		}
 	}
 	return nodes

--- a/server/strategy.go
+++ b/server/strategy.go
@@ -105,29 +105,29 @@ func DecideOps(c *cke.Cluster, cs *cke.ClusterStatus, constraints *cke.Constrain
 
 func riversOps(c *cke.Cluster, nf *NodeFilter, maxConcurrentUpdates int) (ops []cke.Operator) {
 	if nodes := nf.SSHConnectedNodes(nf.RiversStoppedNodes(), true, true); len(nodes) > 0 {
-		ops = append(ops, separateOperators(nodes, func(ns []*cke.Node) cke.Operator {
+		ops = append(ops, splitOperators(nodes, func(ns []*cke.Node) cke.Operator {
 			return op.RiversBootOp(ns, nf.ControlPlane(), c.Options.Rivers, op.RiversContainerName, op.RiversUpstreamPort, op.RiversListenPort)
 		}, maxConcurrentUpdates)...)
 	}
 	if nodes := nf.SSHConnectedNodes(nf.RiversOutdatedNodes(), true, true); len(nodes) > 0 {
-		ops = append(ops, separateOperators(nodes, func(ns []*cke.Node) cke.Operator {
+		ops = append(ops, splitOperators(nodes, func(ns []*cke.Node) cke.Operator {
 			return op.RiversRestartOp(ns, nf.ControlPlane(), c.Options.Rivers, op.RiversContainerName, op.RiversUpstreamPort, op.RiversListenPort)
 		}, maxConcurrentUpdates)...)
 	}
 	if nodes := nf.SSHConnectedNodes(nf.EtcdRiversStoppedNodes(), true, false); len(nodes) > 0 {
-		ops = append(ops, separateOperators(nodes, func(ns []*cke.Node) cke.Operator {
+		ops = append(ops, splitOperators(nodes, func(ns []*cke.Node) cke.Operator {
 			return op.RiversBootOp(ns, nf.ControlPlane(), c.Options.EtcdRivers, op.EtcdRiversContainerName, op.EtcdRiversUpstreamPort, op.EtcdRiversListenPort)
 		}, maxConcurrentUpdates)...)
 	}
 	if nodes := nf.SSHConnectedNodes(nf.EtcdRiversOutdatedNodes(), true, false); len(nodes) > 0 {
-		ops = append(ops, separateOperators(nodes, func(ns []*cke.Node) cke.Operator {
+		ops = append(ops, splitOperators(nodes, func(ns []*cke.Node) cke.Operator {
 			return op.RiversRestartOp(ns, nf.ControlPlane(), c.Options.EtcdRivers, op.EtcdRiversContainerName, op.EtcdRiversUpstreamPort, op.EtcdRiversListenPort)
 		}, maxConcurrentUpdates)...)
 	}
 	return ops
 }
 
-func separateOperators(nodes []*cke.Node, createOps func(ns []*cke.Node) cke.Operator, maxConcurrentUpdates int) (ops []cke.Operator) {
+func splitOperators(nodes []*cke.Node, createOps func(ns []*cke.Node) cke.Operator, maxConcurrentUpdates int) (ops []cke.Operator) {
 	for i := 0; i < len(nodes); i += maxConcurrentUpdates {
 		end := i + maxConcurrentUpdates
 		if end > len(nodes) {
@@ -164,32 +164,32 @@ func k8sOps(c *cke.Cluster, nf *NodeFilter, cs *cke.ClusterStatus, maxConcurrent
 	// For all nodes
 	apiServer := nf.HealthyAPIServer()
 	if nodes := nf.SSHConnectedNodes(nf.KubeletUnrecognizedNodes(), true, true); len(nodes) > 0 {
-		ops = append(ops, separateOperators(nodes, func(ns []*cke.Node) cke.Operator {
+		ops = append(ops, splitOperators(nodes, func(ns []*cke.Node) cke.Operator {
 			return k8s.KubeletRestartOp(ns, c.Name, c.Options.Kubelet, cs.NodeStatuses)
 		}, maxConcurrentUpdates)...)
 	}
 	if nodes := nf.SSHConnectedNodes(nf.KubeletStoppedNodes(), true, true); len(nodes) > 0 {
-		ops = append(ops, separateOperators(nodes, func(ns []*cke.Node) cke.Operator {
+		ops = append(ops, splitOperators(nodes, func(ns []*cke.Node) cke.Operator {
 			return k8s.KubeletBootOp(ns, nf.KubeletStoppedRegisteredNodes(), apiServer, c.Name, c.Options.Kubelet, cs.NodeStatuses)
 		}, maxConcurrentUpdates)...)
 	}
 	if nodes := nf.SSHConnectedNodes(nf.KubeletOutdatedNodes(), true, true); len(nodes) > 0 {
-		ops = append(ops, separateOperators(nodes, func(ns []*cke.Node) cke.Operator {
+		ops = append(ops, splitOperators(nodes, func(ns []*cke.Node) cke.Operator {
 			return k8s.KubeletRestartOp(ns, c.Name, c.Options.Kubelet, cs.NodeStatuses)
 		}, maxConcurrentUpdates)...)
 	}
 	if nodes := nf.SSHConnectedNodes(nf.ProxyStoppedNodes(), true, true); len(nodes) > 0 {
-		ops = append(ops, separateOperators(nodes, func(ns []*cke.Node) cke.Operator {
+		ops = append(ops, splitOperators(nodes, func(ns []*cke.Node) cke.Operator {
 			return k8s.KubeProxyBootOp(ns, c.Name, "", c.Options.Proxy)
 		}, maxConcurrentUpdates)...)
 	}
 	if nodes := nf.SSHConnectedNodes(nf.ProxyOutdatedNodes(c.Options.Proxy), true, true); len(nodes) > 0 {
-		ops = append(ops, separateOperators(nodes, func(ns []*cke.Node) cke.Operator {
+		ops = append(ops, splitOperators(nodes, func(ns []*cke.Node) cke.Operator {
 			return k8s.KubeProxyRestartOp(ns, c.Name, "", c.Options.Proxy)
 		}, maxConcurrentUpdates)...)
 	}
 	if nodes := nf.SSHConnectedNodes(nf.ProxyRunningUnexpectedlyNodes(), true, true); len(nodes) > 0 {
-		ops = append(ops, separateOperators(nodes, func(ns []*cke.Node) cke.Operator {
+		ops = append(ops, splitOperators(nodes, func(ns []*cke.Node) cke.Operator {
 			return op.ProxyStopOp(ns)
 		}, maxConcurrentUpdates)...)
 	}

--- a/server/strategy.go
+++ b/server/strategy.go
@@ -24,7 +24,7 @@ type DecideOpsRebootArgs struct {
 
 // DecideOps returns the next operations to do and the operation phase.
 // This returns nil when no operations need to be done.
-func DecideOps(c *cke.Cluster, cs *cke.ClusterStatus, constraints *cke.Constraints, resources []cke.ResourceDefinition, rebootArgs DecideOpsRebootArgs, maxConcurrentKubeletRestarts int) ([]cke.Operator, cke.OperationPhase) {
+func DecideOps(c *cke.Cluster, cs *cke.ClusterStatus, constraints *cke.Constraints, resources []cke.ResourceDefinition, rebootArgs DecideOpsRebootArgs, maxConcurrentUpdates int) ([]cke.Operator, cke.OperationPhase) {
 	nf := NewNodeFilter(c, cs)
 
 	// 0. Execute upgrade operation if necessary
@@ -40,7 +40,7 @@ func DecideOps(c *cke.Cluster, cs *cke.ClusterStatus, constraints *cke.Constrain
 	// 1. Run or restart rivers.  This guarantees:
 	// - CKE tools image is pulled on all nodes.
 	// - Rivers runs on all nodes and will proxy requests only to control plane nodes.
-	if ops := riversOps(c, nf); len(ops) > 0 {
+	if ops := riversOps(c, nf, maxConcurrentUpdates); len(ops) > 0 {
 		return ops, cke.PhaseRivers
 	}
 
@@ -65,7 +65,7 @@ func DecideOps(c *cke.Cluster, cs *cke.ClusterStatus, constraints *cke.Constrain
 	}
 
 	// 5. Run or restart kubernetes components.
-	if ops := k8sOps(c, nf, cs, maxConcurrentKubeletRestarts); len(ops) > 0 {
+	if ops := k8sOps(c, nf, cs, maxConcurrentUpdates); len(ops) > 0 {
 		return ops, cke.PhaseK8sStart
 	}
 
@@ -103,23 +103,42 @@ func DecideOps(c *cke.Cluster, cs *cke.ClusterStatus, constraints *cke.Constrain
 	return nil, cke.PhaseCompleted
 }
 
-func riversOps(c *cke.Cluster, nf *NodeFilter) (ops []cke.Operator) {
+func riversOps(c *cke.Cluster, nf *NodeFilter, maxConcurrentUpdates int) (ops []cke.Operator) {
 	if nodes := nf.SSHConnectedNodes(nf.RiversStoppedNodes(), true, true); len(nodes) > 0 {
-		ops = append(ops, op.RiversBootOp(nodes, nf.ControlPlane(), c.Options.Rivers, op.RiversContainerName, op.RiversUpstreamPort, op.RiversListenPort))
+		ops = append(ops, separateOperators(nodes, func(ns []*cke.Node) cke.Operator {
+			return op.RiversBootOp(ns, nf.ControlPlane(), c.Options.Rivers, op.RiversContainerName, op.RiversUpstreamPort, op.RiversListenPort)
+		}, maxConcurrentUpdates)...)
 	}
 	if nodes := nf.SSHConnectedNodes(nf.RiversOutdatedNodes(), true, true); len(nodes) > 0 {
-		ops = append(ops, op.RiversRestartOp(nodes, nf.ControlPlane(), c.Options.Rivers, op.RiversContainerName, op.RiversUpstreamPort, op.RiversListenPort))
+		ops = append(ops, separateOperators(nodes, func(ns []*cke.Node) cke.Operator {
+			return op.RiversRestartOp(ns, nf.ControlPlane(), c.Options.Rivers, op.RiversContainerName, op.RiversUpstreamPort, op.RiversListenPort)
+		}, maxConcurrentUpdates)...)
 	}
 	if nodes := nf.SSHConnectedNodes(nf.EtcdRiversStoppedNodes(), true, false); len(nodes) > 0 {
-		ops = append(ops, op.RiversBootOp(nodes, nf.ControlPlane(), c.Options.EtcdRivers, op.EtcdRiversContainerName, op.EtcdRiversUpstreamPort, op.EtcdRiversListenPort))
+		ops = append(ops, separateOperators(nodes, func(ns []*cke.Node) cke.Operator {
+			return op.RiversBootOp(ns, nf.ControlPlane(), c.Options.EtcdRivers, op.EtcdRiversContainerName, op.EtcdRiversUpstreamPort, op.EtcdRiversListenPort)
+		}, maxConcurrentUpdates)...)
 	}
 	if nodes := nf.SSHConnectedNodes(nf.EtcdRiversOutdatedNodes(), true, false); len(nodes) > 0 {
-		ops = append(ops, op.RiversRestartOp(nodes, nf.ControlPlane(), c.Options.EtcdRivers, op.EtcdRiversContainerName, op.EtcdRiversUpstreamPort, op.EtcdRiversListenPort))
+		ops = append(ops, separateOperators(nodes, func(ns []*cke.Node) cke.Operator {
+			return op.RiversRestartOp(ns, nf.ControlPlane(), c.Options.EtcdRivers, op.EtcdRiversContainerName, op.EtcdRiversUpstreamPort, op.EtcdRiversListenPort)
+		}, maxConcurrentUpdates)...)
 	}
 	return ops
 }
 
-func k8sOps(c *cke.Cluster, nf *NodeFilter, cs *cke.ClusterStatus, maxConcurrentKubeletRestarts int) (ops []cke.Operator) {
+func separateOperators(nodes []*cke.Node, createOps func(ns []*cke.Node) cke.Operator, maxConcurrentUpdates int) (ops []cke.Operator) {
+	for i := 0; i < len(nodes); i += maxConcurrentUpdates {
+		end := i + maxConcurrentUpdates
+		if end > len(nodes) {
+			end = len(nodes)
+		}
+		ops = append(ops, createOps(nodes[i:end]))
+	}
+	return ops
+}
+
+func k8sOps(c *cke.Cluster, nf *NodeFilter, cs *cke.ClusterStatus, maxConcurrentUpdates int) (ops []cke.Operator) {
 	// For cp nodes
 	if nodes := nf.SSHConnectedNodes(nf.APIServerStoppedNodes(), true, false); len(nodes) > 0 {
 		kubeletConfig := k8s.GenerateKubeletConfiguration(c.Options.Kubelet, "0.0.0.0", nil)
@@ -145,41 +164,34 @@ func k8sOps(c *cke.Cluster, nf *NodeFilter, cs *cke.ClusterStatus, maxConcurrent
 	// For all nodes
 	apiServer := nf.HealthyAPIServer()
 	if nodes := nf.SSHConnectedNodes(nf.KubeletUnrecognizedNodes(), true, true); len(nodes) > 0 {
-		for i := 0; i < len(nodes); i += maxConcurrentKubeletRestarts {
-			end := i + maxConcurrentKubeletRestarts
-			if end > len(nodes) {
-				end = len(nodes)
-			}
-			ops = append(ops, k8s.KubeletRestartOp(nodes[i:end], c.Name, c.Options.Kubelet, cs.NodeStatuses))
-		}
+		ops = append(ops, separateOperators(nodes, func(ns []*cke.Node) cke.Operator {
+			return k8s.KubeletRestartOp(ns, c.Name, c.Options.Kubelet, cs.NodeStatuses)
+		}, maxConcurrentUpdates)...)
 	}
 	if nodes := nf.SSHConnectedNodes(nf.KubeletStoppedNodes(), true, true); len(nodes) > 0 {
-		for i := 0; i < len(nodes); i += maxConcurrentKubeletRestarts {
-			end := i + maxConcurrentKubeletRestarts
-			if end > len(nodes) {
-				end = len(nodes)
-			}
-			ops = append(ops, k8s.KubeletBootOp(nodes[i:end], nf.KubeletStoppedRegisteredNodes(),
-				apiServer, c.Name, c.Options.Kubelet, cs.NodeStatuses))
-		}
+		ops = append(ops, separateOperators(nodes, func(ns []*cke.Node) cke.Operator {
+			return k8s.KubeletBootOp(ns, nf.KubeletStoppedRegisteredNodes(), apiServer, c.Name, c.Options.Kubelet, cs.NodeStatuses)
+		}, maxConcurrentUpdates)...)
 	}
 	if nodes := nf.SSHConnectedNodes(nf.KubeletOutdatedNodes(), true, true); len(nodes) > 0 {
-		for i := 0; i < len(nodes); i += maxConcurrentKubeletRestarts {
-			end := i + maxConcurrentKubeletRestarts
-			if end > len(nodes) {
-				end = len(nodes)
-			}
-			ops = append(ops, k8s.KubeletRestartOp(nodes[i:end], c.Name, c.Options.Kubelet, cs.NodeStatuses))
-		}
+		ops = append(ops, separateOperators(nodes, func(ns []*cke.Node) cke.Operator {
+			return k8s.KubeletRestartOp(ns, c.Name, c.Options.Kubelet, cs.NodeStatuses)
+		}, maxConcurrentUpdates)...)
 	}
 	if nodes := nf.SSHConnectedNodes(nf.ProxyStoppedNodes(), true, true); len(nodes) > 0 {
-		ops = append(ops, k8s.KubeProxyBootOp(nodes, c.Name, "", c.Options.Proxy))
+		ops = append(ops, separateOperators(nodes, func(ns []*cke.Node) cke.Operator {
+			return k8s.KubeProxyBootOp(ns, c.Name, "", c.Options.Proxy)
+		}, maxConcurrentUpdates)...)
 	}
 	if nodes := nf.SSHConnectedNodes(nf.ProxyOutdatedNodes(c.Options.Proxy), true, true); len(nodes) > 0 {
-		ops = append(ops, k8s.KubeProxyRestartOp(nodes, c.Name, "", c.Options.Proxy))
+		ops = append(ops, separateOperators(nodes, func(ns []*cke.Node) cke.Operator {
+			return k8s.KubeProxyRestartOp(ns, c.Name, "", c.Options.Proxy)
+		}, maxConcurrentUpdates)...)
 	}
 	if nodes := nf.SSHConnectedNodes(nf.ProxyRunningUnexpectedlyNodes(), true, true); len(nodes) > 0 {
-		ops = append(ops, op.ProxyStopOp(nodes))
+		ops = append(ops, separateOperators(nodes, func(ns []*cke.Node) cke.Operator {
+			return op.ProxyStopOp(ns)
+		}, maxConcurrentUpdates)...)
 	}
 	return ops
 }

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"sort"
 	"strconv"
 	"testing"
 	"time"
@@ -1026,14 +1025,6 @@ func TestDecideOps(t *testing.T) {
 			Input: newData().withK8sReady(),
 			ExpectedOps: []opData{
 				{"resource-apply", 1},
-				{"resource-apply", 1},
-				{"resource-apply", 1},
-				{"resource-apply", 1},
-				{"resource-apply", 1},
-				{"resource-apply", 1},
-				{"resource-apply", 1},
-				{"resource-apply", 1},
-				{"resource-apply", 1},
 				{"create-cluster-dns-configmap", 1},
 				{"create-endpoints", 1},
 				{"create-endpointslice", 1},
@@ -1300,8 +1291,8 @@ func TestDecideOps(t *testing.T) {
 					},
 				},
 			),
-			ExpectedOps: []string{
-				"resource-apply",
+			ExpectedOps: []opData{
+				{"resource-apply", 1},
 			},
 		},
 		{
@@ -1371,8 +1362,8 @@ func TestDecideOps(t *testing.T) {
 					Completed: false,
 				},
 			}),
-			ExpectedOps: []string{
-				"resource-apply",
+			ExpectedOps: []opData{
+				{"resource-apply", 1},
 			},
 		},
 		{
@@ -1412,8 +1403,8 @@ func TestDecideOps(t *testing.T) {
 					Completed: false,
 				},
 			}),
-			ExpectedOps: []string{
-				"nop",
+			ExpectedOps: []opData{
+				{"nop", 0},
 			},
 		},
 		{

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -2443,7 +2443,7 @@ func TestDecideOps(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
-			ops, _ := DecideOps(c.Input.Cluster, c.Input.Status, c.Input.Constraints, c.Input.Resources, c.Input.RebootArgs)
+			ops, _ := DecideOps(c.Input.Cluster, c.Input.Status, c.Input.Constraints, c.Input.Resources, c.Input.RebootArgs, 10)
 			if len(ops) == 0 && len(c.ExpectedOps) == 0 {
 				return
 			}

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -622,26 +622,28 @@ func (d testData) withDisableProxy() testData {
 	return d
 }
 
+type opData struct {
+	Name      string
+	TargetNum int
+}
+
 func TestDecideOps(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		Name               string
-		Input              testData
-		ExpectedOps        []string
-		ExpectedTargetNums map[string]int
+		Name        string
+		Input       testData
+		ExpectedOps []opData
 	}{
 		{
-			Name:               "BootRivers",
-			Input:              newData(),
-			ExpectedOps:        []string{"etcd-rivers-bootstrap", "rivers-bootstrap"},
-			ExpectedTargetNums: map[string]int{"etcd-rivers-bootstrap": 3, "rivers-bootstrap": 6},
+			Name:        "BootRivers",
+			Input:       newData(),
+			ExpectedOps: []opData{{"rivers-bootstrap", 6}, {"etcd-rivers-bootstrap", 3}},
 		},
 		{
-			Name:               "BootRivers2",
-			Input:              newData().withHealthyEtcd().withSSHNotConnectedNodes(),
-			ExpectedOps:        []string{"etcd-rivers-bootstrap", "rivers-bootstrap"},
-			ExpectedTargetNums: map[string]int{"etcd-rivers-bootstrap": 2, "rivers-bootstrap": 4},
+			Name:        "BootRivers2",
+			Input:       newData().withHealthyEtcd().withSSHNotConnectedNodes(),
+			ExpectedOps: []opData{{"rivers-bootstrap", 4}, {"etcd-rivers-bootstrap", 2}},
 		},
 		{
 			Name: "RestartRivers",
@@ -649,8 +651,7 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.ControlPlane()[0]).Rivers.Image = ""
 				d.NodeStatus(d.ControlPlane()[1]).Rivers.Image = ""
 			}).withEtcdRivers().withHealthyEtcd().withSSHNotConnectedNodes(),
-			ExpectedOps:        []string{"rivers-restart"},
-			ExpectedTargetNums: map[string]int{"rivers-restart": 1},
+			ExpectedOps: []opData{{"rivers-restart", 1}},
 		},
 		{
 			Name: "RestartRivers2",
@@ -658,8 +659,7 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.ControlPlane()[0]).Rivers.BuiltInParams.ExtraArguments = nil
 				d.NodeStatus(d.ControlPlane()[1]).Rivers.BuiltInParams.ExtraArguments = nil
 			}).withEtcdRivers().withHealthyEtcd().withSSHNotConnectedNodes(),
-			ExpectedOps:        []string{"rivers-restart"},
-			ExpectedTargetNums: map[string]int{"rivers-restart": 1},
+			ExpectedOps: []opData{{"rivers-restart", 1}},
 		},
 		{
 			Name: "RestartRivers3",
@@ -667,8 +667,7 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.ControlPlane()[0]).Rivers.ExtraParams.ExtraArguments = []string{"foo"}
 				d.NodeStatus(d.ControlPlane()[1]).Rivers.ExtraParams.ExtraArguments = []string{"foo"}
 			}).withEtcdRivers().withHealthyEtcd().withSSHNotConnectedNodes(),
-			ExpectedOps:        []string{"rivers-restart"},
-			ExpectedTargetNums: map[string]int{"rivers-restart": 1},
+			ExpectedOps: []opData{{"rivers-restart", 1}},
 		},
 		{
 			Name: "StartRestartRivers",
@@ -676,8 +675,7 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.ControlPlane()[0]).Rivers.Image = ""
 				d.NodeStatus(d.ControlPlane()[1]).Rivers.Running = false
 			}).withEtcdRivers(),
-			ExpectedOps:        []string{"rivers-bootstrap", "rivers-restart"},
-			ExpectedTargetNums: map[string]int{"rivers-bootstrap": 1, "rivers-restart": 1},
+			ExpectedOps: []opData{{"rivers-bootstrap", 1}, {"rivers-restart", 1}},
 		},
 		{
 			Name: "RestartEtcdRivers",
@@ -685,8 +683,7 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.ControlPlane()[0]).EtcdRivers.Image = ""
 				d.NodeStatus(d.ControlPlane()[1]).EtcdRivers.Image = ""
 			}).withHealthyEtcd().withSSHNotConnectedNodes(),
-			ExpectedOps:        []string{"etcd-rivers-restart"},
-			ExpectedTargetNums: map[string]int{"etcd-rivers-restart": 1},
+			ExpectedOps: []opData{{"etcd-rivers-restart", 1}},
 		},
 		{
 			Name: "RestartEtcdRivers2",
@@ -694,8 +691,7 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.ControlPlane()[0]).EtcdRivers.BuiltInParams.ExtraArguments = nil
 				d.NodeStatus(d.ControlPlane()[1]).EtcdRivers.BuiltInParams.ExtraArguments = nil
 			}).withHealthyEtcd().withSSHNotConnectedNodes(),
-			ExpectedOps:        []string{"etcd-rivers-restart"},
-			ExpectedTargetNums: map[string]int{"etcd-rivers-restart": 1},
+			ExpectedOps: []opData{{"etcd-rivers-restart", 1}},
 		},
 		{
 			Name: "RestartEtcdRivers3",
@@ -703,8 +699,7 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.ControlPlane()[0]).EtcdRivers.ExtraParams.ExtraArguments = []string{"foo"}
 				d.NodeStatus(d.ControlPlane()[1]).EtcdRivers.ExtraParams.ExtraArguments = []string{"foo"}
 			}).withHealthyEtcd().withSSHNotConnectedNodes(),
-			ExpectedOps:        []string{"etcd-rivers-restart"},
-			ExpectedTargetNums: map[string]int{"etcd-rivers-restart": 1},
+			ExpectedOps: []opData{{"etcd-rivers-restart", 1}},
 		},
 		{
 			Name: "StartRestartEtcdRivers",
@@ -712,13 +707,12 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.ControlPlane()[0]).EtcdRivers.Image = ""
 				d.NodeStatus(d.ControlPlane()[1]).EtcdRivers.Running = false
 			}),
-			ExpectedOps:        []string{"etcd-rivers-bootstrap", "etcd-rivers-restart"},
-			ExpectedTargetNums: map[string]int{"etcd-rivers-bootstrap": 1, "etcd-rivers-restart": 1},
+			ExpectedOps: []opData{{"etcd-rivers-bootstrap", 1}, {"etcd-rivers-restart", 1}},
 		},
 		{
 			Name:        "EtcdBootstrap",
 			Input:       newData().withRivers().withEtcdRivers(),
-			ExpectedOps: []string{"etcd-bootstrap"},
+			ExpectedOps: []opData{{"etcd-bootstrap", 3}},
 		},
 		{
 			Name:        "SkipEtcdBootstrap",
@@ -728,7 +722,7 @@ func TestDecideOps(t *testing.T) {
 		{
 			Name:        "SkipEtcdBootstrap2",
 			Input:       newData().withRivers().withEtcdRivers().withInitFailedEtcd(),
-			ExpectedOps: []string{"etcd-wait-cluster"},
+			ExpectedOps: []opData{{"etcd-wait-cluster", 3}},
 			// This wait will never succeed.
 			// The recovery from this failure case may need deletion of the data volumes, so it should be handled manually.
 			// The failure case is very rare.  It will not occur once after the etcd cluster started to work.
@@ -736,7 +730,7 @@ func TestDecideOps(t *testing.T) {
 		{
 			Name:        "EtcdStart",
 			Input:       newData().withRivers().withEtcdRivers().withStoppedEtcd(),
-			ExpectedOps: []string{"etcd-start"},
+			ExpectedOps: []opData{{"etcd-start", 3}},
 		},
 		{
 			Name: "EtcdStart2",
@@ -744,86 +738,65 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.ControlPlane()[0]).Etcd.Running = false
 				d.NodeStatus(d.ControlPlane()[1]).Etcd.Running = false
 			}),
-			ExpectedOps: []string{
-				"etcd-start",
-			},
-			ExpectedTargetNums: map[string]int{
-				"etcd-start": 1,
+			ExpectedOps: []opData{
+				{"etcd-start", 1},
 			},
 		},
 		{
-			Name:        "EtcdStart3",
-			Input:       newData().withRivers().withEtcdRivers().withStoppedEtcd().withNotHasDataStoppedEtcd(),
-			ExpectedOps: []string{"etcd-start"},
-			ExpectedTargetNums: map[string]int{
-				"etcd-start": 2,
+			Name:  "EtcdStart3",
+			Input: newData().withRivers().withEtcdRivers().withStoppedEtcd().withNotHasDataStoppedEtcd(),
+			ExpectedOps: []opData{
+				{"etcd-start", 2},
 			},
 		},
 		{
-			Name:        "EtcdStart4",
-			Input:       newData().withRivers().withEtcdRivers().withStoppedEtcd().withNotMarkedStoppedEtcd(),
-			ExpectedOps: []string{"etcd-start"},
-			ExpectedTargetNums: map[string]int{
-				"etcd-start": 2,
+			Name:  "EtcdStart4",
+			Input: newData().withRivers().withEtcdRivers().withStoppedEtcd().withNotMarkedStoppedEtcd(),
+			ExpectedOps: []opData{
+				{"etcd-start", 2},
 			},
 		},
 		{
 			Name:        "WaitEtcd",
 			Input:       newData().withRivers().withEtcdRivers().withUnhealthyEtcd(),
-			ExpectedOps: []string{"etcd-wait-cluster"},
+			ExpectedOps: []opData{{"etcd-wait-cluster", 3}},
 		},
 		{
 			Name:  "BootK8s",
 			Input: newData().withHealthyEtcd().withRivers().withEtcdRivers().withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kube-apiserver-restart",
-				"kube-controller-manager-bootstrap",
-				"kube-proxy-bootstrap",
-				"kube-scheduler-bootstrap",
-				"kubelet-bootstrap",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kube-apiserver-restart":            2,
-				"kube-controller-manager-bootstrap": 2,
-				"kube-proxy-bootstrap":              4,
-				"kube-scheduler-bootstrap":          2,
-				"kubelet-bootstrap":                 4,
+			ExpectedOps: []opData{
+				{"kube-apiserver-restart", 2},
+				{"kube-controller-manager-bootstrap", 2},
+				{"kube-scheduler-bootstrap", 2},
+				{"kubelet-bootstrap", 4},
+				{"kube-proxy-bootstrap", 4},
 			},
 		},
 		{
 			Name:  "BootK8sFromPartiallyRunning",
 			Input: newData().withHealthyEtcd().withRivers().withEtcdRivers().withAPIServer(testServiceSubnet, testDefaultDNSDomain),
-			ExpectedOps: []string{
-				"kube-controller-manager-bootstrap",
-				"kube-proxy-bootstrap",
-				"kube-scheduler-bootstrap",
-				"kubelet-bootstrap",
+			ExpectedOps: []opData{
+				{"kube-controller-manager-bootstrap", 3},
+				{"kube-scheduler-bootstrap", 3},
+				{"kubelet-bootstrap", 6},
+				{"kube-proxy-bootstrap", 6},
 			},
 		},
 		{
 			Name:  "BootK8sWithoutProxy",
 			Input: newData().withHealthyEtcd().withRivers().withEtcdRivers().withSSHNotConnectedNodes().withDisableProxy(),
-			ExpectedOps: []string{
-				"kube-apiserver-restart",
-				"kube-controller-manager-bootstrap",
-				"kube-scheduler-bootstrap",
-				"kubelet-bootstrap",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kube-apiserver-restart":            2,
-				"kube-controller-manager-bootstrap": 2,
-				"kube-scheduler-bootstrap":          2,
-				"kubelet-bootstrap":                 4,
+			ExpectedOps: []opData{
+				{"kube-apiserver-restart", 2},
+				{"kube-controller-manager-bootstrap", 2},
+				{"kube-scheduler-bootstrap", 2},
+				{"kubelet-bootstrap", 4},
 			},
 		},
 		{
 			Name:  "RestartAPIServer",
 			Input: newData().withAllServices().withAPIServer("11.22.33.0/24", testDefaultDNSDomain).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kube-apiserver-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kube-apiserver-restart": 2,
+			ExpectedOps: []opData{
+				{"kube-apiserver-restart", 2},
 			},
 		},
 		{
@@ -832,11 +805,8 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.ControlPlane()[0]).APIServer.Image = ""
 				d.NodeStatus(d.ControlPlane()[1]).APIServer.Image = ""
 			}).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kube-apiserver-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kube-apiserver-restart": 1,
+			ExpectedOps: []opData{
+				{"kube-apiserver-restart", 1},
 			},
 		},
 		{
@@ -845,21 +815,15 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.ControlPlane()[0]).APIServer.ExtraParams.ExtraArguments = []string{"foo"}
 				d.NodeStatus(d.ControlPlane()[1]).APIServer.ExtraParams.ExtraArguments = []string{"foo"}
 			}).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kube-apiserver-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kube-apiserver-restart": 1,
+			ExpectedOps: []opData{
+				{"kube-apiserver-restart", 1},
 			},
 		},
 		{
 			Name:  "RestartControllerManager",
 			Input: newData().withAllServices().withControllerManager("another", testServiceSubnet).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kube-controller-manager-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kube-controller-manager-restart": 2,
+			ExpectedOps: []opData{
+				{"kube-controller-manager-restart", 2},
 			},
 		},
 		{
@@ -868,11 +832,8 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.ControlPlane()[0]).ControllerManager.Image = ""
 				d.NodeStatus(d.ControlPlane()[1]).ControllerManager.Image = ""
 			}).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kube-controller-manager-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kube-controller-manager-restart": 1,
+			ExpectedOps: []opData{
+				{"kube-controller-manager-restart", 1},
 			},
 		},
 		{
@@ -881,11 +842,8 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.ControlPlane()[0]).ControllerManager.ExtraParams.ExtraArguments = []string{"foo"}
 				d.NodeStatus(d.ControlPlane()[1]).ControllerManager.ExtraParams.ExtraArguments = []string{"foo"}
 			}).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kube-controller-manager-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kube-controller-manager-restart": 1,
+			ExpectedOps: []opData{
+				{"kube-controller-manager-restart", 1},
 			},
 		},
 		{
@@ -894,11 +852,8 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.ControlPlane()[0]).Scheduler.BuiltInParams.ExtraArguments = []string{"foo"}
 				d.NodeStatus(d.ControlPlane()[1]).Scheduler.BuiltInParams.ExtraArguments = []string{"foo"}
 			}).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kube-scheduler-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kube-scheduler-restart": 1,
+			ExpectedOps: []opData{
+				{"kube-scheduler-restart", 1},
 			},
 		},
 		{
@@ -907,11 +862,8 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.ControlPlane()[0]).Scheduler.Image = ""
 				d.NodeStatus(d.ControlPlane()[1]).Scheduler.Image = ""
 			}).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kube-scheduler-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kube-scheduler-restart": 1,
+			ExpectedOps: []opData{
+				{"kube-scheduler-restart", 1},
 			},
 		},
 		{
@@ -920,11 +872,8 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.ControlPlane()[0]).Scheduler.ExtraParams.ExtraArguments = []string{"foo"}
 				d.NodeStatus(d.ControlPlane()[1]).Scheduler.ExtraParams.ExtraArguments = []string{"foo"}
 			}).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kube-scheduler-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kube-scheduler-restart": 1,
+			ExpectedOps: []opData{
+				{"kube-scheduler-restart", 1},
 			},
 		},
 		{
@@ -933,31 +882,22 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.ControlPlane()[0]).Scheduler.Config.Parallelism = nil
 				d.NodeStatus(d.ControlPlane()[1]).Scheduler.Config.Parallelism = nil
 			}).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kube-scheduler-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kube-scheduler-restart": 1,
+			ExpectedOps: []opData{
+				{"kube-scheduler-restart", 1},
 			},
 		},
 		{
 			Name:  "RestartKubelet",
 			Input: newData().withAllServices().withKubelet("foo.local", "10.0.0.53", false).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kubelet-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kubelet-restart": 4,
+			ExpectedOps: []opData{
+				{"kubelet-restart", 4},
 			},
 		},
 		{
 			Name:  "RestartKubelet2",
 			Input: newData().withAllServices().withKubelet("", "10.0.0.53", true).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kubelet-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kubelet-restart": 4,
+			ExpectedOps: []opData{
+				{"kubelet-restart", 4},
 			},
 		},
 		{
@@ -966,11 +906,8 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.Cluster.Nodes[3]).Kubelet.Image = ""
 				d.NodeStatus(d.Cluster.Nodes[4]).Kubelet.Image = ""
 			}).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kubelet-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kubelet-restart": 1,
+			ExpectedOps: []opData{
+				{"kubelet-restart", 1},
 			},
 		},
 		{
@@ -979,11 +916,8 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.Cluster.Nodes[3]).Kubelet.ExtraParams.ExtraArguments = []string{"foo"}
 				d.NodeStatus(d.Cluster.Nodes[4]).Kubelet.ExtraParams.ExtraArguments = []string{"foo"}
 			}).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kubelet-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kubelet-restart": 1,
+			ExpectedOps: []opData{
+				{"kubelet-restart", 1},
 			},
 		},
 		{
@@ -992,11 +926,8 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.Cluster.Nodes[3]).Kubelet.Config.ClusterDomain = "neco.local"
 				d.NodeStatus(d.Cluster.Nodes[4]).Kubelet.Config.ClusterDomain = "neco.local"
 			}).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kubelet-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kubelet-restart": 1,
+			ExpectedOps: []opData{
+				{"kubelet-restart", 1},
 			},
 		},
 		{
@@ -1004,11 +935,8 @@ func TestDecideOps(t *testing.T) {
 			Input: newData().withAllServices().with(func(d testData) {
 				d.Cluster.Options.Kubelet.Config.Object["containerLogMaxFiles"] = 20
 			}).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kubelet-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kubelet-restart": 4,
+			ExpectedOps: []opData{
+				{"kubelet-restart", 4},
 			},
 		},
 		{
@@ -1016,11 +944,8 @@ func TestDecideOps(t *testing.T) {
 			Input: newData().withAllServices().with(func(d testData) {
 				d.Cluster.Options.Kubelet.Config.Object["containerLogMaxSize"] = "1Gi"
 			}).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kubelet-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kubelet-restart": 4,
+			ExpectedOps: []opData{
+				{"kubelet-restart", 4},
 			},
 		},
 		{
@@ -1028,8 +953,8 @@ func TestDecideOps(t *testing.T) {
 			Input: newData().withAllServices().with(func(d testData) {
 				d.Cluster.Options.Kubelet.CRIEndpoint = "/var/run/dockershim.sock"
 			}).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"wait-kubernetes",
+			ExpectedOps: []opData{
+				{"wait-kubernetes", 1},
 			},
 		},
 		{
@@ -1037,11 +962,8 @@ func TestDecideOps(t *testing.T) {
 			Input: newData().withAllServices().with(func(d testData) {
 				d.Status.Kubernetes.Nodes = d.Status.Kubernetes.Nodes[:3]
 			}).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kubelet-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kubelet-restart": 2,
+			ExpectedOps: []opData{
+				{"kubelet-restart", 2},
 			},
 		},
 		{
@@ -1050,11 +972,8 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.Cluster.Nodes[3]).Proxy.BuiltInParams.ExtraArguments = []string{"foo"}
 				d.NodeStatus(d.Cluster.Nodes[4]).Proxy.BuiltInParams.ExtraArguments = []string{"foo"}
 			}).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kube-proxy-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kube-proxy-restart": 1,
+			ExpectedOps: []opData{
+				{"kube-proxy-restart", 1},
 			},
 		},
 		{
@@ -1063,11 +982,8 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.Cluster.Nodes[3]).Proxy.Image = ""
 				d.NodeStatus(d.Cluster.Nodes[4]).Proxy.Image = ""
 			}).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kube-proxy-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kube-proxy-restart": 1,
+			ExpectedOps: []opData{
+				{"kube-proxy-restart", 1},
 			},
 		},
 		{
@@ -1076,11 +992,8 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.Cluster.Nodes[3]).Proxy.ExtraParams.ExtraArguments = []string{"foo"}
 				d.NodeStatus(d.Cluster.Nodes[4]).Proxy.ExtraParams.ExtraArguments = []string{"foo"}
 			}).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kube-proxy-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kube-proxy-restart": 1,
+			ExpectedOps: []opData{
+				{"kube-proxy-restart", 1},
 			},
 		},
 		{
@@ -1089,37 +1002,41 @@ func TestDecideOps(t *testing.T) {
 				d.NodeStatus(d.Cluster.Nodes[3]).Proxy.Config.Mode = cke.ProxyModeIPVS
 				d.NodeStatus(d.Cluster.Nodes[4]).Proxy.Config.Mode = cke.ProxyModeIPVS
 			}).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{
-				"kube-proxy-restart",
-			},
-			ExpectedTargetNums: map[string]int{
-				"kube-proxy-restart": 1,
+			ExpectedOps: []opData{
+				{"kube-proxy-restart", 1},
 			},
 		},
 		{
-			Name:        "StopProxy",
-			Input:       newData().withAllServices().withDisableProxy(),
-			ExpectedOps: []string{"stop-kube-proxy"},
-			ExpectedTargetNums: map[string]int{
-				"stop-kube-proxy": 6,
+			Name:  "StopProxy",
+			Input: newData().withAllServices().withDisableProxy(),
+			ExpectedOps: []opData{
+				{"stop-kube-proxy", 6},
 			},
 		},
 		{
 			Name:        "WaitKube",
 			Input:       newData().withAllServices(),
-			ExpectedOps: []string{"wait-kubernetes"},
+			ExpectedOps: []opData{{"wait-kubernetes", 1}},
 		},
 		{
 			Name:  "K8sResources",
 			Input: newData().withK8sReady(),
-			ExpectedOps: []string{
-				"create-cluster-dns-configmap",
-				"create-endpoints",
-				"create-endpoints",
-				"create-endpointslice",
-				"create-endpointslice",
-				"create-etcd-service",
-				"resource-apply",
+			ExpectedOps: []opData{
+				{"resource-apply", 1},
+				{"resource-apply", 1},
+				{"resource-apply", 1},
+				{"resource-apply", 1},
+				{"resource-apply", 1},
+				{"resource-apply", 1},
+				{"resource-apply", 1},
+				{"resource-apply", 1},
+				{"resource-apply", 1},
+				{"create-cluster-dns-configmap", 1},
+				{"create-endpoints", 1},
+				{"create-endpointslice", 1},
+				{"create-etcd-service", 1},
+				{"create-endpoints", 1},
+				{"create-endpointslice", 1},
 			},
 		},
 		{
@@ -1129,9 +1046,9 @@ func TestDecideOps(t *testing.T) {
 				svc.Spec.ClusterIP = "1.1.1.1"
 				d.Status.Kubernetes.DNSService = svc
 			}),
-			ExpectedOps: []string{
-				"update-cluster-dns-configmap",
-				"update-node-dns-configmap",
+			ExpectedOps: []opData{
+				{"update-cluster-dns-configmap", 1},
+				{"update-node-dns-configmap", 1},
 			},
 		},
 		{
@@ -1139,9 +1056,9 @@ func TestDecideOps(t *testing.T) {
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Cluster.Options.Kubelet.Config.Object["clusterDomain"] = "neco.local"
 			}),
-			ExpectedOps: []string{
-				"kube-apiserver-restart",
-				"kubelet-restart",
+			ExpectedOps: []opData{
+				{"kube-apiserver-restart", 3},
+				{"kubelet-restart", 6},
 			},
 		},
 		{
@@ -1152,9 +1069,9 @@ func TestDecideOps(t *testing.T) {
 					st.Kubelet.Config.ClusterDomain = "neco.local"
 				}
 			}).withAPIServer(testServiceSubnet, "neco.local"),
-			ExpectedOps: []string{
-				"update-cluster-dns-configmap",
-				"update-node-dns-configmap",
+			ExpectedOps: []opData{
+				{"update-cluster-dns-configmap", 1},
+				{"update-node-dns-configmap", 1},
 			},
 		},
 		{
@@ -1162,9 +1079,9 @@ func TestDecideOps(t *testing.T) {
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Cluster.DNSServers = []string{"1.1.1.1"}
 			}),
-			ExpectedOps: []string{
-				"update-cluster-dns-configmap",
-				"update-node-dns-configmap",
+			ExpectedOps: []opData{
+				{"update-cluster-dns-configmap", 1},
+				{"update-node-dns-configmap", 1},
 			},
 		},
 		{
@@ -1172,8 +1089,8 @@ func TestDecideOps(t *testing.T) {
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.ClusterDNS.ClusterIP = "10.0.0.54"
 			}),
-			ExpectedOps: []string{
-				"update-node-dns-configmap",
+			ExpectedOps: []opData{
+				{"update-node-dns-configmap", 1},
 			},
 		},
 		{
@@ -1181,77 +1098,77 @@ func TestDecideOps(t *testing.T) {
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.MasterEndpoints.Subsets = []corev1.EndpointSubset{}
 			}),
-			ExpectedOps: []string{"update-endpoints"},
+			ExpectedOps: []opData{{"update-endpoints", 1}},
 		},
 		{
 			Name: "MasterEndpointsUpdate2",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.MasterEndpoints.Subsets[0].Ports = []corev1.EndpointPort{}
 			}),
-			ExpectedOps: []string{"update-endpoints"},
+			ExpectedOps: []opData{{"update-endpoints", 1}},
 		},
 		{
 			Name: "MasterEndpointsUpdate3",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.MasterEndpoints.Subsets[0].Addresses = []corev1.EndpointAddress{}
 			}),
-			ExpectedOps: []string{"update-endpoints"},
+			ExpectedOps: []opData{{"update-endpoints", 1}},
 		},
 		{
 			Name: "MasterEndpointSliceUpdate1",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.MasterEndpointSlice.Endpoints[0].Addresses = []string{}
 			}),
-			ExpectedOps: []string{"update-endpointslice"},
+			ExpectedOps: []opData{{"update-endpointslice", 1}},
 		},
 		{
 			Name: "MasterEndpointSliceUpdate2",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.MasterEndpointSlice.Ports[0] = discoveryv1.EndpointPort{}
 			}),
-			ExpectedOps: []string{"update-endpointslice"},
+			ExpectedOps: []opData{{"update-endpointslice", 1}},
 		},
 		{
 			Name: "EtcdServiceUpdate",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.EtcdService.Spec.Ports = []corev1.ServicePort{}
 			}),
-			ExpectedOps: []string{"update-etcd-service"},
+			ExpectedOps: []opData{{"update-etcd-service", 1}},
 		},
 		{
 			Name: "EtcdEndpointsUpdate1",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.EtcdEndpoints.Subsets = []corev1.EndpointSubset{}
 			}),
-			ExpectedOps: []string{"update-endpoints"},
+			ExpectedOps: []opData{{"update-endpoints", 1}},
 		},
 		{
 			Name: "EtcdEndpointsUpdate2",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.EtcdEndpoints.Subsets[0].Ports = []corev1.EndpointPort{}
 			}),
-			ExpectedOps: []string{"update-endpoints"},
+			ExpectedOps: []opData{{"update-endpoints", 1}},
 		},
 		{
 			Name: "EtcdEndpointsUpdate3",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.EtcdEndpoints.Subsets[0].Addresses = []corev1.EndpointAddress{}
 			}),
-			ExpectedOps: []string{"update-endpoints"},
+			ExpectedOps: []opData{{"update-endpoints", 1}},
 		},
 		{
 			Name: "EtcdEndpointSliceUpdate1",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.EtcdEndpointSlice.Endpoints[0].Addresses = []string{}
 			}),
-			ExpectedOps: []string{"update-endpointslice"},
+			ExpectedOps: []opData{{"update-endpointslice", 1}},
 		},
 		{
 			Name: "EtcdEndpointSliceUpdate2",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.EtcdEndpointSlice.Ports[0] = discoveryv1.EndpointPort{}
 			}),
-			ExpectedOps: []string{"update-endpointslice"},
+			ExpectedOps: []opData{{"update-endpointslice", 1}},
 		},
 		{
 			Name: "EndpointsUpdateWithRebootEntry",
@@ -1262,8 +1179,12 @@ func TestDecideOps(t *testing.T) {
 					Status: cke.RebootStatusDraining,
 				},
 			}),
-			ExpectedOps:        []string{"update-endpoints", "update-endpoints", "update-endpointslice", "update-endpointslice"},
-			ExpectedTargetNums: nil,
+			ExpectedOps: []opData{
+				{"update-endpoints", 1},
+				{"update-endpointslice", 1},
+				{"update-endpoints", 1},
+				{"update-endpointslice", 1},
+			},
 		},
 		{
 			Name: "EndpointsUpdateWithRebootEntry2",
@@ -1280,8 +1201,12 @@ func TestDecideOps(t *testing.T) {
 					Status: cke.RebootStatusQueued,
 				},
 			}),
-			ExpectedOps:        []string{"update-endpoints", "update-endpoints", "update-endpointslice", "update-endpointslice"},
-			ExpectedTargetNums: nil,
+			ExpectedOps: []opData{
+				{"update-endpoints", 1},
+				{"update-endpointslice", 1},
+				{"update-endpoints", 1},
+				{"update-endpointslice", 1},
+			},
 		},
 		{
 			Name: "EndpointsWithRebootEntry",
@@ -1308,8 +1233,7 @@ func TestDecideOps(t *testing.T) {
 				d.Status.Kubernetes.MasterEndpointSlice.Endpoints[2].Conditions.Ready = &endpointReady
 				d.Status.Kubernetes.EtcdEndpointSlice.Endpoints[2].Conditions.Ready = &endpointReady
 			}),
-			ExpectedOps:        []string{"reboot-drain-start", "reboot-recalc-metrics"},
-			ExpectedTargetNums: nil,
+			ExpectedOps: []opData{{"reboot-drain-start", 1}, {"reboot-recalc-metrics", 0}},
 		},
 		{
 			Name: "EndpointsWithCancelledRebootEntry",
@@ -1326,8 +1250,7 @@ func TestDecideOps(t *testing.T) {
 					Status: cke.RebootStatusCancelled,
 				},
 			}),
-			ExpectedOps:        []string{"reboot-dequeue", "reboot-recalc-metrics"},
-			ExpectedTargetNums: nil,
+			ExpectedOps: []opData{{"reboot-dequeue", 1}, {"reboot-recalc-metrics", 0}},
 		},
 		{
 			Name: "UserResourceAdd",
@@ -1510,7 +1433,7 @@ func TestDecideOps(t *testing.T) {
 					},
 				},
 			}),
-			ExpectedOps: []string{"update-node"},
+			ExpectedOps: []opData{{"update-node", 1}},
 		},
 		{
 			Name: "NodeLabel2",
@@ -1534,7 +1457,7 @@ func TestDecideOps(t *testing.T) {
 					},
 				},
 			}),
-			ExpectedOps: []string{"update-node"},
+			ExpectedOps: []opData{{"update-node", 1}},
 		},
 		{
 			Name: "NodeLabel3",
@@ -1561,7 +1484,7 @@ func TestDecideOps(t *testing.T) {
 					},
 				},
 			}),
-			ExpectedOps: []string{"update-node"},
+			ExpectedOps: []opData{{"update-node", 1}},
 		},
 		{
 			Name: "NodeLabel4",
@@ -1588,7 +1511,7 @@ func TestDecideOps(t *testing.T) {
 					},
 				},
 			}),
-			ExpectedOps: []string{"update-node"},
+			ExpectedOps: []opData{{"update-node", 1}},
 		},
 		{
 			Name: "NodeLabel5",
@@ -1615,7 +1538,7 @@ func TestDecideOps(t *testing.T) {
 					},
 				},
 			}),
-			ExpectedOps: []string{"update-node"},
+			ExpectedOps: []opData{{"update-node", 1}},
 		},
 		{
 			Name: "NodeLabelCP1",
@@ -1625,7 +1548,7 @@ func TestDecideOps(t *testing.T) {
 					Labels: map[string]string{},
 				},
 			}),
-			ExpectedOps: []string{"update-node"},
+			ExpectedOps: []opData{{"update-node", 1}},
 		},
 		{
 			Name: "NodeLabelCP2",
@@ -1635,7 +1558,7 @@ func TestDecideOps(t *testing.T) {
 					Labels: map[string]string{op.CKELabelMaster: "true"},
 				},
 			}),
-			ExpectedOps: []string{"update-node"},
+			ExpectedOps: []opData{{"update-node", 1}},
 		},
 		{
 			Name: "NodeLabelCP3",
@@ -1645,7 +1568,7 @@ func TestDecideOps(t *testing.T) {
 					Labels: map[string]string{op.CKELabelMaster: "hoge"},
 				},
 			}),
-			ExpectedOps: []string{"update-node"},
+			ExpectedOps: []opData{{"update-node", 1}},
 		},
 		{
 			Name: "NodeAnnotation1",
@@ -1668,7 +1591,7 @@ func TestDecideOps(t *testing.T) {
 					},
 				},
 			}),
-			ExpectedOps: []string{"update-node"},
+			ExpectedOps: []opData{{"update-node", 1}},
 		},
 		{
 			Name: "NodeAnnotation2",
@@ -1692,7 +1615,7 @@ func TestDecideOps(t *testing.T) {
 					},
 				},
 			}),
-			ExpectedOps: []string{"update-node"},
+			ExpectedOps: []opData{{"update-node", 1}},
 		},
 		{
 			Name: "NodeAnnotation3",
@@ -1719,7 +1642,7 @@ func TestDecideOps(t *testing.T) {
 					},
 				},
 			}),
-			ExpectedOps: []string{"update-node"},
+			ExpectedOps: []opData{{"update-node", 1}},
 		},
 		{
 			Name: "NodeTaint1",
@@ -1744,7 +1667,7 @@ func TestDecideOps(t *testing.T) {
 					},
 				},
 			}),
-			ExpectedOps: []string{"update-node"},
+			ExpectedOps: []opData{{"update-node", 1}},
 		},
 		{
 			Name: "NodeTaint2",
@@ -1768,7 +1691,7 @@ func TestDecideOps(t *testing.T) {
 					},
 				},
 			}),
-			ExpectedOps: []string{"update-node"},
+			ExpectedOps: []opData{{"update-node", 1}},
 		},
 		{
 			Name: "NodeTaint3",
@@ -1792,7 +1715,7 @@ func TestDecideOps(t *testing.T) {
 					},
 				},
 			}),
-			ExpectedOps: []string{"update-node"},
+			ExpectedOps: []opData{{"update-node", 1}},
 		},
 		{
 			Name: "NodeTaint4",
@@ -1820,14 +1743,14 @@ func TestDecideOps(t *testing.T) {
 					},
 				},
 			}),
-			ExpectedOps: []string{"update-node"},
+			ExpectedOps: []opData{{"update-node", 1}},
 		},
 		{
 			Name: "NodeTaintCP1",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Cluster.TaintCP = true
 			}),
-			ExpectedOps: []string{"update-node"},
+			ExpectedOps: []opData{{"update-node", 3}},
 		},
 		{
 			Name: "NodeTaintCP2",
@@ -1876,7 +1799,7 @@ func TestDecideOps(t *testing.T) {
 					},
 				},
 			}),
-			ExpectedOps: []string{},
+			ExpectedOps: []opData{},
 		},
 		{
 			Name: "NodeTaintCP3",
@@ -1925,7 +1848,7 @@ func TestDecideOps(t *testing.T) {
 					},
 				},
 			}),
-			ExpectedOps: []string{"update-node"},
+			ExpectedOps: []opData{{"update-node", 1}},
 		},
 		{
 			Name: "NodeTaintCP4",
@@ -1944,7 +1867,7 @@ func TestDecideOps(t *testing.T) {
 					},
 				},
 			}),
-			ExpectedOps: []string{"update-node"},
+			ExpectedOps: []opData{{"update-node", 1}},
 		},
 		{
 			Name: "NodeTaintCP5",
@@ -2006,7 +1929,7 @@ func TestDecideOps(t *testing.T) {
 					},
 				},
 			}),
-			ExpectedOps: []string{"update-node"},
+			ExpectedOps: []opData{{"update-node", 1}},
 		},
 		{
 			Name: "NodeExtraAttrs",
@@ -2049,7 +1972,7 @@ func TestDecideOps(t *testing.T) {
 					Name: "10.0.0.20",
 				},
 			}),
-			ExpectedOps: []string{"remove-node"},
+			ExpectedOps: []opData{{"remove-node", 1}},
 		},
 		{
 			Name: "AllGreen",
@@ -2081,7 +2004,7 @@ func TestDecideOps(t *testing.T) {
 				d.Status.Etcd.Members["10.0.0.100"] = &etcdserverpb.Member{Name: "10.0.0.100", ID: 3}
 				d.Status.Etcd.InSyncMembers["10.0.0.100"] = false
 			}),
-			ExpectedOps: []string{"etcd-remove-member"},
+			ExpectedOps: []opData{{"etcd-remove-member", 1}},
 		},
 		{
 			Name: "SkipEtcdRemoveNonClusterMember",
@@ -2089,7 +2012,7 @@ func TestDecideOps(t *testing.T) {
 				d.Status.Etcd.Members["10.0.0.100"] = &etcdserverpb.Member{Name: "10.0.0.100", ID: 3}
 				d.Status.Etcd.InSyncMembers["10.0.0.100"] = false
 			}).withSSHNotConnectedNodes(),
-			ExpectedOps: []string{"wait-kubernetes"},
+			ExpectedOps: []opData{{"wait-kubernetes", 1}},
 		},
 		{
 			Name: "EtcdDestroyNonCPMember",
@@ -2097,8 +2020,7 @@ func TestDecideOps(t *testing.T) {
 				d.Status.Etcd.Members["10.0.0.14"] = &etcdserverpb.Member{Name: "10.0.0.14", ID: 3}
 				d.Status.Etcd.InSyncMembers["10.0.0.14"] = false
 			}),
-			ExpectedOps:        []string{"etcd-destroy-member"},
-			ExpectedTargetNums: map[string]int{"etcd-destroy-member": 1},
+			ExpectedOps: []opData{{"etcd-destroy-member", 1}},
 		},
 		{
 			Name: "EtcdDestroyNonCPMemberSSHNotConnected",
@@ -2106,8 +2028,7 @@ func TestDecideOps(t *testing.T) {
 				d.Status.Etcd.Members["10.0.0.14"] = &etcdserverpb.Member{Name: "10.0.0.14", ID: 3}
 				d.Status.Etcd.InSyncMembers["10.0.0.14"] = false
 			}).withSSHNotConnectedNonCPWorker(3),
-			ExpectedOps:        []string{"etcd-destroy-member"},
-			ExpectedTargetNums: map[string]int{"etcd-destroy-member": 0},
+			ExpectedOps: []opData{{"etcd-destroy-member", 0}},
 		},
 		{
 			Name: "EtcdReAdd",
@@ -2116,14 +2037,14 @@ func TestDecideOps(t *testing.T) {
 				d.Status.Etcd.Members["10.0.0.13"].ID = 0
 				d.Status.Etcd.InSyncMembers["10.0.0.13"] = false
 			}),
-			ExpectedOps: []string{"etcd-add-member"},
+			ExpectedOps: []opData{{"etcd-add-member", 1}},
 		},
 		{
 			Name: "EtcdMark",
 			Input: newData().withAllServices().with(func(d testData) {
 				d.Status.NodeStatuses["10.0.0.13"].Etcd.IsAddedMember = false
 			}),
-			ExpectedOps: []string{"etcd-mark-member"},
+			ExpectedOps: []opData{{"etcd-mark-member", 1}},
 		},
 		{
 			Name: "EtcdIsNotGood",
@@ -2142,7 +2063,7 @@ func TestDecideOps(t *testing.T) {
 				delete(d.Status.Etcd.Members, "10.0.0.13")
 				delete(d.Status.Etcd.InSyncMembers, "10.0.0.13")
 			}),
-			ExpectedOps: []string{"etcd-add-member"},
+			ExpectedOps: []opData{{"etcd-add-member", 1}},
 		},
 		{
 			Name: "EtcdRemoveHealthyNonClusterMember",
@@ -2150,7 +2071,7 @@ func TestDecideOps(t *testing.T) {
 				d.Status.Etcd.Members["10.0.0.100"] = &etcdserverpb.Member{Name: "10.0.0.100", ID: 3}
 				d.Status.Etcd.InSyncMembers["10.0.0.100"] = true
 			}),
-			ExpectedOps: []string{"etcd-remove-member"},
+			ExpectedOps: []opData{{"etcd-remove-member", 1}},
 		},
 		{
 			Name: "EtcdDestroyHealthyNonCPMember",
@@ -2158,8 +2079,7 @@ func TestDecideOps(t *testing.T) {
 				d.Status.Etcd.Members["10.0.0.14"] = &etcdserverpb.Member{Name: "10.0.0.14", ID: 14}
 				d.Status.Etcd.InSyncMembers["10.0.0.14"] = true
 			}),
-			ExpectedOps:        []string{"etcd-destroy-member"},
-			ExpectedTargetNums: map[string]int{"etcd-destroy-member": 1},
+			ExpectedOps: []opData{{"etcd-destroy-member", 1}},
 		},
 		{
 			Name: "EtcdDestroyHealthyNonCPMemberSSHNotConnected",
@@ -2167,15 +2087,14 @@ func TestDecideOps(t *testing.T) {
 				d.Status.Etcd.Members["10.0.0.14"] = &etcdserverpb.Member{Name: "10.0.0.14", ID: 14}
 				d.Status.Etcd.InSyncMembers["10.0.0.14"] = true
 			}).withSSHNotConnectedNonCPWorker(3),
-			ExpectedOps:        []string{"etcd-destroy-member"},
-			ExpectedTargetNums: map[string]int{"etcd-destroy-member": 0},
+			ExpectedOps: []opData{{"etcd-destroy-member", 0}},
 		},
 		{
 			Name: "EtcdRestart",
 			Input: newData().withAllServices().with(func(d testData) {
 				d.NodeStatus(d.ControlPlane()[0]).Etcd.Image = ""
 			}),
-			ExpectedOps: []string{"etcd-restart"},
+			ExpectedOps: []opData{{"etcd-restart", 1}},
 		},
 		{
 			Name: "Clean",
@@ -2191,19 +2110,12 @@ func TestDecideOps(t *testing.T) {
 					st.EtcdRivers.Running = true
 				}
 			}).withSSHNotConnectedNonCPWorker(1),
-			ExpectedOps: []string{
-				"stop-etcd",
-				"stop-etcd-rivers",
-				"stop-kube-apiserver",
-				"stop-kube-controller-manager",
-				"stop-kube-scheduler",
-			},
-			ExpectedTargetNums: map[string]int{
-				"stop-etcd":                    1,
-				"stop-etcd-rivers":             1,
-				"stop-kube-apiserver":          1,
-				"stop-kube-controller-manager": 1,
-				"stop-kube-scheduler":          1,
+			ExpectedOps: []opData{
+				{"stop-kube-apiserver", 1},
+				{"stop-kube-controller-manager", 1},
+				{"stop-kube-scheduler", 1},
+				{"stop-etcd", 1},
+				{"stop-etcd-rivers", 1},
 			},
 		},
 		{
@@ -2230,7 +2142,7 @@ func TestDecideOps(t *testing.T) {
 			}).with(func(data testData) {
 				data.Status.ConfigVersion = "1"
 			}),
-			ExpectedOps: []string{"upgrade"},
+			ExpectedOps: []opData{{"upgrade", 3}},
 		},
 		{
 			Name: "UpgradeAbort",
@@ -2266,9 +2178,8 @@ func TestDecideOps(t *testing.T) {
 					op.CKEAnnotationReboot: "true",
 				}
 			}),
-			ExpectedOps: []string{"reboot-uncordon"},
-			ExpectedTargetNums: map[string]int{
-				"reboot-uncordon": 1,
+			ExpectedOps: []opData{
+				{"reboot-uncordon", 1},
 			},
 		},
 		{
@@ -2276,8 +2187,7 @@ func TestDecideOps(t *testing.T) {
 			Input: newData().withK8sResourceReady().withRebootConfig().with(func(d testData) {
 				d.Status.Kubernetes.Nodes[0].Spec.Unschedulable = true
 			}),
-			ExpectedOps:        nil,
-			ExpectedTargetNums: nil,
+			ExpectedOps: nil,
 		},
 		{
 			Name: "RebootWithoutConfig",
@@ -2288,8 +2198,7 @@ func TestDecideOps(t *testing.T) {
 					Status: cke.RebootStatusQueued,
 				},
 			}),
-			ExpectedOps:        nil,
-			ExpectedTargetNums: nil,
+			ExpectedOps: nil,
 		},
 		{
 			Name: "Reboot",
@@ -2311,10 +2220,9 @@ func TestDecideOps(t *testing.T) {
 					Status: cke.RebootStatusQueued,
 				},
 			}),
-			ExpectedOps: []string{"reboot-drain-start", "reboot-recalc-metrics"},
-			ExpectedTargetNums: map[string]int{
-				"reboot-drain-start":    1,
-				"reboot-recalc-metrics": 0,
+			ExpectedOps: []opData{
+				{"reboot-drain-start", 1},
+				{"reboot-recalc-metrics", 0},
 			},
 		},
 		{
@@ -2332,8 +2240,7 @@ func TestDecideOps(t *testing.T) {
 					Status: cke.RebootStatusQueued,
 				},
 			}),
-			ExpectedOps:        nil,
-			ExpectedTargetNums: nil,
+			ExpectedOps: nil,
 		},
 		{
 			Name: "DontSkipStartRebootDrainedTooManyUnreachableNodes",
@@ -2350,10 +2257,9 @@ func TestDecideOps(t *testing.T) {
 					Status: cke.RebootStatusDraining,
 				},
 			}),
-			ExpectedOps: []string{"reboot-reboot", "reboot-recalc-metrics"},
-			ExpectedTargetNums: map[string]int{
-				"reboot-reboot":         1,
-				"reboot-recalc-metrics": 0,
+			ExpectedOps: []opData{
+				{"reboot-reboot", 1},
+				{"reboot-recalc-metrics", 0},
 			},
 		},
 		{
@@ -2371,10 +2277,9 @@ func TestDecideOps(t *testing.T) {
 					Status: cke.RebootStatusDraining,
 				},
 			}),
-			ExpectedOps: []string{"reboot-drain-timeout", "reboot-recalc-metrics"},
-			ExpectedTargetNums: map[string]int{
-				"reboot-drain-timeout":  1,
-				"reboot-recalc-metrics": 0,
+			ExpectedOps: []opData{
+				{"reboot-drain-timeout", 1},
+				{"reboot-recalc-metrics", 0},
 			},
 		},
 		{
@@ -2392,10 +2297,9 @@ func TestDecideOps(t *testing.T) {
 					Status: cke.RebootStatusRebooting,
 				},
 			}),
-			ExpectedOps: []string{"reboot-dequeue", "reboot-recalc-metrics"},
-			ExpectedTargetNums: map[string]int{
-				"reboot-dequeue":        1,
-				"reboot-recalc-metrics": 0,
+			ExpectedOps: []opData{
+				{"reboot-dequeue", 1},
+				{"reboot-recalc-metrics", 0},
 			},
 		},
 		{
@@ -2415,8 +2319,7 @@ func TestDecideOps(t *testing.T) {
 			}).with(func(d testData) {
 				d.Status.Etcd.InSyncMembers["10.0.0.11"] = false
 			}),
-			ExpectedOps:        nil,
-			ExpectedTargetNums: nil,
+			ExpectedOps: nil,
 		},
 		{
 			Name: "CancelReboot",
@@ -2433,10 +2336,9 @@ func TestDecideOps(t *testing.T) {
 					Status: cke.RebootStatusCancelled,
 				},
 			}),
-			ExpectedOps: []string{"reboot-dequeue", "reboot-recalc-metrics"},
-			ExpectedTargetNums: map[string]int{
-				"reboot-dequeue":        1,
-				"reboot-recalc-metrics": 0,
+			ExpectedOps: []opData{
+				{"reboot-dequeue", 1},
+				{"reboot-recalc-metrics", 0},
 			},
 		},
 	}
@@ -2447,18 +2349,13 @@ func TestDecideOps(t *testing.T) {
 			if len(ops) == 0 && len(c.ExpectedOps) == 0 {
 				return
 			}
-			opNames := make([]string, len(ops))
-			opTargetNums := make(map[string]int)
+			actual := make([]opData, len(ops))
 			for i, o := range ops {
-				opNames[i] = o.Name()
-				opTargetNums[o.Name()] = len(o.Targets())
+				actual[i].Name = o.Name()
+				actual[i].TargetNum = len(o.Targets())
 			}
-			sort.Strings(opNames)
-			if !cmp.Equal(c.ExpectedOps, opNames) {
-				t.Error("unexpected ops:", cmp.Diff(c.ExpectedOps, opNames))
-			}
-			if c.ExpectedTargetNums != nil && !cmp.Equal(c.ExpectedTargetNums, opTargetNums) {
-				t.Error("unmatched targets:", cmp.Diff(c.ExpectedTargetNums, opTargetNums))
+			if !cmp.Equal(c.ExpectedOps, actual) {
+				t.Error("unexpected opData:", cmp.Diff(c.ExpectedOps, actual))
 			}
 		OUT:
 			for _, o := range ops {

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -778,7 +778,8 @@ func TestDecideOps(t *testing.T) {
 			ExpectedOps: []opData{
 				{"kube-controller-manager-bootstrap", 3},
 				{"kube-scheduler-bootstrap", 3},
-				{"kubelet-bootstrap", 6},
+				{"kubelet-bootstrap", 5},
+				{"kubelet-bootstrap", 1},
 				{"kube-proxy-bootstrap", 6},
 			},
 		},
@@ -1058,7 +1059,8 @@ func TestDecideOps(t *testing.T) {
 			}),
 			ExpectedOps: []opData{
 				{"kube-apiserver-restart", 3},
-				{"kubelet-restart", 6},
+				{"kubelet-restart", 5},
+				{"kubelet-restart", 1},
 			},
 		},
 		{
@@ -2345,7 +2347,7 @@ func TestDecideOps(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
-			ops, _ := DecideOps(c.Input.Cluster, c.Input.Status, c.Input.Constraints, c.Input.Resources, c.Input.RebootArgs, 10)
+			ops, _ := DecideOps(c.Input.Cluster, c.Input.Status, c.Input.Constraints, c.Input.Resources, c.Input.RebootArgs, 5)
 			if len(ops) == 0 && len(c.ExpectedOps) == 0 {
 				return
 			}

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -638,7 +638,7 @@ func TestDecideOps(t *testing.T) {
 		{
 			Name:        "BootRivers",
 			Input:       newData(),
-			ExpectedOps: []opData{{"rivers-bootstrap", 6}, {"etcd-rivers-bootstrap", 3}},
+			ExpectedOps: []opData{{"rivers-bootstrap", 5}, {"rivers-bootstrap", 1}, {"etcd-rivers-bootstrap", 3}},
 		},
 		{
 			Name:        "BootRivers2",
@@ -780,7 +780,8 @@ func TestDecideOps(t *testing.T) {
 				{"kube-scheduler-bootstrap", 3},
 				{"kubelet-bootstrap", 5},
 				{"kubelet-bootstrap", 1},
-				{"kube-proxy-bootstrap", 6},
+				{"kube-proxy-bootstrap", 5},
+				{"kube-proxy-bootstrap", 1},
 			},
 		},
 		{
@@ -1011,7 +1012,8 @@ func TestDecideOps(t *testing.T) {
 			Name:  "StopProxy",
 			Input: newData().withAllServices().withDisableProxy(),
 			ExpectedOps: []opData{
-				{"stop-kube-proxy", 6},
+				{"stop-kube-proxy", 5},
+				{"stop-kube-proxy", 1},
 			},
 		},
 		{

--- a/sonobuoy/README.md
+++ b/sonobuoy/README.md
@@ -28,7 +28,7 @@ Please choose an appropriate ZONE to run C2 machine family VMs.
 
 ```
 PROJECT=neco-test
-ZONE=asia-northeast1-c
+ZONE=asia-northeast2-c
 SERVICE_ACCOUNT=neco-test@neco-test.iam.gserviceaccount.com
 ```
 


### PR DESCRIPTION
Add a new cli option `max-concurrent-updates`.
It can limit the number of components (kubelet, kube-proxy and rivers) that can be updated simultaneously.

This change will solve the following problems:

- Prevent large amounts access to the Internet
- Prevent large amounts access to APIServer
- Prevent all kubelets from going down

Signed-off-by: zoetrope <a.ikezoe@gmail.com>