### PR TITLE
Issue client certificates for cke:user:admin by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project employs a versioning scheme described in [RELEASE.md](RELEASE.md#ve
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING** `ckecli kubernetes issue` now issues certificates for `cke:user:admin` instead of `admin`, so that audit logs can tell operators from CKE itself (pass `--user=admin` to restore the old name) in [#911](https://github.com/cybozu-go/cke/pull/911)
+
 ## [1.35.3]
 
 ### Changed

--- a/docs/ckecli.md
+++ b/docs/ckecli.md
@@ -239,7 +239,17 @@ This config file embeds client certificate and can be used with `kubectl` to con
 | --------- | ---------------- | ------------------------------------------- |
 | `--ttl`   | `2h`             | TTL of the client certificate               |
 | `--group` | `system:masters` | organization name of the client certificate |
-| `--user`  | `admin`          | user name of the client certificate         |
+| `--user`  | `cke:user:admin` | user name of the client certificate         |
+
+Certificates issued by this command are named under the `cke:user:` prefix by
+convention, while CKE itself uses `admin`.  Keeping the two apart lets audit logs
+attribute a request to a person rather than to CKE, and lets an admission webhook
+match on `request.userInfo.username.startsWith("cke:user:")`.
+
+Pass `--user=cke:user:alice` to be identified individually in audit logs.  The
+value is used verbatim, so `--user=admin` reproduces the user name of CKE 1.35.3
+and earlier.  Giving `--user` explicitly also suppresses the notice this command
+writes to stderr about the changed default, which is useful in scripts.
 
 ## `ckecli resource`
 

--- a/example/README.md
+++ b/example/README.md
@@ -111,6 +111,9 @@ $ KUBECONFIG=$(pwd)/.kubeconfig
 $ export KUBECONFIG
 ```
 
+The certificate is issued for `cke:user:admin` by default.
+Pass `--user=cke:user:YOURNAME` to be identified individually in audit logs.
+
 ## Setup CNI plugin
 
 CKE itself does not install any network plugins.

--- a/pkg/ckecli/cmd/kubernetes_issue.go
+++ b/pkg/ckecli/cmd/kubernetes_issue.go
@@ -26,6 +26,7 @@ var kubernetesIssueCmd = &cobra.Command{
 	Long:  `Issue TLS client certificates for k8s user.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// TODO: delete this notice after CKE 1.35.5.
 		if !cmd.Flags().Changed("user") {
 			// stderr, because stdout carries the kubeconfig.
 			fmt.Fprintf(os.Stderr,

--- a/pkg/ckecli/cmd/kubernetes_issue.go
+++ b/pkg/ckecli/cmd/kubernetes_issue.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 
 	"github.com/cybozu-go/cke"
 	"github.com/cybozu-go/well"
@@ -25,6 +26,14 @@ var kubernetesIssueCmd = &cobra.Command{
 	Long:  `Issue TLS client certificates for k8s user.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if !cmd.Flags().Changed("user") {
+			// stderr, because stdout carries the kubeconfig.
+			fmt.Fprintf(os.Stderr,
+				"issuing a certificate for user %q (previously %q)\n"+
+					"NOTE: pass --user=cke:user:YOURNAME for per-person audit attribution\n",
+				kubernetesIssueOpts.UserName, cke.RoleAdmin)
+		}
+
 		well.Go(func(ctx context.Context) error {
 			cluster, err := storage.GetCluster(ctx)
 			if err != nil {
@@ -66,6 +75,6 @@ func init() {
 	fs := kubernetesIssueCmd.Flags()
 	fs.StringVar(&kubernetesIssueOpts.TTL, "ttl", "2h", "TTL of the certificate")
 	fs.StringVarP(&kubernetesIssueOpts.GroupName, "group", "g", cke.AdminGroup, "Group name of the issuing config")
-	fs.StringVarP(&kubernetesIssueOpts.UserName, "user", "u", cke.RoleAdmin, "User name of the issuing config")
+	fs.StringVarP(&kubernetesIssueOpts.UserName, "user", "u", cke.DefaultUserName, "User name of the issuing config")
 	kubernetesCmd.AddCommand(kubernetesIssueCmd)
 }

--- a/pkg/ckecli/cmd/kubernetes_issue_test.go
+++ b/pkg/ckecli/cmd/kubernetes_issue_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/cybozu-go/cke"
+)
+
+func TestKubernetesIssueDefaults(t *testing.T) {
+	// CKE itself issues certificates for cke.RoleAdmin.  Should this command
+	// ever default to the same name again, audit logs would no longer be able
+	// to tell a human operator from CKE's own reconciliation.
+	if cke.DefaultUserName == cke.RoleAdmin {
+		t.Errorf("the default user name must differ from CKE's own %q", cke.RoleAdmin)
+	}
+	if got := kubernetesIssueCmd.Flags().Lookup("user").DefValue; got != cke.DefaultUserName {
+		t.Errorf("--user: expected %q, actual %q", cke.DefaultUserName, got)
+	}
+
+	// Permissions of the issued certificate come from this organization rather
+	// than from the user name, so renaming the user must not disturb it.
+	if got := kubernetesIssueCmd.Flags().Lookup("group").DefValue; got != cke.AdminGroup {
+		t.Errorf("--group: expected %q, actual %q", cke.AdminGroup, got)
+	}
+}

--- a/pki.go
+++ b/pki.go
@@ -54,6 +54,12 @@ const (
 // AdminGroup is the group name of cluster admin users
 const AdminGroup = "system:masters"
 
+// DefaultUserName is the default user name of client certificates issued by
+// "ckecli kubernetes issue".  User names of this command are named under the
+// "cke:user:" prefix by convention, while CKE itself uses RoleAdmin, so that
+// audit logs and admission webhooks can tell CKE's users from CKE itself.
+const DefaultUserName = "cke:user:admin"
+
 // IssueResponse is cli output format.
 type IssueResponse struct {
 	Cert   string `json:"certificate"`


### PR DESCRIPTION
`ckecli kubernetes issue` defaulted to the user name `admin`, which CKE itself also uses to reconcile the cluster. Because both identities were the same string, kube-apiserver audit logs could not tell a human operator from CKE's own reconciliation, and an admission webhook had no way to exclude CKE.

This names certificates issued by the command under a `cke:user:` prefix so the two can be told apart. The default becomes `cke:user:admin`, and the command writes a notice to stderr when `--user` is not given.

Cluster permissions are unaffected: they come from the `system:masters` organization, which is unchanged. `UserKubeconfig` names the context `default` rather than deriving it from the user name, so `kubectl --context=default` keeps working.

**This is a breaking change.** The user name embedded in the kubeconfig changes, so `kubectl --user=admin` and anything reading `.users[0].name` will break. Pass `--user=admin` to restore the previous name. Since MAJOR.MINOR tracks Kubernetes (RELEASE.md), this cannot be signaled by a version bump, which is why the notice goes to stderr.