### PR TITLE
Implement reboot-queue status metrices

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -9,8 +9,10 @@ CKE exposes the following metrics with the Prometheus format at `/metrics` REST 
 | node_reboot_status                    | The reboot status of a node.                                               | Gauge | `node`, `status` |
 | operation_phase                       | 1 if CKE is operating in the phase specified by the `phase` label.         | Gauge | `phase`          |
 | operation_phase_timestamp_seconds     | The Unix timestamp when `operation_phase` was last updated.                | Gauge |                  |
+| reboot_queue_enabled                  | True (=1) if reboot queue is enabled.                                      | Gauge |                  |
 | reboot_queue_entries                  | The number of reboot queue entries remaining.                              | Gauge |                  |
 | reboot_queue_items                    | The number reboot queue entries remaining per status.                      | Gauge | `status`         |
+| reboot_queue_running                  | True (=1) if reboot queue is enabled and the queue is not empty.           | Gauge |                  |
 | sabakan_integration_successful        | True (=1) if sabakan-integration satisfies constraints.                    | Gauge |                  |
 | sabakan_integration_timestamp_seconds | The Unix timestamp when `sabakan_integration_successful` was last updated. | Gauge |                  |
 | sabakan_workers                       | The number of worker nodes for each role.                                  | Gauge | `role`           |

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -33,6 +33,13 @@ var operationPhaseTimestampSeconds = prometheus.NewGauge(
 	},
 )
 
+var rebootQueueEnabled = prometheus.NewDesc(
+	prometheus.BuildFQName(namespace, "", "reboot_queue_enabled"),
+	"1 if reboot queue is enabled.",
+	nil,
+	nil,
+)
+
 var rebootQueueEntries = prometheus.NewDesc(
 	prometheus.BuildFQName(namespace, "", "reboot_queue_entries"),
 	"The number of reboot queue entries remaining.",
@@ -44,6 +51,13 @@ var rebootQueueItems = prometheus.NewDesc(
 	prometheus.BuildFQName(namespace, "", "reboot_queue_items"),
 	"The number of reboot queue entries remaining per status.",
 	[]string{"status"},
+	nil,
+)
+
+var rebootQueueRunning = prometheus.NewDesc(
+	prometheus.BuildFQName(namespace, "", "reboot_queue_running"),
+	"1 if reboot queue is enabled and the queue is not empty.",
+	nil,
 	nil,
 )
 


### PR DESCRIPTION
This PR adds `reboot_queue_enabled` and `reboot_queue_running` metrices.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>