### PR TITLE
perform eviction dry-run during node reboot feature

### DIFF
--- a/mtest/assets_test.go
+++ b/mtest/assets_test.go
@@ -14,6 +14,9 @@ var rebootJobCompletedYAML []byte
 //go:embed reboot-job-running.yaml
 var rebootJobRunningYAML []byte
 
+//go:embed reboot-eviction-dry-run.yaml
+var rebootEvictionDryRunYAML []byte
+
 //go:embed reboot-slow-eviction-deployment.yaml
 var rebootSlowEvictionDeploymentYAML []byte
 

--- a/mtest/reboot-eviction-dry-run.yaml
+++ b/mtest/reboot-eviction-dry-run.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: reboot-test
+  name: 1-not-evictable
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      reboot-app: 1-not-evictable
+  template:
+    metadata:
+      labels:
+        reboot-app: 1-not-evictable
+    spec:
+      containers:
+        - name: httpd
+          image: ghcr.io/cybozu/testhttpd:0
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  namespace: reboot-test
+  name: 1-not-evictable
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      reboot-app: 1-not-evictable
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: reboot-test
+  name: 0-evictable
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      reboot-app: 0-evictable
+  template:
+    metadata:
+      labels:
+        reboot-app: 0-evictable
+    spec:
+      containers:
+        - name: httpd
+          image: ghcr.io/cybozu/testhttpd:0
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                reboot-app: 1-not-evictable
+            topologyKey: kubernetes.io/hostname
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: reboot-test
+  name: 2-evictable
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      reboot-app: 2-evictable
+  template:
+    metadata:
+      labels:
+        reboot-app: 2-evictable
+    spec:
+      containers:
+        - name: httpd
+          image: ghcr.io/cybozu/testhttpd:0
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                reboot-app: 1-not-evictable
+            topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
part of https://github.com/cybozu-go/cke/issues/735

- perform eviction dry-run before actual eviction
- add more logs related to eviction

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>