### PR TITLE
Add machine serial to repair queue entries

### DIFF
--- a/docs/ckecli.md
+++ b/docs/ckecli.md
@@ -52,7 +52,7 @@ $ ckecli [--config FILE] <subcommand> args...
 - [`ckecli repair-queue`](#ckecli-repair-queue)
   - [`ckecli repair-queue enable|disable`](#ckecli-repair-queue-enabledisable)
   - [`ckecli repair-queue is-enabled`](#ckecli-repair-queue-is-enabled)
-  - [`ckecli repair-queue add OPERATION MACHINE_TYPE ADDRESS`](#ckecli-repair-queue-add-operation-machine_type-address)
+  - [`ckecli repair-queue add OPERATION MACHINE_TYPE ADDRESS [SERIAL]`](#ckecli-repair-queue-add-operation-machine_type-address-serial)
   - [`ckecli repair-queue list`](#ckecli-repair-queue-list)
   - [`ckecli repair-queue delete INDEX`](#ckecli-repair-queue-delete-index)
   - [`ckecli repair-queue delete-finished`](#ckecli-repair-queue-delete-finished)
@@ -340,11 +340,12 @@ Enable/Disable processing repair queue entries.
 Show repair queue is enabled or disabled.
 This displays `true` or `false`.
 
-### `ckecli repair-queue add OPERATION MACHINE_TYPE ADDRESS`
+### `ckecli repair-queue add OPERATION MACHINE_TYPE ADDRESS [SERIAL]`
 
 Append a repair request to the repair queue.
 The repair target is a machine with an IP address `ADDRESS` and a machine type `MACHINE_TYPE`.
 The machine should be processed with an operation `OPERATION`.
+Optionally, you can specify the machine's serial number `SERIAL` as the fourth argument.
 
 ### `ckecli repair-queue list`
 

--- a/docs/repair.md
+++ b/docs/repair.md
@@ -13,11 +13,11 @@ First see the [description of the reboot functionality](reboot.md#description).
 The behavior of the repair functionality is almost the same with the reboot.
 A significant difference is that the repair functionality issues a series of repair commands instead of one reboot command.
 
-An administrator can request CKE to repair a machine via `ckecli repair-queue add OPERATION MACHINE_TYPE ADDRESS`.
+An administrator can request CKE to repair a machine via `ckecli repair-queue add OPERATION MACHINE_TYPE ADDRESS [SERIAL]`.
 The request is appended to the repair queue.
 Each request entry corresponds to a machine.
 
-The command `ckecli repair-queue add` takes extra two arguments in addition to the IP address of the target machine; the operation name and the type of the target machine.
+The command `ckecli repair-queue add` takes extra two required arguments and one optional argument: the operation name, the type of the target machine, the IP address of the target machine, and optionally the serial number of the machine.
 
 CKE watches the repair queue and handles the repair requests.
 CKE processes a repair request in the following manner:

--- a/mtest/repair_test.go
+++ b/mtest/repair_test.go
@@ -97,7 +97,7 @@ func testRepairOperations() {
 		repairQueueAdd := func(address string) {
 			execSafeAt(host1, "docker", "exec", "cke", "find", "/tmp", "-maxdepth", "1", "-name", "mtest-repair-*", "-delete")
 			execSafeAt(host2, "docker", "exec", "cke", "find", "/tmp", "-maxdepth", "1", "-name", "mtest-repair-*", "-delete")
-			_, stderr, err := ckecli("repair-queue", "add", "op1", "type1", address)
+			_, stderr, err := ckecli("repair-queue", "add", "op1", "type1", address, "SN1234")
 			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "stderr: %s", stderr)
 			currentWriteIndex++
 		}

--- a/pkg/ckecli/cmd/repair_queue_add.go
+++ b/pkg/ckecli/cmd/repair_queue_add.go
@@ -9,20 +9,25 @@ import (
 )
 
 var repairQueueAddCmd = &cobra.Command{
-	Use:   "add OPERATION MACHINE_TYPE ADDRESS",
+	Use:   "add OPERATION MACHINE_TYPE ADDRESS [SERIAL]",
 	Short: "append a repair request to the repair queue",
 	Long: `Append a repair request to the repair queue.
 
 The repair target is a machine with an IP address ADDRESS and a machine type MACHINE_TYPE.
-The machine should be processed with an operation OPERATION.`,
-	Args: cobra.ExactArgs(3),
+The machine should be processed with an operation OPERATION.
+Optionally, you can specify the machine's serial number as the fourth argument.`,
+	Args: cobra.RangeArgs(3, 4),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		operation := args[0]
 		machineType := args[1]
 		address := args[2]
+		serial := ""
+		if len(args) > 3 {
+			serial = args[3]
+		}
 
 		well.Go(func(ctx context.Context) error {
-			entry := cke.NewRepairQueueEntry(operation, machineType, address)
+			entry := cke.NewRepairQueueEntry(operation, machineType, address, serial)
 			cluster, err := storage.GetCluster(ctx)
 			if err != nil {
 				return err

--- a/repair.go
+++ b/repair.go
@@ -32,6 +32,7 @@ type RepairQueueEntry struct {
 	Index              int64            `json:"index,string"`
 	Address            string           `json:"address"`
 	Nodename           string           `json:"nodename"`
+	Serial             string           `json:"serial,omitempty"`
 	MachineType        string           `json:"machine_type"`
 	Operation          string           `json:"operation"`
 	Status             RepairStatus     `json:"status"`
@@ -49,11 +50,12 @@ var (
 	ErrRepairStepOutOfRange    = errors.New("repair step of repair queue entry is out of range")
 )
 
-func NewRepairQueueEntry(operation, machineType, address string) *RepairQueueEntry {
+func NewRepairQueueEntry(operation, machineType, address, serial string) *RepairQueueEntry {
 	return &RepairQueueEntry{
 		Operation:   operation,
 		MachineType: machineType,
 		Address:     address,
+		Serial:      serial,
 		Status:      RepairStatusQueued,
 		StepStatus:  RepairStepStatusWaiting,
 	}

--- a/repair_test.go
+++ b/repair_test.go
@@ -53,7 +53,7 @@ func TestRepairQueueEntry(t *testing.T) {
 	}
 
 	// for in-cluster machine
-	entry := NewRepairQueueEntry("unreachable", "type2", "1.1.1.1")
+	entry := NewRepairQueueEntry("unreachable", "type2", "1.1.1.1", "")
 	entry.FillNodename(cluster)
 	if entry.Nodename != "node1" {
 		t.Error("FillNodename() failed to fill Nodename:", entry.Nodename)
@@ -64,7 +64,7 @@ func TestRepairQueueEntry(t *testing.T) {
 
 	// for out-of-cluster machine
 	// GetCorrespondingNode should fail for bad address
-	entry = NewRepairQueueEntry("unreachable", "type2", "2.2.2.2")
+	entry = NewRepairQueueEntry("unreachable", "type2", "2.2.2.2", "")
 	entry.FillNodename(cluster)
 	if entry.Nodename != "" {
 		t.Error("FillNodename() filled wrong Nodename:", entry.Nodename)
@@ -74,7 +74,7 @@ func TestRepairQueueEntry(t *testing.T) {
 	}
 
 	// HaveFinished should return true iff entry has succeeded or failed
-	entry = NewRepairQueueEntry("unreachable", "type2", "1.1.1.1")
+	entry = NewRepairQueueEntry("unreachable", "type2", "1.1.1.1", "")
 	for _, testCase := range []struct {
 		status   RepairStatus
 		finished bool
@@ -91,7 +91,7 @@ func TestRepairQueueEntry(t *testing.T) {
 	}
 
 	// GetMatchingRepairOperation should succeed
-	entry = NewRepairQueueEntry("unreachable", "type2", "1.1.1.1")
+	entry = NewRepairQueueEntry("unreachable", "type2", "1.1.1.1", "")
 	op, err := entry.GetMatchingRepairOperation(cluster)
 	if err != nil {
 		t.Fatal("GetMatchingRepairOperation() failed:", err)
@@ -101,21 +101,21 @@ func TestRepairQueueEntry(t *testing.T) {
 	}
 
 	// GetMatchingRepairOperation should fail for bad machine type
-	entry = NewRepairQueueEntry("unreachable", "type4", "1.1.1.1")
+	entry = NewRepairQueueEntry("unreachable", "type4", "1.1.1.1", "")
 	_, err = entry.GetMatchingRepairOperation(cluster)
 	if err != ErrRepairProcedureNotFound {
 		t.Error("GetMatchingRepairOperation() returned wrong error:", err)
 	}
 
 	// GetMatchingRepairOperation should fail for bad operation
-	entry = NewRepairQueueEntry("noop", "type2", "1.1.1.1")
+	entry = NewRepairQueueEntry("noop", "type2", "1.1.1.1", "")
 	_, err = entry.GetMatchingRepairOperation(cluster)
 	if err != ErrRepairOperationNotFound {
 		t.Error("GetMatchingRepairOperation() returned wrong error:", err)
 	}
 
 	// GetCurrentRepairStep should succeed
-	entry = NewRepairQueueEntry("unreachable", "type2", "1.1.1.1")
+	entry = NewRepairQueueEntry("unreachable", "type2", "1.1.1.1", "")
 	entry.Status = RepairStatusProcessing
 	entry.Step = 1
 	entry.StepStatus = RepairStepStatusWatching
@@ -135,7 +135,7 @@ func TestRepairQueueEntry(t *testing.T) {
 	}
 
 	// GetCurrentRepairStep should fail for bad machine type
-	entry = NewRepairQueueEntry("unreachable", "type4", "1.1.1.1")
+	entry = NewRepairQueueEntry("unreachable", "type4", "1.1.1.1", "")
 	entry.Status = RepairStatusProcessing
 	entry.Step = 1
 	entry.StepStatus = RepairStepStatusWatching
@@ -145,7 +145,7 @@ func TestRepairQueueEntry(t *testing.T) {
 	}
 
 	// GetCurrentRepairStep should fail for bad operation
-	entry = NewRepairQueueEntry("noop", "type2", "1.1.1.1")
+	entry = NewRepairQueueEntry("noop", "type2", "1.1.1.1", "")
 	entry.Status = RepairStatusProcessing
 	entry.Step = 1
 	entry.StepStatus = RepairStepStatusWatching

--- a/sabakan/repairer.go
+++ b/sabakan/repairer.go
@@ -72,7 +72,8 @@ func Repairer(machines []Machine, repairEntries []*cke.RepairQueueEntry, rebootE
 		operation := strings.ToLower(string(machine.Status.State))
 		typ := machine.Spec.BMC.Type
 		address := machine.Spec.IPv4[0]
-		entry := cke.NewRepairQueueEntry(operation, typ, address)
+		serial := machine.Spec.Serial
+		entry := cke.NewRepairQueueEntry(operation, typ, address, serial)
 		log.Info("initiate sabakan-triggered automatic repair", map[string]interface{}{
 			"serial":    machine.Spec.Serial,
 			"address":   address,

--- a/sabakan/repairer_test.go
+++ b/sabakan/repairer_test.go
@@ -24,10 +24,10 @@ func TestRepairer(t *testing.T) {
 
 	entries := []*cke.RepairQueueEntry{
 		nil,
-		cke.NewRepairQueueEntry("unreachable", "type1", "1.1.1.1"),
-		cke.NewRepairQueueEntry("unhealthy", "type2", "2.2.2.2"),
-		cke.NewRepairQueueEntry("unreachable", "type3", "3.3.3.3"),
-		cke.NewRepairQueueEntry("unreachable", "type4", "4.4.4.4"),
+		cke.NewRepairQueueEntry("unreachable", "type1", "1.1.1.1", "1111"),
+		cke.NewRepairQueueEntry("unhealthy", "type2", "2.2.2.2", "2222"),
+		cke.NewRepairQueueEntry("unreachable", "type3", "3.3.3.3", "3333"),
+		cke.NewRepairQueueEntry("unreachable", "type4", "4.4.4.4", "4444"),
 	}
 
 	rebootEntries := []*cke.RebootQueueEntry{
@@ -88,7 +88,7 @@ func TestRepairer(t *testing.T) {
 		{
 			name:            "IgnoreRecentlyRepairedWithDifferentOperation",
 			failedMachines:  []Machine{machines[1], machines[2], machines[3]},
-			queuedEntries:   []*cke.RepairQueueEntry{cke.NewRepairQueueEntry("unreachable", "type2", "2.2.2.2")},
+			queuedEntries:   []*cke.RepairQueueEntry{cke.NewRepairQueueEntry("unreachable", "type2", "2.2.2.2", "2222")},
 			rebootEntries:   nil,
 			nodeStatuses:    nodeStatuses,
 			expectedEntries: []*cke.RepairQueueEntry{entries[1], entries[3]},

--- a/storage_test.go
+++ b/storage_test.go
@@ -918,14 +918,14 @@ func testStorageRepair(t *testing.T) {
 	}
 
 	// first write - index is 0
-	entry := NewRepairQueueEntry("operation1", "machine1", "1.2.3.4")
+	entry := NewRepairQueueEntry("operation1", "machine1", "1.2.3.4", "")
 	err = storage.RegisterRepairsEntry(ctx, entry)
 	if err != nil {
 		t.Fatal("RegisterRepairsEntry failed:", err)
 	}
 
 	// second write - index is 1
-	entry2 := NewRepairQueueEntry("operation2", "machine2", "12.34.56.78")
+	entry2 := NewRepairQueueEntry("operation2", "machine2", "12.34.56.78", "")
 	err = storage.RegisterRepairsEntry(ctx, entry2)
 	if err != nil {
 		t.Fatal("RegisterRepairsEntry failed:", err)


### PR DESCRIPTION
This PR adds machine serial number to repair queue.
Changes are below:

- Added Serial field to RepairQueueEntry struct
- Updated NewRepairQueueEntry() to accept serial parameter
- Modified CLI command signature: ckecli repair-queue add OPERATION MACHINE_TYPE ADDRESS [SERIAL]
- Updated Sabakan integration to pass machine serial when creating repair entries
- Updated all tests and documentation

The ckecli repair-queue add command now accepts an optional SERIAL parameter for backward compatibility.
```console
# Before
$ ckecli repair-queue add unreachable type1 10.0.0.1
# New
$ ckecli repair-queue add unreachable type1 10.0.0.1 SN123456
# Also works
$ ckecli repair-queue add unreachable type1 10.0.0.1
```