### PR TITLE
Output endpoint name to log

### DIFF
--- a/op/kube_endpoints.go
+++ b/op/kube_endpoints.go
@@ -24,7 +24,7 @@ func KubeEndpointsCreateOp(apiserver *cke.Node, ep *corev1.Endpoints) cke.Operat
 }
 
 func (o *kubeEndpointsCreateOp) Name() string {
-	return "create-endpoints"
+	return "create-" + o.endpoints.Name + "-endpoints"
 }
 
 func (o *kubeEndpointsCreateOp) NextCommand() cke.Commander {
@@ -57,7 +57,7 @@ func KubeEndpointsUpdateOp(apiserver *cke.Node, ep *corev1.Endpoints) cke.Operat
 }
 
 func (o *kubeEndpointsUpdateOp) Name() string {
-	return "update-endpoints"
+	return "update-" + o.endpoints.Name + "-endpoints"
 }
 
 func (o *kubeEndpointsUpdateOp) NextCommand() cke.Commander {

--- a/op/kube_endpointslice.go
+++ b/op/kube_endpointslice.go
@@ -24,7 +24,7 @@ func KubeEndpointSliceCreateOp(apiserver *cke.Node, eps *discoveryv1.EndpointSli
 }
 
 func (o *kubeEndpointSliceCreateOp) Name() string {
-	return "create-endpointslice"
+	return "create-" + o.endpointslice.Name + "-endpointslice"
 }
 
 func (o *kubeEndpointSliceCreateOp) NextCommand() cke.Commander {
@@ -57,7 +57,7 @@ func KubeEndpointSliceUpdateOp(apiserver *cke.Node, eps *discoveryv1.EndpointSli
 }
 
 func (o *kubeEndpointSliceUpdateOp) Name() string {
-	return "update-endpointslice"
+	return "update-" + o.endpointslice.Name + "-endpointslice"
 }
 
 func (o *kubeEndpointSliceUpdateOp) NextCommand() cke.Commander {

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -1094,11 +1094,11 @@ func TestDecideOps(t *testing.T) {
 				{"resource-apply", 1},
 				{"resource-apply", 1},
 				{"create-cluster-dns-configmap", 1},
-				{"create-endpoints", 1},
-				{"create-endpointslice", 1},
+				{"create-kubernetes-endpoints", 1},
+				{"create-kubernetes-endpointslice", 1},
 				{"create-etcd-service", 1},
-				{"create-endpoints", 1},
-				{"create-endpointslice", 1},
+				{"create-cke-etcd-endpoints", 1},
+				{"create-cke-etcd-endpointslice", 1},
 			},
 		},
 		{
@@ -1160,35 +1160,35 @@ func TestDecideOps(t *testing.T) {
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.MasterEndpoints.Subsets = []corev1.EndpointSubset{}
 			}),
-			ExpectedOps: []opData{{"update-endpoints", 1}},
+			ExpectedOps: []opData{{"update-kubernetes-endpoints", 1}},
 		},
 		{
 			Name: "MasterEndpointsUpdate2",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.MasterEndpoints.Subsets[0].Ports = []corev1.EndpointPort{}
 			}),
-			ExpectedOps: []opData{{"update-endpoints", 1}},
+			ExpectedOps: []opData{{"update-kubernetes-endpoints", 1}},
 		},
 		{
 			Name: "MasterEndpointsUpdate3",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.MasterEndpoints.Subsets[0].Addresses = []corev1.EndpointAddress{}
 			}),
-			ExpectedOps: []opData{{"update-endpoints", 1}},
+			ExpectedOps: []opData{{"update-kubernetes-endpoints", 1}},
 		},
 		{
 			Name: "MasterEndpointSliceUpdate1",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.MasterEndpointSlice.Endpoints[0].Addresses = []string{}
 			}),
-			ExpectedOps: []opData{{"update-endpointslice", 1}},
+			ExpectedOps: []opData{{"update-kubernetes-endpointslice", 1}},
 		},
 		{
 			Name: "MasterEndpointSliceUpdate2",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.MasterEndpointSlice.Ports[0] = discoveryv1.EndpointPort{}
 			}),
-			ExpectedOps: []opData{{"update-endpointslice", 1}},
+			ExpectedOps: []opData{{"update-kubernetes-endpointslice", 1}},
 		},
 		{
 			Name: "EtcdServiceUpdate",
@@ -1202,35 +1202,35 @@ func TestDecideOps(t *testing.T) {
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.EtcdEndpoints.Subsets = []corev1.EndpointSubset{}
 			}),
-			ExpectedOps: []opData{{"update-endpoints", 1}},
+			ExpectedOps: []opData{{"update-cke-etcd-endpoints", 1}},
 		},
 		{
 			Name: "EtcdEndpointsUpdate2",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.EtcdEndpoints.Subsets[0].Ports = []corev1.EndpointPort{}
 			}),
-			ExpectedOps: []opData{{"update-endpoints", 1}},
+			ExpectedOps: []opData{{"update-cke-etcd-endpoints", 1}},
 		},
 		{
 			Name: "EtcdEndpointsUpdate3",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.EtcdEndpoints.Subsets[0].Addresses = []corev1.EndpointAddress{}
 			}),
-			ExpectedOps: []opData{{"update-endpoints", 1}},
+			ExpectedOps: []opData{{"update-cke-etcd-endpoints", 1}},
 		},
 		{
 			Name: "EtcdEndpointSliceUpdate1",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.EtcdEndpointSlice.Endpoints[0].Addresses = []string{}
 			}),
-			ExpectedOps: []opData{{"update-endpointslice", 1}},
+			ExpectedOps: []opData{{"update-cke-etcd-endpointslice", 1}},
 		},
 		{
 			Name: "EtcdEndpointSliceUpdate2",
 			Input: newData().withK8sResourceReady().with(func(d testData) {
 				d.Status.Kubernetes.EtcdEndpointSlice.Ports[0] = discoveryv1.EndpointPort{}
 			}),
-			ExpectedOps: []opData{{"update-endpointslice", 1}},
+			ExpectedOps: []opData{{"update-cke-etcd-endpointslice", 1}},
 		},
 		{
 			Name: "EndpointsUpdateWithRebootEntry",
@@ -1242,10 +1242,10 @@ func TestDecideOps(t *testing.T) {
 				},
 			}),
 			ExpectedOps: []opData{
-				{"update-endpoints", 1},
-				{"update-endpointslice", 1},
-				{"update-endpoints", 1},
-				{"update-endpointslice", 1},
+				{"update-kubernetes-endpoints", 1},
+				{"update-kubernetes-endpointslice", 1},
+				{"update-cke-etcd-endpoints", 1},
+				{"update-cke-etcd-endpointslice", 1},
 			},
 		},
 		{
@@ -1264,10 +1264,10 @@ func TestDecideOps(t *testing.T) {
 				},
 			}),
 			ExpectedOps: []opData{
-				{"update-endpoints", 1},
-				{"update-endpointslice", 1},
-				{"update-endpoints", 1},
-				{"update-endpointslice", 1},
+				{"update-kubernetes-endpoints", 1},
+				{"update-kubernetes-endpointslice", 1},
+				{"update-cke-etcd-endpoints", 1},
+				{"update-cke-etcd-endpointslice", 1},
 			},
 		},
 		{
@@ -1319,10 +1319,10 @@ func TestDecideOps(t *testing.T) {
 			Name:  "RestoreEndpoints",
 			Input: newData().withK8sResourceReady().withNotReadyEndpoint(2),
 			ExpectedOps: []opData{
-				{"update-endpoints", 1},
-				{"update-endpointslice", 1},
-				{"update-endpoints", 1},
-				{"update-endpointslice", 1},
+				{"update-kubernetes-endpoints", 1},
+				{"update-kubernetes-endpointslice", 1},
+				{"update-cke-etcd-endpoints", 1},
+				{"update-cke-etcd-endpointslice", 1},
 			},
 		},
 		{
@@ -1341,10 +1341,10 @@ func TestDecideOps(t *testing.T) {
 				},
 			}).withNotReadyEndpoint(2),
 			ExpectedOps: []opData{
-				{"update-endpoints", 1},
-				{"update-endpointslice", 1},
-				{"update-endpoints", 1},
-				{"update-endpointslice", 1},
+				{"update-kubernetes-endpoints", 1},
+				{"update-kubernetes-endpointslice", 1},
+				{"update-cke-etcd-endpoints", 1},
+				{"update-cke-etcd-endpointslice", 1},
 			},
 		},
 		{
@@ -1357,10 +1357,10 @@ func TestDecideOps(t *testing.T) {
 				},
 			}).withNotReadyEndpoint(2),
 			ExpectedOps: []opData{
-				{"update-endpoints", 1},
-				{"update-endpointslice", 1},
-				{"update-endpoints", 1},
-				{"update-endpointslice", 1},
+				{"update-kubernetes-endpoints", 1},
+				{"update-kubernetes-endpointslice", 1},
+				{"update-cke-etcd-endpoints", 1},
+				{"update-cke-etcd-endpointslice", 1},
 			},
 		},
 		{
@@ -1379,10 +1379,10 @@ func TestDecideOps(t *testing.T) {
 				},
 			}).withNotReadyEndpoint(2),
 			ExpectedOps: []opData{
-				{"update-endpoints", 1},
-				{"update-endpointslice", 1},
-				{"update-endpoints", 1},
-				{"update-endpointslice", 1},
+				{"update-kubernetes-endpoints", 1},
+				{"update-kubernetes-endpointslice", 1},
+				{"update-cke-etcd-endpoints", 1},
+				{"update-cke-etcd-endpointslice", 1},
 			},
 		},
 		{


### PR DESCRIPTION
This PR adds Endpoint (or EndpointSlices) name to the operation name. 

CKE manages two Endpoints, `kubernetes` and `cke-etcd`. But CKE does not output these Endpoint names.
Therefore, it is difficult to verify the CKE operations from logs or history.

In this PR, by adding the Endpoint name to the operation name, makes it easier to verify CKE operations.

The log and history will be as follows:

<details>

<summary>CKE log</summary>

```
2025-11-12T09:23:34.439597Z gcp0-boot-0 cke info: "begin new operation" op="update-kubernetes-endpoints"
2025-11-12T09:23:34.440287Z gcp0-boot-0 cke info: "record targets" op="update-kubernetes-endpoints" targets="10.69.0.4"
2025-11-12T09:23:34.442373Z gcp0-boot-0 cke info: "execute a command" command="updateEndpointsCommand 10.69.0.4,10.69.1.133" op="update-kubernetes-endpoints"
2025-11-12T09:23:34.451504Z gcp0-boot-0 cke info: "operation completed" op="update-kubernetes-endpoints"
2025-11-12T09:23:34.458193Z gcp0-boot-0 cke info: "begin new operation" op="update-kubernetes-endpointslice"
2025-11-12T09:23:34.458235Z gcp0-boot-0 cke info: "record targets" op="update-kubernetes-endpointslice" targets="10.69.0.4"
2025-11-12T09:23:34.461183Z gcp0-boot-0 cke info: "execute a command" command="updateEndpointSliceCommand 10.69.0.4,10.69.1.133,10.69.0.196" op="update-kubernetes-endpointslice"
2025-11-12T09:23:34.473117Z gcp0-boot-0 cke info: "operation completed" op="update-kubernetes-endpointslice"
2025-11-12T09:23:34.481844Z gcp0-boot-0 cke info: "begin new operation" op="update-cke-etcd-endpoints"
2025-11-12T09:23:34.481889Z gcp0-boot-0 cke info: "record targets" op="update-cke-etcd-endpoints" targets="10.69.0.4"
2025-11-12T09:23:34.483749Z gcp0-boot-0 cke info: "execute a command" command="updateEndpointsCommand 10.69.0.4,10.69.1.133" op="update-cke-etcd-endpoints"
2025-11-12T09:23:34.494175Z gcp0-boot-0 cke info: "operation completed" op="update-cke-etcd-endpoints"
2025-11-12T09:23:34.503056Z gcp0-boot-0 cke info: "begin new operation" op="update-cke-etcd-endpointslice"
2025-11-12T09:23:34.503094Z gcp0-boot-0 cke info: "record targets" op="update-cke-etcd-endpointslice" targets="10.69.0.4"
2025-11-12T09:23:34.505928Z gcp0-boot-0 cke info: "execute a command" command="updateEndpointSliceCommand 10.69.0.4,10.69.1.133,10.69.0.196" op="update-cke-etcd-endpointslice"
2025-11-12T09:23:34.516487Z gcp0-boot-0 cke info: "operation completed" op="update-cke-etcd-endpointslice"
```

</details>

<details>

<summary>CKE history</summary>


```
$ ckecli history -f
(snip)
{
    "id": "577",
    "status": "completed",
    "operation": "update-kubernetes-endpointslice",
    "command": {
        "name": "updateEndpointSliceCommand",
        "target": "10.69.0.4,10.69.1.133,10.69.0.196"
    },
    "targets": [
        "10.69.0.4"
    ],
    "info": "",
    "error": "",
    "start-at": "2025-11-12T09:23:34.453390248Z",
    "end-at": "2025-11-12T09:23:34.467609998Z"
}
{
    "id": "578",
    "status": "new",
    "operation": "update-cke-etcd-endpoints",
    "command": {
        "name": "",
        "target": ""
    },
    "targets": [
        "10.69.0.4"
    ],
    "info": "",
    "error": "",
    "start-at": "2025-11-12T09:23:34.474600455Z",
    "end-at": "0001-01-01T00:00:00Z"
}
```

</details>