### PR TITLE
Reduce mtest Slack notification noise and right-size the CI instance

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,6 +6,9 @@ on:
       - 'main'
 env:
   filename: "main.yaml"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build:
     name: Build CKE
@@ -55,13 +58,13 @@ jobs:
         if: ${{ always() }}
         run: cat cke-service.log
       - name: Set the instance lifetime
-        if: ${{ failure() ||  cancelled() }}
+        if: ${{ failure() }}
         run: |
           . ./bin/env
           $GCLOUD compute instances add-metadata ${INSTANCE_NAME} --zone ${ZONE} \
           --metadata shutdown-at=$(date -Iseconds -d+30minutes)
       - name: Notify to Slack
-        if: ${{ failure() ||  cancelled() }}
+        if: ${{ failure() }}
         run: |
           . ./bin/env
           if [[ ${{ github.event_name }} == 'pull_request' ]]; then
@@ -70,22 +73,37 @@ jobs:
               BRANCH_NAME=${GITHUB_REF#refs/heads/}
           fi
           curl -X POST -H 'Content-type: application/json' --data "{
-            \"blocks\": [
+            \"attachments\": [
               {
-                \"type\": \"section\",
-                \"text\": {
-                  \"type\": \"mrkdwn\",
-                  \"text\": \"Failed: ${{ github.actor }}'s workflow (${{ github.workflow }}) in <https://github.com/${{ github.repository }}/actions/workflows/${{ env.filename }}|${{ github.repository }}> (<https://github.com/${{ github.repository }}/actions/workflows/${{ env.filename }}?query=branch%3A${BRANCH_NAME}|${BRANCH_NAME}>) \n Do you extend the lifetime of ${INSTANCE_NAME}?\"
-                },
-                \"accessory\": {
-                  \"type\": \"button\",
-                  \"text\": {
-                    \"type\": \"plain_text\",
-                    \"text\": \"Extend\",
-                    \"emoji\": true
-                  },
-                  \"value\": \"${INSTANCE_NAME}\"
-                }
+                \"color\": \"#ff4b00\",
+                \"blocks\": [
+                  {
+                    \"type\": \"section\",
+                    \"text\": {
+                      \"type\": \"mrkdwn\",
+                      \"text\": \"Failure: ${{ github.actor }}'s workflow in <https://github.com/${{ github.repository }}|${{ github.repository }}> (<https://github.com/${{ github.repository }}/actions/workflows/${{ env.filename }}?query=branch%3A${BRANCH_NAME}|${BRANCH_NAME}>)\"
+                    },
+                    \"fields\": [
+                      {
+                        \"type\": \"mrkdwn\",
+                        \"text\": \"*Workflow*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }} #${{ github.run_number }}> [${SUITE}]\"
+                      },
+                      {
+                        \"type\": \"mrkdwn\",
+                        \"text\": \"*Instance*\n${INSTANCE_NAME}\"
+                      }
+                    ],
+                    \"accessory\": {
+                      \"type\": \"button\",
+                      \"text\": {
+                        \"type\": \"plain_text\",
+                        \"text\": \"Extend\",
+                        \"emoji\": true
+                      },
+                      \"value\": \"${INSTANCE_NAME}\"
+                    }
+                  }
+                ]
               }
             ]
           }" ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/bin/env
+++ b/bin/env
@@ -1,7 +1,7 @@
 PROJECT=neco-test
 ZONE=asia-northeast1-c
 SERVICE_ACCOUNT=neco-test@neco-test.iam.gserviceaccount.com
-MACHINE_TYPE=c2-standard-30
+MACHINE_TYPE=n2-standard-16
 DISK_TYPE=pd-ssd
 BOOT_DISK_SIZE=30GB
 GCLOUD="gcloud --quiet --account ${SERVICE_ACCOUNT} --project ${PROJECT}"

--- a/bin/run-mtest.sh
+++ b/bin/run-mtest.sh
@@ -14,8 +14,6 @@ $GCLOUD compute instances create ${INSTANCE_NAME} \
   --boot-disk-type ${DISK_TYPE} \
   --boot-disk-size ${BOOT_DISK_SIZE} \
   --local-ssd interface=nvme \
-  --local-ssd interface=nvme \
-  --local-ssd interface=nvme \
   --local-ssd interface=nvme
 
 # Run multi-host test


### PR DESCRIPTION
This PR reduces the Slack notification noise from the `mtest` job and right-sizes the GCE instance it provisions, so a single failure no longer floods Slack and the job stops requesting scarce, oversized hardware that kept failing to schedule.

## Background

`mtest` is a 5-suite matrix (`functions, robustness, operators, reboot, repair`), each provisioning its own GCE instance in a single zone (`asia-northeast1-c`).

- With `fail-fast` (default) enabled, one failing suite cancels the other four. The `Notify to Slack` step ran on `failure() || cancelled()`, so a single real failure produced up to **5 notifications** (1 failure + 4 cancelled). With no `concurrency` control, repeated pushes multiplied this further.
- Each suite requested a `c2-standard-30` (30 vCPU / 120 GB) with **four** local SSDs. This is heavily oversized and provisioned on scarce compute-optimized hardware, so all five instances routinely hit `ZONE_RESOURCE_POOL_EXHAUSTED` at once.

## Changes

**Notification noise**
1. Gate `Notify to Slack` and `Set the instance lifetime` on `failure()` only (drop `cancelled()`), so only the suite that actually failed notifies and keeps its debug instance.
2. Add a `concurrency` group with `cancel-in-progress: true` so superseded runs on the same ref are cancelled instead of accumulating (safe now that notifications no longer fire on cancellation).
3. Align the notification with meows' slack-agent format: red color bar `#ff4b00`, a `Failure: <actor>'s workflow in <repo>` heading, and `Workflow` / `Instance` labeled fields. The Extend button is unchanged.

**Instance right-sizing**
4. Switch the mtest instance from `c2-standard-30` to `n2-standard-16` (`bin/env`). The guest workload is small — `cluster.yml` boots 8 VMs of 1 vCPU / 3 GB (8 vCPU / 24 GB total) — so 16 vCPU / 64 GB is ample, and N2 is a far more abundant family that still supports nested virtualization.
5. Cut the local SSDs from four to two (`bin/run-mtest.sh`). `run.sh` only ever formats and mounts `/dev/nvme0n1` on `/var/scratch`; the extra disks were attached but never used (no RAID, no extra mounts). `n2-standard-16` only accepts a local SSD count of `0, 2, 4, 8, 16, or 24`, so two is the minimum non-zero count (`run.sh` still uses only the first). Fewer local SSDs also loosens host placement.

## Effect

- Per single failure: **5 messages → 1**. `fail-fast` behavior is unchanged.
- The instance drops from 30→16 vCPU and 4→2 local SSDs on a much more available family, so scheduling should no longer routinely hit `ZONE_RESOURCE_POOL_EXHAUSTED`.
