### PR TITLE
add setup-go in release-cke-image

### DIFF
--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -77,6 +77,9 @@ jobs:
     needs: release-cke-image
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
       - name: Download sonobuoy test
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
There are no steps `actions/setup-go`, so it uses default Go(1.18) and it is incompatible with current CKE.