### PR TITLE
Bump version to 1.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project employs a versioning scheme described in [RELEASE.md](RELEASE.md#ve
 
 ## [Unreleased]
 
+## [1.32.0]
+
+- No changes from 1.32.0-rc.1
+
 ## [1.32.0-rc.1]
 
 ### Changed
@@ -36,5 +40,6 @@ This project employs a versioning scheme described in [RELEASE.md](RELEASE.md#ve
 - See [release-1.13/CHANGELOG.md](https://github.com/cybozu-go/cke/blob/release-1.13/CHANGELOG.md) for changes in CKE 1.13.
 - See [release-1.12/CHANGELOG.md](https://github.com/cybozu-go/cke/blob/release-1.12/CHANGELOG.md) for changes in CKE 1.12.
 
-[Unreleased]: https://github.com/cybozu-go/cke/compare/v1.32.0-rc.1...HEAD
+[Unreleased]: https://github.com/cybozu-go/cke/compare/v1.32.0...HEAD
+[1.32.0]: https://github.com/cybozu-go/cke/compare/v1.32.0-rc.1...v1.32.0
 [1.32.0-rc.1]: https://github.com/cybozu-go/cke/compare/v1.31.1...v1.32.0-rc.1

--- a/version.go
+++ b/version.go
@@ -1,7 +1,7 @@
 package cke
 
 // Version represents current cke version
-const Version = "1.32.0-rc.1"
+const Version = "1.32.0"
 
 // ConfigVersion represents the current configuration scheme
 // of how CKE constructs its Kubernetes cluster.


### PR DESCRIPTION
part of https://github.com/cybozu-go/cke/issues/799

The sonobuoy test was passed.
https://github.com/cybozu-go/cke/actions/runs/15962240397