### PR TITLE
Update etcd to 3.6.11.1 (backport to 1.34)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
           go-version-file: go.mod
       - name: Check auto-generated files
         run: make check-generate
-      - run: docker run -d --network host gcr.io/etcd-development/etcd:v3.6.9
+      - run: docker run -d --network host gcr.io/etcd-development/etcd:v3.6.11
       - run: make test
       - run: make install GOBIN=$(pwd)/docker
       - run: docker build -t ghcr.io/cybozu-go/cke:latest ./docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project employs a versioning scheme described in [RELEASE.md](RELEASE.md#ve
 
 ## [Unreleased]
 
+### Changed
+
+- Update etcd to v3.6.11 in [#881](https://github.com/cybozu-go/cke/pull/881)
+
 ## [1.34.3]
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for cke
 
-ETCD_VERSION = 3.6.9
+ETCD_VERSION = 3.6.11
 
 .PHONY: all
 all: test

--- a/images.go
+++ b/images.go
@@ -10,7 +10,7 @@ func (i Image) Name() string {
 
 // Container image definitions
 const (
-	EtcdImage            = Image("ghcr.io/cybozu/etcd:3.6.9.1")
+	EtcdImage            = Image("ghcr.io/cybozu/etcd:3.6.11.1")
 	KubernetesImage      = Image("ghcr.io/cybozu/kubernetes:1.34.4.2")
 	ToolsImage           = Image("ghcr.io/cybozu-go/cke-tools:1.34.0")
 	PauseImage           = Image("ghcr.io/cybozu/pause:3.10.1.4")

--- a/mtest/Makefile
+++ b/mtest/Makefile
@@ -2,7 +2,7 @@
 
 # tool versions
 ## Make sure the binary is included in the GitHub release. The release of ct v0.9.4 does not include binary files.
-MANAGEMENT_ETCD_VERSION = 3.6.9
+MANAGEMENT_ETCD_VERSION = 3.6.11
 VAULT_VERSION = 1.21.4
 K8S_VERSION = 1.34.4
 CONTAINERD_VERSION = 2.2.1


### PR DESCRIPTION
This PR is backport of https://github.com/cybozu-go/cke/pull/877.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>
