### PR TITLE
Update actions/setup-go to v5

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - name: Check auto-generated files
@@ -32,7 +32,7 @@ jobs:
       CLUSTER: "cke-cluster.yml"
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - uses: google-github-actions/auth@v2
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - uses: google-github-actions/auth@v2

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - uses: google-github-actions/auth@v2
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - run: make install GOBIN=$(pwd)/docker
@@ -77,7 +77,7 @@ jobs:
     needs: release-cke-image
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - name: Download sonobuoy test

--- a/.github/workflows/release-tools.yaml
+++ b/.github/workflows/release-tools.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - name: Build CKE tools

--- a/.github/workflows/sonobuoy.yaml
+++ b/.github/workflows/sonobuoy.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - uses: google-github-actions/auth@v2


### PR DESCRIPTION
Other dependencies have been updated in https://github.com/cybozu-go/cke/pull/719.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>