### PR TITLE
cke-tools: Update CNI plugins to v1.4.1

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,4 +1,4 @@
-CNI_PLUGIN_VERSION = 1.3.0
+CNI_PLUGIN_VERSION = 1.4.1
 TAG = ghcr.io/cybozu-go/cke-tools:dev
 GOBUILD = CGO_ENABLED=0 go build -ldflags="-w -s"
 


### PR DESCRIPTION
part of https://github.com/cybozu-go/cke/issues/706

This PR updates CNI plugins to v1.4.1.

ref: https://github.com/containernetworking/plugins/releases/tag/v1.4.1