### PR TITLE
Add feature to repair control-plane

### DIFF
--- a/mtest/repair_test.go
+++ b/mtest/repair_test.go
@@ -285,4 +285,91 @@ func testRepairOperations() {
 		waitRepairSuccess()
 		nodesShouldBeSchedulable(nodeNames[1])
 	})
+
+	// A control plane failure naturally makes its etcd member out of sync.
+	// CKE must still repair the node, because the out-of-sync member is
+	// explained by the very control plane failure being repaired.
+	// This test stops a control plane node, so it must run last.
+	It("should repair a stopped control plane node whose etcd member is out of sync", func() {
+		cluster := getCluster(0, 1, 2)
+
+		By("cleaning up the repair queue")
+		ckecliSafe("repair-queue", "enable")
+		ckecliSafe("repair-queue", "delete-finished")
+		waitRepairEmpty()
+
+		By("stopping CKE to avoid hang-up in SSH session due to node3 shutdown")
+		stopCKE()
+
+		By("stopping a control plane node")
+		execAt(node3, "sudo", "systemd-run", "halt", "-f", "-f")
+		Eventually(func(g Gomega) {
+			_, err := execAtLocal("ping", "-c", "1", "-W", "1", node3)
+			g.Expect(err).To(HaveOccurred())
+		}).Should(Succeed())
+
+		By("restarting CKE")
+		runCKE(ckeImageURL)
+		waitServerStatusCompletion()
+
+		By("confirming etcd is healthy but only node3 is out of sync")
+		Eventually(func(g Gomega) {
+			cs, _, err := getClusterStatus(cluster)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(cs.Etcd.IsHealthy).To(BeTrue())
+			g.Expect(cs.Etcd.InSyncMembers).To(HaveKeyWithValue(node1, true))
+			g.Expect(cs.Etcd.InSyncMembers).To(HaveKeyWithValue(node2, true))
+			g.Expect(cs.Etcd.InSyncMembers).To(HaveKeyWithValue(node3, false))
+		}).Should(Succeed())
+
+		By("disabling need_drain to repair the stopped node without draining")
+		cluster.Repair.RepairProcedures[0].RepairOperations[0].RepairSteps[0].NeedDrain = false
+		clusterSetAndWait(cluster)
+
+		By("adding a repair request for the stopped control plane node")
+		execSafeAt(host1, "docker", "exec", "cke", "find", "/tmp", "-maxdepth", "1", "-name", "mtest-repair-*", "-delete")
+		execSafeAt(host2, "docker", "exec", "cke", "find", "/tmp", "-maxdepth", "1", "-name", "mtest-repair-*", "-delete")
+		ckecliSafe("repair-queue", "add", "op1", "type1", node3, "SN1234")
+
+		By("waiting for the repair to succeed")
+		waitRepairSuccess()
+		repairSuccessCommandSuccess(node3)
+
+		ckecliSafe("repair-queue", "delete-finished")
+		waitRepairEmpty()
+	})
+
+	// When a second control plane node also goes down, the etcd cluster is no
+	// longer good for repair (it loses quorum and the control plane is degraded
+	// by more than one node), so CKE must NOT proceed with repair.
+	// This stops a second control plane node, so it must run last.
+	It("should not repair while the control plane is degraded by more than one node", func() {
+		By("cleaning up the repair queue")
+		ckecliSafe("repair-queue", "enable")
+		ckecliSafe("repair-queue", "delete-finished")
+		waitRepairEmpty()
+
+		By("stopping CKE to avoid hang-up in SSH session due to node2 shutdown")
+		stopCKE()
+
+		By("stopping a second control plane node")
+		execAt(node2, "sudo", "systemd-run", "halt", "-f", "-f")
+		Eventually(func(g Gomega) {
+			_, err := execAtLocal("ping", "-c", "1", "-W", "1", node2)
+			g.Expect(err).To(HaveOccurred())
+		}).Should(Succeed())
+
+		By("restarting CKE")
+		runCKE(ckeImageURL)
+		// Do not wait for completion: with two control plane nodes down the etcd
+		// cluster is not healthy, so CKE stays in the etcd-wait phase.
+
+		By("adding a repair request and confirming it does not proceed")
+		execSafeAt(host1, "docker", "exec", "cke", "find", "/tmp", "-maxdepth", "1", "-name", "mtest-repair-*", "-delete")
+		execSafeAt(host2, "docker", "exec", "cke", "find", "/tmp", "-maxdepth", "1", "-name", "mtest-repair-*", "-delete")
+		ckecliSafe("repair-queue", "add", "op1", "type1", node2, "SN1234")
+		repairShouldNotProceed()
+
+		ckecliSafe("repair-queue", "delete-unfinished")
+	})
 }

--- a/mtest/repair_test.go
+++ b/mtest/repair_test.go
@@ -286,7 +286,7 @@ func testRepairOperations() {
 		nodesShouldBeSchedulable(nodeNames[1])
 	})
 
-	// The two tests above stop control plane nodes, so they must run last.
+	// The two tests below stop control plane nodes, so they must run last.
 	It("should repair a stopped control plane node whose etcd member is out of sync", func() {
 		cluster := getCluster(0, 1, 2)
 

--- a/mtest/repair_test.go
+++ b/mtest/repair_test.go
@@ -286,10 +286,7 @@ func testRepairOperations() {
 		nodesShouldBeSchedulable(nodeNames[1])
 	})
 
-	// A control plane failure naturally makes its etcd member out of sync.
-	// CKE must still repair the node, because the out-of-sync member is
-	// explained by the very control plane failure being repaired.
-	// This test stops a control plane node, so it must run last.
+	// The two tests above stop control plane nodes, so they must run last.
 	It("should repair a stopped control plane node whose etcd member is out of sync", func() {
 		cluster := getCluster(0, 1, 2)
 
@@ -339,10 +336,6 @@ func testRepairOperations() {
 		waitRepairEmpty()
 	})
 
-	// When a second control plane node also goes down, the etcd cluster is no
-	// longer good for repair (it loses quorum and the control plane is degraded
-	// by more than one node), so CKE must NOT proceed with repair.
-	// This stops a second control plane node, so it must run last.
 	It("should not repair while the control plane is degraded by more than one node", func() {
 		By("cleaning up the repair queue")
 		ckecliSafe("repair-queue", "enable")

--- a/mtest/repair_test.go
+++ b/mtest/repair_test.go
@@ -361,12 +361,15 @@ func testRepairOperations() {
 
 		By("restarting CKE")
 		runCKE(ckeImageURL)
-		// Do not wait for completion: with two control plane nodes down the etcd
-		// cluster is not healthy, so CKE stays in the etcd-wait phase.
+		// Do not wait for status completion: with two control plane nodes down the
+		// etcd cluster is not healthy, so CKE stays in the etcd-wait phase. Just
+		// wait for the CKE container to be running so the assertion is meaningful.
+		Eventually(func() error {
+			_, _, err := execAt(host1, "docker", "inspect", "cke")
+			return err
+		}).Should(Succeed())
 
 		By("adding a repair request and confirming it does not proceed")
-		execSafeAt(host1, "docker", "exec", "cke", "find", "/tmp", "-maxdepth", "1", "-name", "mtest-repair-*", "-delete")
-		execSafeAt(host2, "docker", "exec", "cke", "find", "/tmp", "-maxdepth", "1", "-name", "mtest-repair-*", "-delete")
 		ckecliSafe("repair-queue", "add", "op1", "type1", node2, "SN1234")
 		repairShouldNotProceed()
 

--- a/mtest/suite_test.go
+++ b/mtest/suite_test.go
@@ -154,7 +154,7 @@ var _ = Describe("Test CKE", func() {
 			testRebootOperations()
 		})
 	case "repair":
-		Context("repair", func() {
+		Context("repair", Ordered, func() {
 			testRepairOperations()
 		})
 	case "upgrade":

--- a/server/node_filter.go
+++ b/server/node_filter.go
@@ -158,27 +158,24 @@ func (nf *NodeFilter) EtcdIsGood() bool {
 // EtcdIsGoodForRepair returns true like EtcdIsGood, but tolerates up to one
 // out-of-sync member running on an SSH-unreachable control plane node, since
 // such a member is the result of a control plane failure to be repaired.
-func (nf *NodeFilter) EtcdIsGoodForRepair() bool {
+func (nf *NodeFilter) EtcdIsGoodForRepair(controlPlaneCount int) bool {
 	st := nf.status.Etcd
 	if !st.IsHealthy {
 		return false
 	}
-	tolerated := 0
-	for k := range st.Members {
-		if st.InSyncMembers[k] {
+	inSyncCP := 0
+	for address, inSync := range st.InSyncMembers {
+		if inSync {
+			inSyncCP++
 			continue
 		}
-		// tolerate only an out-of-sync member caused by a control plane failure
-		n, ok := nf.nodeMap[k]
+
+		n, ok := nf.nodeMap[address]
 		if !ok || !n.ControlPlane || nf.nodeStatus(n).SSHConnected {
 			return false
 		}
-		tolerated++
-		if tolerated > 1 {
-			return false
-		}
 	}
-	return true
+	return inSyncCP >= controlPlaneCount-1
 }
 
 // EtcdStopped filters nodes that are not running etcd.

--- a/server/node_filter.go
+++ b/server/node_filter.go
@@ -155,6 +155,32 @@ func (nf *NodeFilter) EtcdIsGood() bool {
 	return true
 }
 
+// EtcdIsGoodForRepair returns true like EtcdIsGood, but tolerates up to one
+// out-of-sync member running on an SSH-unreachable control plane node, since
+// such a member is the result of a control plane failure to be repaired.
+func (nf *NodeFilter) EtcdIsGoodForRepair() bool {
+	st := nf.status.Etcd
+	if !st.IsHealthy {
+		return false
+	}
+	tolerated := 0
+	for k := range st.Members {
+		if st.InSyncMembers[k] {
+			continue
+		}
+		// tolerate only an out-of-sync member caused by a control plane failure
+		n, ok := nf.nodeMap[k]
+		if !ok || !n.ControlPlane || nf.nodeStatus(n).SSHConnected {
+			return false
+		}
+		tolerated++
+		if tolerated > 1 {
+			return false
+		}
+	}
+	return true
+}
+
 // EtcdStopped filters nodes that are not running etcd.
 func (nf *NodeFilter) EtcdStopped(targets []*cke.Node) (nodes []*cke.Node) {
 	for _, n := range targets {

--- a/server/strategy.go
+++ b/server/strategy.go
@@ -89,8 +89,8 @@ func DecideOps(c *cke.Cluster, cs *cke.ClusterStatus, constraints *cke.Constrain
 
 	// 10. Repair machines if repair requests have been arrived to the repair queue, and the number of unreachable nodes is less than a threshold.
 	if ops, phaseRepair := repairOps(c, cs, constraints, nf); phaseRepair {
-		if !nf.EtcdIsGood() {
-			log.Warn("cannot repair machines because etcd cluster is not responding and in-sync", nil)
+		if !nf.EtcdIsGoodForRepair() {
+			log.Warn("cannot repair machines because etcd cluster is not responding or is out of sync without a control plane failure", nil)
 			return nil, cke.PhaseRepairMachines
 		}
 		return ops, cke.PhaseRepairMachines

--- a/server/strategy.go
+++ b/server/strategy.go
@@ -89,8 +89,8 @@ func DecideOps(c *cke.Cluster, cs *cke.ClusterStatus, constraints *cke.Constrain
 
 	// 10. Repair machines if repair requests have been arrived to the repair queue, and the number of unreachable nodes is less than a threshold.
 	if ops, phaseRepair := repairOps(c, cs, constraints, nf); phaseRepair {
-		if !nf.EtcdIsGoodForRepair() {
-			log.Warn("cannot repair machines because etcd cluster is not responding or is out of sync without a control plane failure", nil)
+		if !nf.EtcdIsGoodForRepair(constraints.ControlPlaneCount) {
+			log.Warn("cannot repair machines because etcd cluster is not responding, is out of sync without a control plane failure, or the control plane is degraded by more than one node", nil)
 			return nil, cke.PhaseRepairMachines
 		}
 		return ops, cke.PhaseRepairMachines

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -34,11 +34,7 @@ const (
 
 var (
 	testDefaultDNSServers = []string{"8.8.8.8"}
-	testConstraints       = &cke.Constraints{
-		ControlPlaneCount:        3,
-		RebootMaximumUnreachable: 1,
-	}
-	testResources = []cke.ResourceDefinition{
+	testResources         = []cke.ResourceDefinition{
 		{
 			Key:        "Namespace/foo",
 			Kind:       "Namespace",
@@ -170,12 +166,15 @@ func newData() testData {
 		RebootQueue: cke.RebootQueueStatus{Enabled: true},
 	}
 
-	constraints := *testConstraints
+	constraints := &cke.Constraints{
+		ControlPlaneCount:        3,
+		RebootMaximumUnreachable: 1,
+	}
 
 	return testData{
 		Cluster:     cluster,
 		Status:      status,
-		Constraints: &constraints,
+		Constraints: constraints,
 		Resources:   testResources,
 	}
 }

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -2733,6 +2733,42 @@ func TestDecideOps(t *testing.T) {
 			ExpectedPhase: cke.PhaseRepairMachines,
 		},
 		{
+			// Repair runs even when a failed control plane node makes its etcd member out of sync.
+			Name: "RepairControlPlaneFailureEtcdOutOfSync",
+			Input: newData().withK8sResourceReady().withRepairConfig().withRepairEntries([]*cke.RepairQueueEntry{
+				{Address: nodeNames[0], MachineType: "type1", Operation: "op1"},
+			}).withSSHNotConnectedCP(0).withNotReadyMasterEndpoint(0).with(func(d testData) {
+				d.Status.Etcd.InSyncMembers[nodeNames[0]] = false
+			}),
+			ExpectedOps: []opData{
+				{"repair-execute", 1},
+			},
+			ExpectedPhase: cke.PhaseRepairMachines,
+		},
+		{
+			// Repair is blocked when an etcd member is out of sync without a control plane failure.
+			Name: "RepairBlockedByEtcdOutOfSyncWithoutCPFailure",
+			Input: newData().withK8sResourceReady().withRepairConfig().withRepairEntries([]*cke.RepairQueueEntry{
+				{Address: nodeNames[4], MachineType: "type1", Operation: "op1"},
+			}).with(func(d testData) {
+				d.Status.Etcd.InSyncMembers[nodeNames[0]] = false
+			}),
+			ExpectedOps:   nil,
+			ExpectedPhase: cke.PhaseRepairMachines,
+		},
+		{
+			// Repair is blocked by a second out-of-sync member not caused by a control plane failure.
+			Name: "RepairBlockedByExtraEtcdOutOfSync",
+			Input: newData().withK8sResourceReady().withRepairConfig().withRepairEntries([]*cke.RepairQueueEntry{
+				{Address: nodeNames[0], MachineType: "type1", Operation: "op1"},
+			}).withSSHNotConnectedCP(0).withNotReadyMasterEndpoint(0).with(func(d testData) {
+				d.Status.Etcd.InSyncMembers[nodeNames[0]] = false
+				d.Status.Etcd.InSyncMembers[nodeNames[1]] = false
+			}),
+			ExpectedOps:   nil,
+			ExpectedPhase: cke.PhaseRepairMachines,
+		},
+		{
 			Name: "RepairWithoutConfig",
 			Input: newData().withK8sResourceReady().withRepairEntries([]*cke.RepairQueueEntry{
 				{Address: nodeNames[4], MachineType: "type1", Operation: "op1"},

--- a/server/strategy_test.go
+++ b/server/strategy_test.go
@@ -170,10 +170,12 @@ func newData() testData {
 		RebootQueue: cke.RebootQueueStatus{Enabled: true},
 	}
 
+	constraints := *testConstraints
+
 	return testData{
 		Cluster:     cluster,
 		Status:      status,
-		Constraints: testConstraints,
+		Constraints: &constraints,
 		Resources:   testResources,
 	}
 }
@@ -2733,7 +2735,6 @@ func TestDecideOps(t *testing.T) {
 			ExpectedPhase: cke.PhaseRepairMachines,
 		},
 		{
-			// Repair runs even when a failed control plane node makes its etcd member out of sync.
 			Name: "RepairControlPlaneFailureEtcdOutOfSync",
 			Input: newData().withK8sResourceReady().withRepairConfig().withRepairEntries([]*cke.RepairQueueEntry{
 				{Address: nodeNames[0], MachineType: "type1", Operation: "op1"},
@@ -2746,7 +2747,6 @@ func TestDecideOps(t *testing.T) {
 			ExpectedPhase: cke.PhaseRepairMachines,
 		},
 		{
-			// Repair is blocked when an etcd member is out of sync without a control plane failure.
 			Name: "RepairBlockedByEtcdOutOfSyncWithoutCPFailure",
 			Input: newData().withK8sResourceReady().withRepairConfig().withRepairEntries([]*cke.RepairQueueEntry{
 				{Address: nodeNames[4], MachineType: "type1", Operation: "op1"},
@@ -2757,13 +2757,23 @@ func TestDecideOps(t *testing.T) {
 			ExpectedPhase: cke.PhaseRepairMachines,
 		},
 		{
-			// Repair is blocked by a second out-of-sync member not caused by a control plane failure.
 			Name: "RepairBlockedByExtraEtcdOutOfSync",
 			Input: newData().withK8sResourceReady().withRepairConfig().withRepairEntries([]*cke.RepairQueueEntry{
 				{Address: nodeNames[0], MachineType: "type1", Operation: "op1"},
 			}).withSSHNotConnectedCP(0).withNotReadyMasterEndpoint(0).with(func(d testData) {
 				d.Status.Etcd.InSyncMembers[nodeNames[0]] = false
 				d.Status.Etcd.InSyncMembers[nodeNames[1]] = false
+			}),
+			ExpectedOps:   nil,
+			ExpectedPhase: cke.PhaseRepairMachines,
+		},
+		{
+			Name: "RepairBlockedByMissingControlPlane",
+			Input: newData().withK8sResourceReady().withRepairConfig().withRepairEntries([]*cke.RepairQueueEntry{
+				{Address: nodeNames[0], MachineType: "type1", Operation: "op1"},
+			}).withSSHNotConnectedCP(0).withNotReadyMasterEndpoint(0).with(func(d testData) {
+				d.Constraints.ControlPlaneCount = 4
+				d.Status.Etcd.InSyncMembers[nodeNames[0]] = false
 			}),
 			ExpectedOps:   nil,
 			ExpectedPhase: cke.PhaseRepairMachines,


### PR DESCRIPTION
In current implementation, repair of unreachable control-plane is not executed because `EtcdIsGood` returns false if one of the  etcd member lost connections.
This adds `EtcdIsGoodForRepair`, which allows repair when etcd still has quorum and out-of-sync member is on an SSH-unreachable control-plane node.