### PR TITLE
Remove Unhealthy/Unreachable taint

### DIFF
--- a/docs/sabakan-integration.md
+++ b/docs/sabakan-integration.md
@@ -164,7 +164,6 @@ CKE generates cluster configuration with the following conditions.
 * The servers which have the same role should be distributed evenly over the racks.
 * Newer machines should be preferred than old ones.
 * Healthy machines should be preferred than non-healthy ones.
-* Unhealthy and unreachable machines in the cluster should be [tainted][taint] with `NoSchedule`.
 * Retiring and retired machines should be [tainted][taint] with `NoExecute`.
 * Retired machines should be removed if the machines are kept retired for a while.
 * Rebooting machines should not be removed from the cluster nor be tainted.
@@ -305,8 +304,6 @@ The taint key is `cke.cybozu.com/state`.
 
 | Machine state | Taint value   | Taint effect |
 | ------------- | ------------- | ------------ |
-| Unhealthy     | `unhealthy`   | `NoSchedule` |
-| Unreachable   | `unreachable` | `NoSchedule` |
 | Retiring      | `retiring`    | `NoExecute`  |
 | Retired       | `retired`     | `NoExecute`  |
 

--- a/sabakan/generator.go
+++ b/sabakan/generator.go
@@ -63,18 +63,6 @@ func MachineToNode(m *Machine, tmpl *cke.Node) *cke.Node {
 
 	n.Taints = append(n.Taints, tmpl.Taints...)
 	switch m.Status.State {
-	case StateUnhealthy:
-		n.Taints = append(n.Taints, corev1.Taint{
-			Key:    "cke.cybozu.com/state",
-			Value:  "unhealthy",
-			Effect: corev1.TaintEffectNoSchedule,
-		})
-	case StateUnreachable:
-		n.Taints = append(n.Taints, corev1.Taint{
-			Key:    "cke.cybozu.com/state",
-			Value:  "unreachable",
-			Effect: corev1.TaintEffectNoSchedule,
-		})
 	case StateRetiring:
 		n.Taints = append(n.Taints, corev1.Taint{
 			Key:    "cke.cybozu.com/state",
@@ -699,14 +687,6 @@ func hasValidTaint(n *cke.Node, m *Machine) bool {
 	}
 
 	switch m.Status.State {
-	case StateUnhealthy:
-		if ckeTaint.Value != "unhealthy" || ckeTaint.Effect != corev1.TaintEffectNoSchedule {
-			return false
-		}
-	case StateUnreachable:
-		if ckeTaint.Value != "unreachable" || ckeTaint.Effect != corev1.TaintEffectNoSchedule {
-			return false
-		}
 	case StateRetiring:
 		if ckeTaint.Value != "retiring" || ckeTaint.Effect != corev1.TaintEffectNoExecute {
 			return false

--- a/sabakan/generator_test.go
+++ b/sabakan/generator_test.go
@@ -85,9 +85,6 @@ func testMachineToNode(t *testing.T) {
 	if !containsTaint(res1.Taints, corev1.Taint{Key: "foo", Effect: corev1.TaintEffectNoSchedule}) {
 		t.Error(`res1.Taints do not have corev1.Taint{Key"foo", Effect: corev1.TaintEffectNoSchedule}, actual:`, res1.Taints)
 	}
-	if !containsTaint(res1.Taints, corev1.Taint{Key: domain + "/state", Value: "unhealthy", Effect: corev1.TaintEffectNoSchedule}) {
-		t.Error(`res1.Taints do not have corev1.Taint{Key: "cke.cybozu.com/state", Value: "unhealthy", Effect: "NoSchedule"}, actual:`, res1.Taints)
-	}
 
 	machine.Status.State = StateRetiring
 	res2 := MachineToNode(machine, node)
@@ -533,7 +530,6 @@ func testUpdate(t *testing.T) {
 		k8sUntaintedNodes = append(k8sUntaintedNodes, n)
 		n.Spec.Taints = []corev1.Taint{
 			{Key: corev1.TaintNodeNotReady, Effect: corev1.TaintEffectNoSchedule},
-			{Key: "cke.cybozu.com/state", Value: "unhealthy", Effect: corev1.TaintEffectNoSchedule},
 			{Key: op.CKETaintMaster, Effect: corev1.TaintEffectNoSchedule},
 			{Key: "foo.cybozu.com/transient", Effect: corev1.TaintEffectNoSchedule},
 		}


### PR DESCRIPTION
This PR removes the following taints, which are used by the Sabakan integration.

- `cke.cybozu.com/state: unhealthy` (NoSchedule)
- `cke.cybozu.com/state: unreachable` (NoSchedule)


## Reasons for removing taint

### `cke.cybozu.com/state: unhealthy`

The taint must not be set if the machine failure is minor enough to allow the process to run.

### `cke.cybozu.com/state: unreachable`

When a node cannot communicate, the `node.kubernetes.io/unreachable` (NoExecute) taint is added.
So `cke.cybozu.com/state: unreachable` taint does not work well.