### PR TITLE
Revive unreachable taint

### DIFF
--- a/docs/sabakan-integration.md
+++ b/docs/sabakan-integration.md
@@ -164,6 +164,7 @@ CKE generates cluster configuration with the following conditions.
 * The servers which have the same role should be distributed evenly over the racks.
 * Newer machines should be preferred than old ones.
 * Healthy machines should be preferred than non-healthy ones.
+* Unreachable machines in the cluster should be [tainted][taint] with `NoSchedule`.
 * Retiring and retired machines should be [tainted][taint] with `NoExecute`.
 * Retired machines should be removed if the machines are kept retired for a while.
 * Rebooting machines should not be removed from the cluster nor be tainted.
@@ -304,6 +305,7 @@ The taint key is `cke.cybozu.com/state`.
 
 | Machine state | Taint value   | Taint effect |
 | ------------- | ------------- | ------------ |
+| Unreachable   | `unreachable` | `NoSchedule` |
 | Retiring      | `retiring`    | `NoExecute`  |
 | Retired       | `retired`     | `NoExecute`  |
 
@@ -320,7 +322,7 @@ Other Machine fields are also translated to labels as follows.
 `node-role.kubernetes.io/<role>` are used by `kubectl` to display the node's role.
 
 | Field               | Label key                                | Value                                               |
-|---------------------|------------------------------------------|-----------------------------------------------------|
+| ------------------- | ---------------------------------------- | --------------------------------------------------- |
 | `spec.rack`         | `cke.cybozu.com/rack`                    | `spec.rack` converted to string.                    |
 | `spec.rack`         | `topology.kubernetes.io/zone`            | `spec.rack` converted to string with prefix `rack`. |
 | `spec.rack`         | `failure-domain.beta.kubernetes.io/zone` | `spec.rack` converted to string with prefix `rack`. |

--- a/sabakan/generator.go
+++ b/sabakan/generator.go
@@ -63,6 +63,12 @@ func MachineToNode(m *Machine, tmpl *cke.Node) *cke.Node {
 
 	n.Taints = append(n.Taints, tmpl.Taints...)
 	switch m.Status.State {
+	case StateUnreachable:
+		n.Taints = append(n.Taints, corev1.Taint{
+			Key:    "cke.cybozu.com/state",
+			Value:  "unreachable",
+			Effect: corev1.TaintEffectNoSchedule,
+		})
 	case StateRetiring:
 		n.Taints = append(n.Taints, corev1.Taint{
 			Key:    "cke.cybozu.com/state",
@@ -687,6 +693,10 @@ func hasValidTaint(n *cke.Node, m *Machine) bool {
 	}
 
 	switch m.Status.State {
+	case StateUnreachable:
+		if ckeTaint.Value != "unreachable" || ckeTaint.Effect != corev1.TaintEffectNoSchedule {
+			return false
+		}
 	case StateRetiring:
 		if ckeTaint.Value != "retiring" || ckeTaint.Effect != corev1.TaintEffectNoExecute {
 			return false

--- a/sabakan/generator_test.go
+++ b/sabakan/generator_test.go
@@ -86,15 +86,20 @@ func testMachineToNode(t *testing.T) {
 		t.Error(`res1.Taints do not have corev1.Taint{Key"foo", Effect: corev1.TaintEffectNoSchedule}, actual:`, res1.Taints)
 	}
 
-	machine.Status.State = StateRetiring
+	machine.Status.State = StateUnreachable
 	res2 := MachineToNode(machine, node)
-	if !containsTaint(res2.Taints, corev1.Taint{Key: domain + "/state", Value: "retiring", Effect: corev1.TaintEffectNoExecute}) {
-		t.Error(`res2.Taints do not have corev1.Taint{Key: "cke.cybozu.com/state", Value: "retiring", Effect: "NoExecute"}, actual:`, res2.Taints)
+	if !containsTaint(res2.Taints, corev1.Taint{Key: domain + "/state", Value: "unreachable", Effect: corev1.TaintEffectNoSchedule}) {
+		t.Error(`res2.Taints do not have corev1.Taint{Key: "cke.cybozu.com/state", Value: "unreachable", Effect: "NoSchedule"}, actual:`, res2.Taints)
+	}
+	machine.Status.State = StateRetiring
+	res3 := MachineToNode(machine, node)
+	if !containsTaint(res3.Taints, corev1.Taint{Key: domain + "/state", Value: "retiring", Effect: corev1.TaintEffectNoExecute}) {
+		t.Error(`res3.Taints do not have corev1.Taint{Key: "cke.cybozu.com/state", Value: "retiring", Effect: "NoExecute"}, actual:`, res3.Taints)
 	}
 	machine.Status.State = StateRetired
-	res3 := MachineToNode(machine, node)
-	if !containsTaint(res3.Taints, corev1.Taint{Key: domain + "/state", Value: "retired", Effect: corev1.TaintEffectNoExecute}) {
-		t.Error(`res3.Taints do not have corev1.Taint{Key: "cke.cybozu.com/state", Value: "retired", Effect: "NoExecute"}, actual:`, res3.Taints)
+	res4 := MachineToNode(machine, node)
+	if !containsTaint(res4.Taints, corev1.Taint{Key: domain + "/state", Value: "retired", Effect: corev1.TaintEffectNoExecute}) {
+		t.Error(`res4.Taints do not have corev1.Taint{Key: "cke.cybozu.com/state", Value: "retired", Effect: "NoExecute"}, actual:`, res4.Taints)
 	}
 }
 


### PR DESCRIPTION
This PR adds (revives) the following taint.

- `cke.cybozu.com/state: unreachable` (NoSchedule)

This taint was removed in https://github.com/cybozu-go/cke/pull/710. However, since `node.kubernetes.io/unreachable` taint alone was not sufficient for our operations, so I'll revives the taint.