### PR TITLE
Fix not to change status of repair-queue's finished entry

### DIFF
--- a/server/strategy.go
+++ b/server/strategy.go
@@ -727,6 +727,9 @@ func repairOps(c *cke.Cluster, cs *cke.ClusterStatus, constraints *cke.Constrain
 			ops = append(ops, op.RepairDequeueOp(entry))
 			continue
 		}
+		if entry.HasFinished() {
+			continue
+		}
 		if rqs.RepairCompleted[entry.Address] {
 			ops = append(ops, op.RepairFinishOp(entry, true))
 			continue


### PR DESCRIPTION
This commit is for the following situation:
* there is a finished entry in the repair queue, especially failed one
* a new entry with the same target address is queued
* the target machine becomes healthy

The results of health check are indexed by the target machine's address,
not by the entry ID.
Though health check is not executed for a finished entry, check for
another entry with the same target address can change the status of
the failed entry into "succeeded."
This commit prevents it.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>