### PR TITLE
Confirm EndpointSlice in mtest

### DIFF
--- a/mtest/kubernetes_test.go
+++ b/mtest/kubernetes_test.go
@@ -317,6 +317,8 @@ func testKubernetes() {
 		Expect(err).NotTo(HaveOccurred(), "stderr=%s", stderr)
 		_, stderr, err = kubectl("-n", "kube-system", "get", "endpoints/cke-etcd")
 		Expect(err).NotTo(HaveOccurred(), "stderr=%s", stderr)
+		_, stderr, err = kubectl("-n", "kube-system", "get", "endpointslices/cke-etcd")
+		Expect(err).NotTo(HaveOccurred(), "stderr=%s", stderr)
 	})
 
 	It("can output audit log to journal log", func() {


### PR DESCRIPTION
This PR adds a test case to confirm the `kubernetes` EndpointSlice in mtest.
Additionally, adds minor improvements to the update logic for EndpointSlices.