### PR TITLE
fix sabakan integration to handle role that is not exist in sabakan

### DIFF
--- a/sabakan/generator.go
+++ b/sabakan/generator.go
@@ -2,6 +2,7 @@ package sabakan
 
 import (
 	"errors"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -178,12 +179,25 @@ func (g *Generator) clearIntermediateData() {
 	g.countWorkerByRole = make(map[string]int)
 }
 
+func (g *Generator) countSabakanMachineByRole(role string) int {
+	count := 0
+	for _, m := range g.machineMap {
+		if m.Spec.Role == role {
+			count++
+		}
+	}
+	return count
+}
+
 func (g *Generator) chooseWorkerTmpl() nodeTemplate {
 	count := g.countWorkerByRole
 
-	least := float64(count[g.workerTmpls[0].Role]) / g.workerTmpls[0].Weight
+	least := math.MaxFloat64
 	leastIndex := 0
 	for i, tmpl := range g.workerTmpls {
+		if g.countSabakanMachineByRole(tmpl.Role) == 0 {
+			continue
+		}
 		w := float64(count[tmpl.Role]) / tmpl.Weight
 		if w < least {
 			least = w


### PR DESCRIPTION
Before this PR, if roles that do not exist in sabakan is written in cke-template,`chooseWorkerTmpl()` always return such role bacause count of it is always zero.
In such a situation, increseWorker does not work.
In this PR, I change `chooseWorkerTmpl()` to skip that role if it has no sabakan machines.