### PR TITLE
Stop unnecessary resource updating

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -261,7 +261,7 @@ func (d ResourceDefinition) NeedUpdate(rs *ResourceStatus) bool {
 
 	curImage, ok := rs.Annotations[AnnotationResourceImage]
 	if !ok {
-		return true
+		return false
 	}
 	return curImage != d.Image
 }


### PR DESCRIPTION
Should not update a resource, If it does not have `cke.cybozu.com/image` annotation.