### PR TITLE
Supress dns log

### DIFF
--- a/bin/env
+++ b/bin/env
@@ -1,5 +1,5 @@
 PROJECT=neco-test
-ZONE=asia-northeast2-c
+ZONE=asia-northeast1-c
 SERVICE_ACCOUNT=neco-test@neco-test.iam.gserviceaccount.com
 MACHINE_TYPE=c2-standard-30
 DISK_TYPE=pd-ssd

--- a/op/clusterdns/clusterdns.go
+++ b/op/clusterdns/clusterdns.go
@@ -17,7 +17,9 @@ var clusterDNSTemplate = template.Must(template.New("").Parse(`.:1053 {
     errors
     health
     ready
-    log
+    log . {combined} {
+        class denial error
+    }
     kubernetes {{ .Domain }} in-addr.arpa ip6.arpa {
       pods verified
 {{- if .Upstreams }}

--- a/op/nodedns/nodedns.go
+++ b/op/nodedns/nodedns.go
@@ -28,7 +28,7 @@ server:
   logfile: ""
   use-syslog: no
   log-time-ascii: yes
-  log-queries: yes
+  log-queries: no
   log-replies: yes
   log-local-actions: yes
   log-servfail: yes


### PR DESCRIPTION
This PR supress DNS query logs for cluster-dns and node-dns.

cf.
- https://coredns.io/plugins/log/
- https://nlnetlabs.nl/documentation/unbound/unbound.conf/