### PR TITLE
Bump version to 1.34.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,13 @@ This project employs a versioning scheme described in [RELEASE.md](RELEASE.md#ve
 
 ## [Unreleased]
 
-### Changed
-
-- Update etcd to v3.6.11 in [#881](https://github.com/cybozu-go/cke/pull/881)
-- add root role to kube-apiserver in [#883](https://github.com/cybozu-go/cke/pull/883)
-
-## [1.34.3]
+## [1.34.4]
 
 ### Changed
 
 - Bump unbound image to 1.25.1.1 in [#876](https://github.com/cybozu-go/cke/pull/876)
+- Update etcd to v3.6.11 in [#881](https://github.com/cybozu-go/cke/pull/881)
+- add root role to kube-apiserver in [#883](https://github.com/cybozu-go/cke/pull/883)
 
 ## [1.34.2]
 
@@ -63,8 +60,8 @@ This project employs a versioning scheme described in [RELEASE.md](RELEASE.md#ve
 - See [release-1.13/CHANGELOG.md](https://github.com/cybozu-go/cke/blob/release-1.13/CHANGELOG.md) for changes in CKE 1.13.
 - See [release-1.12/CHANGELOG.md](https://github.com/cybozu-go/cke/blob/release-1.12/CHANGELOG.md) for changes in CKE 1.12.
 
-[Unreleased]: https://github.com/cybozu-go/cke/compare/v1.34.3...HEAD
-[1.34.3]: https://github.com/cybozu-go/cke/compare/v1.34.2...v1.34.3
+[Unreleased]: https://github.com/cybozu-go/cke/compare/v1.34.4...HEAD
+[1.34.4]: https://github.com/cybozu-go/cke/compare/v1.34.2...v1.34.4
 [1.34.2]: https://github.com/cybozu-go/cke/compare/v1.34.1...v1.34.2
 [1.34.1]: https://github.com/cybozu-go/cke/compare/v1.34.0...v1.34.1
 [1.34.0]: https://github.com/cybozu-go/cke/compare/v1.33.4...v1.34.0

--- a/version.go
+++ b/version.go
@@ -1,7 +1,7 @@
 package cke
 
 // Version represents current cke version
-const Version = "1.34.3"
+const Version = "1.34.4"
 
 // ConfigVersion represents the current configuration scheme
 // of how CKE constructs its Kubernetes cluster.


### PR DESCRIPTION
Since 1.34.3 could not be released due to failing sonobuoy tests, the 1.34.3 section has been removed from CHANGELOG.md.