### PR TITLE
Fix blocking by kubelet-restart op

### DIFF
--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -608,7 +608,7 @@ func TestDecideOps(t *testing.T) {
 		{
 			Name:        "BootRivers",
 			Input:       newData(),
-			ExpectedOps: []opData{{"rivers-bootstrap", 5}, {"rivers-bootstrap", 1}, {"etcd-rivers-bootstrap", 3}},
+			ExpectedOps: []opData{{"rivers-bootstrap", 5}, {"etcd-rivers-bootstrap", 3}},
 		},
 		{
 			Name:        "BootRivers2",
@@ -749,9 +749,7 @@ func TestDecideOps(t *testing.T) {
 				{"kube-controller-manager-bootstrap", 3},
 				{"kube-scheduler-bootstrap", 3},
 				{"kubelet-bootstrap", 5},
-				{"kubelet-bootstrap", 1},
 				{"kube-proxy-bootstrap", 5},
-				{"kube-proxy-bootstrap", 1},
 			},
 		},
 		{
@@ -983,7 +981,6 @@ func TestDecideOps(t *testing.T) {
 			Input: newData().withAllServices().withDisableProxy(),
 			ExpectedOps: []opData{
 				{"stop-kube-proxy", 5},
-				{"stop-kube-proxy", 1},
 			},
 		},
 		{
@@ -1032,7 +1029,6 @@ func TestDecideOps(t *testing.T) {
 			ExpectedOps: []opData{
 				{"kube-apiserver-restart", 3},
 				{"kubelet-restart", 5},
-				{"kubelet-restart", 1},
 			},
 		},
 		{


### PR DESCRIPTION
`kubelet-restart` op takes a long time.
If a problem occurs during `kubelet-restart` op (e.g. controller-manager crashes), the problem will not be repaired.

In this PR, after one of `kubelet-restart` op is finished, next operation is decided again.
This will be able to repair a problem in a short time.