### PR TITLE
Bump cke-tools version to 1.27.0

### DIFF
--- a/tools/CHANGELOG.md
+++ b/tools/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 cke-tools related changes.
 
+## 1.27.0 - 2023-11-17
+
+- Update dependencies [#671](https://github.com/cybozu-go/cke/pull/671)
+
 ## 1.26.0 - 2023-07-10
 
 - Update CNI plugins to 1.3.0[#644](https://github.com/cybozu-go/cke/pull/644)


### PR DESCRIPTION
part of https://github.com/cybozu-go/cke/issues/666

The latest version of CNI Plugins is still v1.3.0.
https://github.com/containernetworking/plugins/releases/tag/v1.3.0