### PR TITLE
Fix `cke_node_reboot_status` metrics

### DIFF
--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -123,6 +123,7 @@ func (c collector) Collect(ch chan<- prometheus.Metric) {
 	wg.Wait()
 }
 
+// nodeMetricsCollector implements prometheus.Collector interface.
 type nodeMetricsCollector struct {
 	storage storage
 }
@@ -141,11 +142,17 @@ func (c nodeMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 
 	rqEntries, err := c.storage.GetRebootsEntries(ctx)
 	if err != nil {
+		log.Error("failed to get reboots entries", map[string]interface{}{
+			log.FnError: err,
+		})
 		return
 	}
 
 	cluster, err := c.storage.GetCluster(ctx)
 	if err != nil {
+		log.Error("failed to get reboots entries", map[string]interface{}{
+			log.FnError: err,
+		})
 		return
 	}
 	itemCounts := cke.CountRebootQueueEntries(rqEntries)

--- a/metrics/collector.go
+++ b/metrics/collector.go
@@ -150,7 +150,7 @@ func (c nodeMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 
 	cluster, err := c.storage.GetCluster(ctx)
 	if err != nil {
-		log.Error("failed to get reboots entries", map[string]interface{}{
+		log.Error("failed to get cluster", map[string]interface{}{
 			log.FnError: err,
 		})
 		return

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -33,29 +33,25 @@ var operationPhaseTimestampSeconds = prometheus.NewGauge(
 	},
 )
 
-var rebootQueueEntries = prometheus.NewGauge(
-	prometheus.GaugeOpts{
-		Namespace: namespace,
-		Name:      "reboot_queue_entries",
-		Help:      "The number of reboot queue entries remaining.",
-	},
+var rebootQueueEntries = prometheus.NewDesc(
+	namespace+"_reboot_queue_entries",
+	"The number of reboot queue entries remaining.",
+	nil,
+	nil,
 )
 
-var rebootQueueItems = prometheus.NewGaugeVec(
-	prometheus.GaugeOpts{
-		Namespace: namespace,
-		Name:      "reboot_queue_items",
-		Help:      "The number of reboot queue entries remaining per status.",
-	},
+var rebootQueueItems = prometheus.NewDesc(
+	namespace+"_reboot_queue_items",
+	"The number of reboot queue entries remaining per status.",
 	[]string{"status"},
+	nil,
 )
 
-var nodeRebootStatus = prometheus.NewGaugeVec(
-	prometheus.GaugeOpts{
-		Namespace: namespace,
-		Name:      "node_reboot_status",
-		Help:      "The reboot status of a node.",
-	}, []string{"node", "status"},
+var nodeRebootStatus = prometheus.NewDesc(
+	namespace+"_node_reboot_status",
+	"The reboot status of a node.",
+	[]string{"node", "status"},
+	nil,
 )
 
 var sabakanIntegrationSuccessful = prometheus.NewGauge(

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -34,21 +34,21 @@ var operationPhaseTimestampSeconds = prometheus.NewGauge(
 )
 
 var rebootQueueEntries = prometheus.NewDesc(
-	namespace+"_reboot_queue_entries",
+	prometheus.BuildFQName(namespace, "", "reboot_queue_entries"),
 	"The number of reboot queue entries remaining.",
 	nil,
 	nil,
 )
 
 var rebootQueueItems = prometheus.NewDesc(
-	namespace+"_reboot_queue_items",
+	prometheus.BuildFQName(namespace, "", "reboot_queue_items"),
 	"The number of reboot queue entries remaining per status.",
 	[]string{"status"},
 	nil,
 )
 
 var nodeRebootStatus = prometheus.NewDesc(
-	namespace+"_node_reboot_status",
+	prometheus.BuildFQName(namespace, "", "node_reboot_status"),
 	"The reboot status of a node.",
 	[]string{"node", "status"},
 	nil,

--- a/metrics/updater.go
+++ b/metrics/updater.go
@@ -39,36 +39,6 @@ func isOperationPhaseAvailable(_ context.Context, _ storage) (bool, error) {
 	return isLeader, nil
 }
 
-// UpdateRebootQueueEntries updates "reboot_queue_entries".
-func UpdateRebootQueueEntries(numEntries int) {
-	rebootQueueEntries.Set(float64(numEntries))
-}
-
-// UpdateRebootQueueItems updates "reboot_queue_items".
-func UpdateRebootQueueItems(counts map[string]int) {
-	for status, count := range counts {
-		rebootQueueItems.With(map[string]string{
-			"status": status,
-		}).Set(float64(count))
-	}
-}
-
-// UpdateNodeRebootStatus updates "node_reboot_status".
-func UpdateNodeRebootStatus(nodeStatus map[string]map[string]bool) {
-	for node, statuses := range nodeStatus {
-		for status, matches := range statuses {
-			value := float64(0)
-			if matches {
-				value = 1
-			}
-			nodeRebootStatus.With(map[string]string{
-				"node":   node,
-				"status": status,
-			}).Set(value)
-		}
-	}
-}
-
 func isRebootAvailable(_ context.Context, _ storage) (bool, error) {
 	return isLeader, nil
 }

--- a/metrics/updater_test.go
+++ b/metrics/updater_test.go
@@ -258,21 +258,15 @@ func testUpdateRebootQueueEntries(t *testing.T) {
 		{
 			name: "one",
 			input: []*cke.RebootQueueEntry{
-				{
-					Status: cke.RebootStatusQueued,
-				},
+				{Status: cke.RebootStatusQueued},
 			},
 			expected: 1,
 		},
 		{
 			name: "two",
 			input: []*cke.RebootQueueEntry{
-				{
-					Status: cke.RebootStatusQueued,
-				},
-				{
-					Status: cke.RebootStatusRebooting,
-				},
+				{Status: cke.RebootStatusQueued},
+				{Status: cke.RebootStatusRebooting},
 			},
 			expected: 2,
 		},
@@ -320,24 +314,12 @@ func testUpdateRebootQueueItems(t *testing.T) {
 		{
 			name: "zero",
 			input: []*cke.RebootQueueEntry{
-				{
-					Status: cke.RebootStatusQueued,
-				},
-				{
-					Status: cke.RebootStatusDraining,
-				},
-				{
-					Status: cke.RebootStatusDraining,
-				},
-				{
-					Status: cke.RebootStatusRebooting,
-				},
-				{
-					Status: cke.RebootStatusRebooting,
-				},
-				{
-					Status: cke.RebootStatusRebooting,
-				},
+				{Status: cke.RebootStatusQueued},
+				{Status: cke.RebootStatusDraining},
+				{Status: cke.RebootStatusDraining},
+				{Status: cke.RebootStatusRebooting},
+				{Status: cke.RebootStatusRebooting},
+				{Status: cke.RebootStatusRebooting},
 			},
 			expected: map[string]float64{
 				"queued":    1.0,
@@ -349,51 +331,21 @@ func testUpdateRebootQueueItems(t *testing.T) {
 		{
 			name: "one",
 			input: []*cke.RebootQueueEntry{
-				{
-					Status: cke.RebootStatusQueued,
-				},
-				{
-					Status: cke.RebootStatusQueued,
-				},
-				{
-					Status: cke.RebootStatusQueued,
-				},
-				{
-					Status: cke.RebootStatusQueued,
-				},
-				{
-					Status: cke.RebootStatusDraining,
-				},
-				{
-					Status: cke.RebootStatusDraining,
-				},
-				{
-					Status: cke.RebootStatusDraining,
-				},
-				{
-					Status: cke.RebootStatusDraining,
-				},
-				{
-					Status: cke.RebootStatusDraining,
-				},
-				{
-					Status: cke.RebootStatusCancelled,
-				},
-				{
-					Status: cke.RebootStatusCancelled,
-				},
-				{
-					Status: cke.RebootStatusCancelled,
-				},
-				{
-					Status: cke.RebootStatusCancelled,
-				},
-				{
-					Status: cke.RebootStatusCancelled,
-				},
-				{
-					Status: cke.RebootStatusCancelled,
-				},
+				{Status: cke.RebootStatusQueued},
+				{Status: cke.RebootStatusQueued},
+				{Status: cke.RebootStatusQueued},
+				{Status: cke.RebootStatusQueued},
+				{Status: cke.RebootStatusDraining},
+				{Status: cke.RebootStatusDraining},
+				{Status: cke.RebootStatusDraining},
+				{Status: cke.RebootStatusDraining},
+				{Status: cke.RebootStatusDraining},
+				{Status: cke.RebootStatusCancelled},
+				{Status: cke.RebootStatusCancelled},
+				{Status: cke.RebootStatusCancelled},
+				{Status: cke.RebootStatusCancelled},
+				{Status: cke.RebootStatusCancelled},
+				{Status: cke.RebootStatusCancelled},
 			},
 			expected: map[string]float64{
 				"queued":    4.0,

--- a/mtest/reboot_test.go
+++ b/mtest/reboot_test.go
@@ -94,7 +94,6 @@ func testRebootOperations() {
 	// - RebootDrainTimeoutOp
 	// - RebootUncordonOp
 	// - RebootDequeueOp
-	// - RebootRecalcMetricsOp
 
 	cluster := getCluster()
 	for i := 0; i < 3; i++ {

--- a/pkg/cke/main.go
+++ b/pkg/cke/main.go
@@ -126,7 +126,8 @@ func main() {
 	// API server
 	mux := http.NewServeMux()
 	// Metrics
-	collector := metrics.NewCollector(etcd)
+	storage := &cke.Storage{Client: etcd}
+	collector := metrics.NewCollector(storage)
 	metricsHandler := metrics.GetHandler(collector)
 	mux.Handle("/metrics", metricsHandler)
 	// REST API

--- a/sabakan/generator.go
+++ b/sabakan/generator.go
@@ -52,6 +52,8 @@ func MachineToNode(m *Machine, tmpl *cke.Node) *cke.Node {
 	n.Labels["cke.cybozu.com/rack"] = strconv.Itoa(m.Spec.Rack)
 	n.Labels["cke.cybozu.com/index-in-rack"] = strconv.Itoa(m.Spec.IndexInRack)
 	n.Labels["cke.cybozu.com/role"] = m.Spec.Role
+	n.Labels["cke.cybozu.com/retire-date"] = m.Spec.RetireDate.Format("2006-01")
+	n.Labels["cke.cybozu.com/register-date"] = m.Spec.RegisterDate.Format("2006-01")
 	n.Labels["node-role.kubernetes.io/"+m.Spec.Role] = "true"
 	if n.ControlPlane {
 		n.Labels["node-role.kubernetes.io/master"] = "true"

--- a/sabakan/generator.go
+++ b/sabakan/generator.go
@@ -52,8 +52,6 @@ func MachineToNode(m *Machine, tmpl *cke.Node) *cke.Node {
 	n.Labels["cke.cybozu.com/rack"] = strconv.Itoa(m.Spec.Rack)
 	n.Labels["cke.cybozu.com/index-in-rack"] = strconv.Itoa(m.Spec.IndexInRack)
 	n.Labels["cke.cybozu.com/role"] = m.Spec.Role
-	n.Labels["cke.cybozu.com/retire-date"] = m.Spec.RetireDate.Format("2006-01")
-	n.Labels["cke.cybozu.com/register-date"] = m.Spec.RegisterDate.Format("2006-01")
 	n.Labels["node-role.kubernetes.io/"+m.Spec.Role] = "true"
 	if n.ControlPlane {
 		n.Labels["node-role.kubernetes.io/master"] = "true"

--- a/server/control.go
+++ b/server/control.go
@@ -314,9 +314,6 @@ func (c Controller) runOnce(ctx context.Context, leaderKey string, tick <-chan t
 	if err != nil {
 		return err
 	}
-	metrics.UpdateRebootQueueEntries(len(rqEntries))
-	itemCounts := cke.CountRebootQueueEntries(rqEntries)
-	metrics.UpdateRebootQueueItems(itemCounts)
 	rqEntries = cke.DedupRebootQueueEntries(rqEntries)
 
 	if len(rqEntries) > 0 {

--- a/server/strategy.go
+++ b/server/strategy.go
@@ -719,7 +719,6 @@ func rebootOps(c *cke.Cluster, constraints *cke.Constraints, rebootArgs DecideOp
 	}
 	if len(ops) > 0 {
 		phaseReboot = true
-		ops = append(ops, op.RebootRecalcMetricsOp())
 	}
 
 	return ops, phaseReboot

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -1207,7 +1207,7 @@ func TestDecideOps(t *testing.T) {
 				d.Status.Kubernetes.MasterEndpointSlice.Endpoints[2].Conditions.Ready = &endpointReady
 				d.Status.Kubernetes.EtcdEndpointSlice.Endpoints[2].Conditions.Ready = &endpointReady
 			}),
-			ExpectedOps: []opData{{"reboot-drain-start", 1}, {"reboot-recalc-metrics", 0}},
+			ExpectedOps: []opData{{"reboot-drain-start", 1}},
 		},
 		{
 			Name: "EndpointsWithCancelledRebootEntry",
@@ -1224,7 +1224,7 @@ func TestDecideOps(t *testing.T) {
 					Status: cke.RebootStatusCancelled,
 				},
 			}),
-			ExpectedOps: []opData{{"reboot-dequeue", 1}, {"reboot-recalc-metrics", 0}},
+			ExpectedOps: []opData{{"reboot-dequeue", 1}},
 		},
 		{
 			Name: "UserResourceAdd",
@@ -2065,7 +2065,6 @@ func TestDecideOps(t *testing.T) {
 			}),
 			ExpectedOps: []opData{
 				{"reboot-drain-start", 1},
-				{"reboot-recalc-metrics", 0},
 			},
 		},
 		{
@@ -2102,7 +2101,6 @@ func TestDecideOps(t *testing.T) {
 			}),
 			ExpectedOps: []opData{
 				{"reboot-reboot", 1},
-				{"reboot-recalc-metrics", 0},
 			},
 		},
 		{
@@ -2122,7 +2120,6 @@ func TestDecideOps(t *testing.T) {
 			}),
 			ExpectedOps: []opData{
 				{"reboot-drain-timeout", 1},
-				{"reboot-recalc-metrics", 0},
 			},
 		},
 		{
@@ -2142,7 +2139,6 @@ func TestDecideOps(t *testing.T) {
 			}),
 			ExpectedOps: []opData{
 				{"reboot-dequeue", 1},
-				{"reboot-recalc-metrics", 0},
 			},
 		},
 		{
@@ -2181,7 +2177,6 @@ func TestDecideOps(t *testing.T) {
 			}),
 			ExpectedOps: []opData{
 				{"reboot-dequeue", 1},
-				{"reboot-recalc-metrics", 0},
 			},
 		},
 	}


### PR DESCRIPTION
Currently, there is an issue with `cke_node_reboot_status` metrics not being reflected correctly in the following cases:

- When drain/uncordon is repeated
- When node additions and deletions occur with sabakan integration

This PR calculates the value of metrics each time they are collected.
As a result we will be able to get correct metrics.