### PR TITLE
change CKE to proceed rebooting immediately after draining of node  is completed

### DIFF
--- a/op/reboot.go
+++ b/op/reboot.go
@@ -568,6 +568,13 @@ func drainBackOff(ctx context.Context, inf cke.Infrastructure, entry *cke.Reboot
 		"name":      entry.Node,
 		log.FnError: err,
 	})
+	etcdEntry, err := inf.Storage().GetRebootsEntry(ctx, entry.Index)
+	if err != nil {
+		return err
+	}
+	if etcdEntry.Status == cke.RebootStatusCancelled {
+		return nil
+	}
 	entry.Status = cke.RebootStatusQueued
 	entry.LastTransitionTime = time.Now().Truncate(time.Second).UTC()
 	entry.DrainBackOffCount++

--- a/op/reboot_decide.go
+++ b/op/reboot_decide.go
@@ -196,12 +196,10 @@ func ChooseDrainedNodes(c *cke.Cluster, apiServers map[string]bool, rqEntries []
 			return nil
 		}
 	}
-	if len(workerInProgress) >= maxConcurrentReboots {
-		return nil
-	} else if len(workerInProgress)+len(workerDrainable) <= maxConcurrentReboots {
-		return workerDrainable
+	if len(workerInProgress) < maxConcurrentReboots && len(workerDrainable) > 0 {
+		return workerDrainable[:1]
 	} else {
-		return workerDrainable[:maxConcurrentReboots-len(workerInProgress)]
+		return nil
 	}
 }
 

--- a/server/strategy.go
+++ b/server/strategy.go
@@ -885,21 +885,19 @@ func rebootOps(c *cke.Cluster, constraints *cke.Constraints, rebootArgs DecideOp
 	}
 
 	if len(rebootArgs.RebootCancelled) > 0 {
-		phaseReboot = true
 		ops = append(ops, op.RebootCancelOp(rebootArgs.RebootCancelled))
-		return ops, phaseReboot
 	}
 	if len(rebootArgs.RebootDequeued) > 0 {
-		phaseReboot = true
 		ops = append(ops, op.RebootDequeueOp(rebootArgs.RebootDequeued))
-		return ops, phaseReboot
 	}
+	if len(ops) > 0 {
+		return ops, true
+	}
+
 	if len(rebootArgs.DrainCompleted) > 0 {
-		phaseReboot = true
 		ops = append(ops, op.RebootRebootOp(nf.HealthyAPIServer(), rebootArgs.DrainCompleted, &c.Reboot))
 	}
 	if len(rebootArgs.NewlyDrained) > 0 {
-		phaseReboot = true
 		sshCheckNodes := make([]*cke.Node, 0, len(nf.cluster.Nodes))
 		for _, node := range nf.cluster.Nodes {
 			if !rebootProcessing(rebootArgs.RQEntries, node.Address) {
@@ -913,7 +911,6 @@ func rebootOps(c *cke.Cluster, constraints *cke.Constraints, rebootArgs DecideOp
 		}
 	}
 	if len(rebootArgs.DrainTimedout) > 0 {
-		phaseReboot = true
 		ops = append(ops, op.RebootDrainTimeoutOp(rebootArgs.DrainTimedout))
 	}
 	if len(ops) > 0 {

--- a/server/strategy.go
+++ b/server/strategy.go
@@ -889,6 +889,10 @@ func rebootOps(c *cke.Cluster, constraints *cke.Constraints, rebootArgs DecideOp
 		ops = append(ops, op.RebootCancelOp(rebootArgs.RebootCancelled))
 		return ops, phaseReboot
 	}
+	if len(rebootArgs.DrainCompleted) > 0 {
+		phaseReboot = true
+		ops = append(ops, op.RebootRebootOp(nf.HealthyAPIServer(), rebootArgs.DrainCompleted, &c.Reboot))
+	}
 	if len(rebootArgs.NewlyDrained) > 0 {
 		phaseReboot = true
 		sshCheckNodes := make([]*cke.Node, 0, len(nf.cluster.Nodes))
@@ -902,10 +906,6 @@ func rebootOps(c *cke.Cluster, constraints *cke.Constraints, rebootArgs DecideOp
 		} else {
 			ops = append(ops, op.RebootDrainStartOp(nf.HealthyAPIServer(), rebootArgs.NewlyDrained, &c.Reboot))
 		}
-	}
-	if len(rebootArgs.DrainCompleted) > 0 {
-		phaseReboot = true
-		ops = append(ops, op.RebootRebootOp(nf.HealthyAPIServer(), rebootArgs.DrainCompleted, &c.Reboot))
 	}
 	if len(rebootArgs.DrainTimedout) > 0 {
 		phaseReboot = true

--- a/server/strategy.go
+++ b/server/strategy.go
@@ -889,6 +889,11 @@ func rebootOps(c *cke.Cluster, constraints *cke.Constraints, rebootArgs DecideOp
 		ops = append(ops, op.RebootCancelOp(rebootArgs.RebootCancelled))
 		return ops, phaseReboot
 	}
+	if len(rebootArgs.RebootDequeued) > 0 {
+		phaseReboot = true
+		ops = append(ops, op.RebootDequeueOp(rebootArgs.RebootDequeued))
+		return ops, phaseReboot
+	}
 	if len(rebootArgs.DrainCompleted) > 0 {
 		phaseReboot = true
 		ops = append(ops, op.RebootRebootOp(nf.HealthyAPIServer(), rebootArgs.DrainCompleted, &c.Reboot))
@@ -910,10 +915,6 @@ func rebootOps(c *cke.Cluster, constraints *cke.Constraints, rebootArgs DecideOp
 	if len(rebootArgs.DrainTimedout) > 0 {
 		phaseReboot = true
 		ops = append(ops, op.RebootDrainTimeoutOp(rebootArgs.DrainTimedout))
-	}
-	if len(rebootArgs.RebootDequeued) > 0 {
-		phaseReboot = true
-		ops = append(ops, op.RebootDequeueOp(rebootArgs.RebootDequeued))
 	}
 	if len(ops) > 0 {
 		phaseReboot = true


### PR DESCRIPTION
In the current CKE, even if `max_concurrent_reboots` is larger than 1, draining is conducted by serial and rebooting is conducted after draining of all drainable node is finished.
This behavior cause long down time of first drained node.

This PR changes the CKE to move rebooting immediately after draining of each node is finished.
In addition, this PR fixes behavior of canceled reboot queue entry.
