### PR TITLE
use docker compose v2 in appropriate way

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -115,13 +115,13 @@ jobs:
         working-directory: ./example
       - name: Set up compose test
         run: |
-          docker-compose build
-          docker-compose up -d
+          docker compose build
+          docker compose up -d
           ./wait-up.sh
         working-directory: ./example
       - name: Run compose test
-        run: docker-compose run setup /opt/setup/test.sh
+        run: docker compose run setup /opt/setup/test.sh
         working-directory: ./example
       - name: Clean up
-        run: docker-compose down
+        run: docker compose down
         working-directory: ./example

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -80,7 +80,7 @@ GitHub Actions also creates a GitHub release automatically after running [sonobu
 So, **DO NOT MANUALLY CREATE GITHUB RELEASES**.  The test results will be attached to the GitHub
 release that can be submitted to [cncf/k8s-conformance](https://github.com/cncf/k8s-conformance).
 
-## Maintain docker-compose
+## Maintain docker compose
 
 After new CKE released, update cke image on docker-compose.yml.
 

--- a/example/README.md
+++ b/example/README.md
@@ -1,4 +1,4 @@
-# Demonstration with docker-compose and Vagrant
+# Demonstration with `docker compose` and Vagrant
 
 ## Overview
 
@@ -19,14 +19,14 @@ Use this only for testing and development.
 
 ## Setup CKE
 
-Follow the steps to setup CKE with docker-compose.
+Follow the steps to setup CKE with `docker compose`.
 
 ```console
 $ git clone https://github.com/cybozu-go/cke.git
 $ cd ./cke/example/
 $ mkdir bin
 $ mkdir etcd-data
-$ docker-compose up -d
+$ docker compose up -d
 ```
 
 `bin` is the directory where the cli tools are installed.

--- a/sonobuoy/Makefile
+++ b/sonobuoy/Makefile
@@ -44,7 +44,7 @@ bin/sonobuoy:
 .PHONY: run
 run: bin/cke bin/ckecli bin/kubectl
 	mkdir -p etcd-data
-	/usr/local/bin/docker-compose up -d
+	docker compose up -d
 	./wait-up.sh
 	$(CKECLI) vault ssh-privkey /home/cybozu/gcp_rsa
 	$(CKECLI) constraints set minimum-workers 2
@@ -66,13 +66,14 @@ sonobuoy: bin/sonobuoy
 
 .PHONY: clean
 clean:
-	-/usr/local/bin/docker-compose down
+	-docker compose down
 	$(SUDO) rm -rf bin etcd-data
 
 .PHONY: setup
 setup:
-	$(SUDO) $(CURL) -o /usr/local/bin/docker-compose $(DOCKER_COMPOSE_URL)
-	$(SUDO) chmod +x /usr/local/bin/docker-compose
+	$(SUDO) mkdir -p /usr/local/lib/docker/cli-plugins
+	$(SUDO) $(CURL) -o /usr/local/lib/docker/cli-plugins/docker-compose $(DOCKER_COMPOSE_URL)
+	$(SUDO) chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 
 $(CT):
 	mkdir -p bin

--- a/sonobuoy/README.md
+++ b/sonobuoy/README.md
@@ -35,7 +35,7 @@ SERVICE_ACCOUNT=neco-test@neco-test.iam.gserviceaccount.com
 ## Run Sonobuoy
 
 Run `bin/run-sonobuoy.sh`.
-This script creates 4 GCE VMs, runs CKE on VM #0 by using `docker-compose`, runs Kubernetes deployed by CKE on VM #1~#3, and runs [Sonobuoy][] on VM #0.
+This script creates 4 GCE VMs, runs CKE on VM #0 by using `docker compose`, runs Kubernetes deployed by CKE on VM #1~#3, and runs [Sonobuoy][] on VM #0.
 
 ```console
 $ env INSTANCE_NAME=sonobuoy-vm GITHUB_SHA=vX.Y.Z GITHUB_REPOSITORY=cybozu-go/cke ./bin/run-sonobuoy.sh


### PR DESCRIPTION
GitHub Actions' ubuntu runner no longer has `docker-compose` command.
Use `docker compose` subcommand.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>