### PR TITLE
Add `register-month` and `retire-month` labels

### DIFF
--- a/docs/sabakan-integration.md
+++ b/docs/sabakan-integration.md
@@ -322,14 +322,16 @@ Other Machine fields are also translated to labels as follows.
 `topology.kubernetes.io/zone` and `failure-domain.beta.kubernetes.io/zone`(deprecated) are well-known labels.
 `node-role.kubernetes.io/<role>` are used by `kubectl` to display the node's role.
 
-| Field              | Label key                                | Value                                               |
-| ------------------ | ---------------------------------------- | --------------------------------------------------- |
-| `spec.rack`        | `cke.cybozu.com/rack`                    | `spec.rack` converted to string.                    |
-| `spec.rack`        | `topology.kubernetes.io/zone`            | `spec.rack` converted to string with prefix `rack`. |
-| `spec.rack`        | `failure-domain.beta.kubernetes.io/zone` | `spec.rack` converted to string with prefix `rack`. |
-| `spec.indexInRack` | `cke.cybozu.com/index-in-rack`           | `spec.indexInRack` converted to string.             |
-| `spec.role`        | `cke.cybozu.com/role`                    | The same as `spec.role`.                            |
-| `spec.role`        | `node-role.kubernetes.io/<role>`         | `"true"`                                            |
+| Field               | Label key                                | Value                                               |
+|---------------------|------------------------------------------|-----------------------------------------------------|
+| `spec.rack`         | `cke.cybozu.com/rack`                    | `spec.rack` converted to string.                    |
+| `spec.rack`         | `topology.kubernetes.io/zone`            | `spec.rack` converted to string with prefix `rack`. |
+| `spec.rack`         | `failure-domain.beta.kubernetes.io/zone` | `spec.rack` converted to string with prefix `rack`. |
+| `spec.indexInRack`  | `cke.cybozu.com/index-in-rack`           | `spec.indexInRack` converted to string.             |
+| `spec.role`         | `cke.cybozu.com/role`                    | The same as `spec.role`.                            |
+| `spec.role`         | `node-role.kubernetes.io/<role>`         | `"true"`                                            |
+| `spec.registerDate` | `cke.cybozu.com/register-month`          | `spec.registerDate` in `yyyy-MM` format.            |
+| `spec.retireDate`   | `cke.cybozu.com/retire-month`            | `spec.retireDate` in `yyyy-MM` format.              |
 
 In addition `node-role.kubernetes.io/master` is set to `"true"` in the control plane node.
 

--- a/sabakan/generator.go
+++ b/sabakan/generator.go
@@ -52,6 +52,8 @@ func MachineToNode(m *Machine, tmpl *cke.Node) *cke.Node {
 	n.Labels["cke.cybozu.com/rack"] = strconv.Itoa(m.Spec.Rack)
 	n.Labels["cke.cybozu.com/index-in-rack"] = strconv.Itoa(m.Spec.IndexInRack)
 	n.Labels["cke.cybozu.com/role"] = m.Spec.Role
+	n.Labels["cke.cybozu.com/retire-date"] = m.Spec.RetireDate.Format("2006-01")
+	n.Labels["cke.cybozu.com/register-date"] = m.Spec.RegisterDate.Format("2006-01")
 	n.Labels["node-role.kubernetes.io/"+m.Spec.Role] = "true"
 	if n.ControlPlane {
 		n.Labels["node-role.kubernetes.io/master"] = "true"

--- a/sabakan/generator.go
+++ b/sabakan/generator.go
@@ -52,8 +52,8 @@ func MachineToNode(m *Machine, tmpl *cke.Node) *cke.Node {
 	n.Labels["cke.cybozu.com/rack"] = strconv.Itoa(m.Spec.Rack)
 	n.Labels["cke.cybozu.com/index-in-rack"] = strconv.Itoa(m.Spec.IndexInRack)
 	n.Labels["cke.cybozu.com/role"] = m.Spec.Role
-	n.Labels["cke.cybozu.com/retire-date"] = m.Spec.RetireDate.Format("2006-01")
-	n.Labels["cke.cybozu.com/register-date"] = m.Spec.RegisterDate.Format("2006-01")
+	n.Labels["cke.cybozu.com/retire-month"] = m.Spec.RetireDate.Format("2006-01")
+	n.Labels["cke.cybozu.com/register-month"] = m.Spec.RegisterDate.Format("2006-01")
 	n.Labels["node-role.kubernetes.io/"+m.Spec.Role] = "true"
 	if n.ControlPlane {
 		n.Labels["node-role.kubernetes.io/master"] = "true"

--- a/sabakan/generator_test.go
+++ b/sabakan/generator_test.go
@@ -76,11 +76,11 @@ func testMachineToNode(t *testing.T) {
 	if res1.Labels["node-role.kubernetes.io/control-plane"] != "true" {
 		t.Error(`res1.Lables["node-role.kubernetes.io/control-plane"] != "true", actual:`, res1.Labels)
 	}
-	if res1.Labels[domain+"/register-date"] != testPast250.Format("2006-01") {
-		t.Error(`res1.Labels["cke.cybozu.com/register-date"] != machine.Spec.RegisterDate.Format("2006-01"), actual:`, res1.Labels)
+	if res1.Labels[domain+"/register-month"] != testPast250.Format("2006-01") {
+		t.Error(`res1.Labels["cke.cybozu.com/register-month"] != machine.Spec.RegisterDate.Format("2006-01"), actual:`, res1.Labels)
 	}
-	if res1.Labels[domain+"/retire-date"] != testBaseTS.Format("2006-01") {
-		t.Error(`res1.Labels["cke.cybozu.com/register-date"] != machine.Spec.RetireDate.Format("2006-01"), actual:`, res1.Labels)
+	if res1.Labels[domain+"/retire-month"] != testBaseTS.Format("2006-01") {
+		t.Error(`res1.Labels["cke.cybozu.com/register-month"] != machine.Spec.RetireDate.Format("2006-01"), actual:`, res1.Labels)
 	}
 	if !containsTaint(res1.Taints, corev1.Taint{Key: "foo", Effect: corev1.TaintEffectNoSchedule}) {
 		t.Error(`res1.Taints do not have corev1.Taint{Key"foo", Effect: corev1.TaintEffectNoSchedule}, actual:`, res1.Taints)

--- a/sabakan/generator_test.go
+++ b/sabakan/generator_test.go
@@ -76,6 +76,12 @@ func testMachineToNode(t *testing.T) {
 	if res1.Labels["node-role.kubernetes.io/control-plane"] != "true" {
 		t.Error(`res1.Lables["node-role.kubernetes.io/control-plane"] != "true", actual:`, res1.Labels)
 	}
+	if res1.Labels[domain+"/register-date"] != testPast250.Format("2006-01") {
+		t.Error(`res1.Labels["cke.cybozu.com/register-date"] != machine.Spec.RegisterDate.Format("2006-01"), actual:`, res1.Labels)
+	}
+	if res1.Labels[domain+"/retire-date"] != testBaseTS.Format("2006-01") {
+		t.Error(`res1.Labels["cke.cybozu.com/register-date"] != machine.Spec.RetireDate.Format("2006-01"), actual:`, res1.Labels)
+	}
 	if !containsTaint(res1.Taints, corev1.Taint{Key: "foo", Effect: corev1.TaintEffectNoSchedule}) {
 		t.Error(`res1.Taints do not have corev1.Taint{Key"foo", Effect: corev1.TaintEffectNoSchedule}, actual:`, res1.Taints)
 	}


### PR DESCRIPTION
Add registration and retiring months to node labels.
These labels will be helpful in scheduling pods.