### PR TITLE
cke-tools: Update CNI plugins to v1.3.0

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
       - name: Check static resources
@@ -35,7 +35,7 @@ jobs:
       CLUSTER: "cke-cluster.yml"
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
       - uses: google-github-actions/auth@v1
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
       - uses: google-github-actions/auth@v1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'main'
 env:
-  go-version: 1.19
   filename: "main.yaml"
 jobs:
   build:
@@ -15,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.go-version }}
+          go-version-file: go.mod
       - name: Check static resources
         run: |
             cp ./static/resources.go /tmp/resources.go
@@ -38,7 +37,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.go-version }}
+          go-version-file: go.mod
       - uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.NECO_TEST_SERVICE_ACCOUNT }}
@@ -104,7 +103,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.go-version }}
+          go-version-file: go.mod
       - uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.NECO_TEST_SERVICE_ACCOUNT }}

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -4,7 +4,6 @@ on:
     tags:
       - 'v*'
 env:
-  go-version: 1.19
   tag: ${GITHUB_REF#refs/tags/v}
   prerelease: ${{ contains(github.ref, '-') }}
 jobs:
@@ -15,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.go-version }}
+          go-version-file: go.mod
       - uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.NECO_TEST_SERVICE_ACCOUNT }}
@@ -46,7 +45,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.go-version }}
+          go-version-file: go.mod
       - run: make install GOBIN=$(pwd)/docker
       - run: docker build -t quay.io/cybozu/cke:latest ./docker
       - name: Push docker image to Quay.io

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
       - uses: google-github-actions/auth@v1
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
       - run: make install GOBIN=$(pwd)/docker

--- a/.github/workflows/release-tools.yaml
+++ b/.github/workflows/release-tools.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
       - name: Build CKE tools

--- a/.github/workflows/release-tools.yaml
+++ b/.github/workflows/release-tools.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version-file: go.mod
       - name: Build CKE tools
         run: |
           cd tools

--- a/.github/workflows/sonobuoy.yaml
+++ b/.github/workflows/sonobuoy.yaml
@@ -1,8 +1,6 @@
 name: sonobuoy
 on:
   workflow_dispatch:
-env:
-  go-version: 1.19
 jobs:
   sonobuoy:
     name: Run sonobuoy
@@ -11,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.go-version }}
+          go-version-file: go.mod
       - uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.NECO_TEST_SERVICE_ACCOUNT }}

--- a/.github/workflows/sonobuoy.yaml
+++ b/.github/workflows/sonobuoy.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
       - uses: google-github-actions/auth@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,82 +5,9 @@ This project employs a versioning scheme described in [RELEASE.md](RELEASE.md#ve
 
 ## [Unreleased]
 
-## [1.25.8]
-
-### Fixed
-
-- Fix retry of reboot to set timeout in each retry in [#641](https://github.com/cybozu-go/cke/pull/641)
-
-## [1.25.7]
-
-### Fixed
-
-- Fix to call addon on k8sMaintain phase [#638](https://github.com/cybozu-go/cke/pull/638)
-
-## [1.25.6]
-
-### Changed
-
-- fix to apply resources that has same rank at the same time [#634](https://github.com/cybozu-go/cke/pull/634)
-
-## [1.25.5]
-
-### Added 
-
-- Limit the number of components (kubelet, kube-proxy and rivers) that can be updated simultaneously [#630](https://github.com/cybozu-go/cke/pull/630)
-
-## [1.25.4]
-
-### Added 
-
-- Update user-defined resource applying logic [#617](https://github.com/cybozu-go/cke/pull/617)
-
-## [1.25.3]
-
-### Changed
-
-- Update Kubernetes to 1.25.10 in [#628](https://github.com/cybozu-go/cke/pull/628)
-
-## [1.25.2]
-
-### Fixed
-
-- Fix Calico manifest to latest version [#627](https://github.com/cybozu-go/cke/pull/627)
- 
-### Changed
-
-- Update for Kubernetes 1.25.9 [#624](https://github.com/cybozu-go/cke/pull/624)
-  - Update Kubernetes to v1.25.9
-  - Update some dependencies
-- Update CKE image for example in [#618](https://github.com/cybozu-go/cke/pull/618)
-  - Update CKE image for example
-  - Add email address in PRODUCT.yaml
-
-## [1.25.1]
-
-### Changed
-
-- Change behavior to not do SELinux labeling unless SELinux enforcing mode [#620](https://github.com/cybozu-go/cke/pull/620)
-- Retry reboot command if failed in processing reboot queue in [#621](https://github.com/cybozu-go/cke/pull/621)
-
-## [1.25.0]
-
-### Changed
-
-- Support Kubernetes 1.25 [#610](https://github.com/cybozu-go/cke/pull/610)
-  - Update Kubernetes to v1.25.6
-  - Update some dependencies
-
-## [1.25.0-rc.1]
-
-### Changed
-
-- Support Kubernetes 1.25 [#610](https://github.com/cybozu-go/cke/pull/610)
-  - Update Kubernetes to v1.25.6
-  - Update some dependencies
-
 ## Ancient changes
 
+- See [release-1.25/CHANGELOG.md](https://github.com/cybozu-go/cke/blob/release-1.25/CHANGELOG.md) for changes in CKE 1.25.
 - See [release-1.24/CHANGELOG.md](https://github.com/cybozu-go/cke/blob/release-1.24/CHANGELOG.md) for changes in CKE 1.24.
 - See [release-1.23/CHANGELOG.md](https://github.com/cybozu-go/cke/blob/release-1.23/CHANGELOG.md) for changes in CKE 1.23.
 - See [release-1.22/CHANGELOG.md](https://github.com/cybozu-go/cke/blob/release-1.22/CHANGELOG.md) for changes in CKE 1.22.
@@ -96,13 +23,3 @@ This project employs a versioning scheme described in [RELEASE.md](RELEASE.md#ve
 - See [release-1.12/CHANGELOG.md](https://github.com/cybozu-go/cke/blob/release-1.12/CHANGELOG.md) for changes in CKE 1.12.
 
 [Unreleased]: https://github.com/cybozu-go/cke/compare/v1.25.8...HEAD
-[1.25.8]: https://github.com/cybozu-go/cke/compare/v1.25.7...v1.25.8
-[1.25.7]: https://github.com/cybozu-go/cke/compare/v1.25.6...v1.25.7
-[1.25.6]: https://github.com/cybozu-go/cke/compare/v1.25.5...v1.25.6
-[1.25.5]: https://github.com/cybozu-go/cke/compare/v1.25.4...v1.25.5
-[1.25.4]: https://github.com/cybozu-go/cke/compare/v1.25.3...v1.25.4
-[1.25.3]: https://github.com/cybozu-go/cke/compare/v1.25.2...v1.25.3
-[1.25.2]: https://github.com/cybozu-go/cke/compare/v1.25.1...v1.25.2
-[1.25.1]: https://github.com/cybozu-go/cke/compare/v1.25.0...v1.25.1
-[1.25.0]: https://github.com/cybozu-go/cke/compare/v1.24.2...v1.25.0
-[1.25.0-rc.1]: https://github.com/cybozu-go/cke/compare/v1.24.2...v1.25.0-rc.1

--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 cke-tools related changes.
 
+## 1.26.0 - 2023-07-10
+
+- Update CNI plugins to 1.3.0[#644](https://github.com/cybozu-go/cke/pull/644)
+- Update go to 1.20 [#644](https://github.com/cybozu-go/cke/pull/644)
+
 ## 1.25.0 - 2023-02-14
 
 - Update CNI plugins to 1.2.0[#609](https://github.com/cybozu-go/cke/pull/609)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,4 +1,4 @@
-CNI_PLUGIN_VERSION = 1.2.0
+CNI_PLUGIN_VERSION = 1.3.0
 TAG = quay.io/cybozu/cke-tools:dev
 GOBUILD = CGO_ENABLED=0 go build -ldflags="-w -s"
 


### PR DESCRIPTION
This PR:
- updates Go to 1.20
- updates CNI plugin to 1.3.0

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>