### PR TITLE
Add rw option to extra volumes

### DIFF
--- a/container.go
+++ b/container.go
@@ -183,6 +183,8 @@ func (c docker) RunSystem(name string, img Image, opts []string, params, extra S
 		var opts []string
 		if m.ReadOnly {
 			opts = append(opts, "ro")
+		} else {
+			opts = append(opts, "rw")
 		}
 		if len(m.Propagation) > 0 {
 			opts = append(opts, m.Propagation.String())

--- a/localproxy/infrastructure.go
+++ b/localproxy/infrastructure.go
@@ -233,6 +233,8 @@ func (l localDocker) RunSystem(name string, img cke.Image, opts []string, params
 		var opts []string
 		if m.ReadOnly {
 			opts = append(opts, "ro")
+		} else {
+			opts = append(opts, "rw")
 		}
 		if len(m.Propagation) > 0 {
 			opts = append(opts, m.Propagation.String())


### PR DESCRIPTION
From Docker 25.0.0 or 24.0.5, the parsing volume option has been strict.
https://github.com/docker/cli/pull/4415

With the current implementation, the following error occurs when `extra_binds` is used.
So, this PR fixes it so that parsing errors do not happen.

```
root@cke--82-174134-0:~/go/src/github.com/cybozu-go/cke/sonobuoy# ./bin/ckecli --config=./cke.config history | head -n 30
{
    "id": "54",
    "status": "cancelled",
    "operation": "kubelet-bootstrap",
    "command": {
        "name": "run-container",
        "target": "kubelet"
    },
    "targets": [
        "10.174.0.111",
        "10.174.0.112",
        "10.174.0.113"
    ],
    "info": "",
    "error": "Process exited with status 125, cmdline: docker run --log-driver=journald -d --name=kubelet --read-only --network=host --uts=host --pid=host --privileged --tmpfs=/tmp --volume=/etc/machine-id:/etc/machine-id:ro --volume=/etc/os-release:/etc/os-release:ro --volume=/etc/kubernetes:/etc/kubernetes:ro --volume=/var/lib/kubelet:/var/lib/kubelet:rshared --volume=/var/lib/docker:/var/lib/docker: --volume=/opt/volume/bin:/opt/volume/bin:shared --volume=/var/log/pods:/var/log/pods: --volume=/var/log/containers:/var/log/containers: --volume=/run:/run: --volume=/sys:/sys:ro --volume=/dev:/dev: --volume=/opt/cni/bin:/opt/cni/bin:ro --volume=/etc/cni/net.d:/etc/cni/net.d:ro --volume=/var/lib/cni:/var/lib/cni: --label-file=/tmp/8239f4931490879aa5201a804c0b7141 ghcr.io/cybozu/kubernetes:1.27.10.1 kubelet --config=/etc/kubernetes/kubelet/config.yml --kubeconfig=/etc/kubernetes/kubelet/kubeconfig --hostname-override=10.174.0.113 --container-runtime-endpoint=/run/containerd/containerd.sock, stdout: , stderr: docker: invalid spec: /var/log/pods:/var/log/pods:: empty section between colons.\nSee 'docker run --help'.\n",
    "start-at": "2024-03-21T09:30:36.541202703Z",
    "end-at": "2024-03-21T09:30:37.467904031Z"
}
```