### PR TITLE
Replace well.CommandContext to local exec helper

### DIFF
--- a/op/exec.go
+++ b/op/exec.go
@@ -1,0 +1,77 @@
+package op
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/cybozu-go/log"
+)
+
+// These errors are returned by runCommand instead of the raw error from cmd.Run().
+// The command, its exit status, stdout, and stderr are already recorded by the log call in runCommand.
+// So returning that same detail again would just duplicate it wherever the caller logs err.
+var (
+	errCommandTimedOut = errors.New("command timed out")
+	errCommandFailed   = errors.New("command failed")
+	errContextDone     = errors.New("context done before command finished")
+)
+
+// runCommand runs a command (command[0] is the executable, the rest are its arguments). It blocks until the command exits.
+// If timeoutSeconds is nonzero, the command is killed after that many seconds; a zero value means no timeout is applied.
+// This function logs the result (elapsed time, stdout, and stderr of the command) and returns the captured stdout.
+func runCommand(ctx context.Context, timeoutSeconds int, command []string) (stdout string, err error) {
+	execCtx := ctx
+	if timeoutSeconds != 0 {
+		var cancel context.CancelFunc
+		execCtx, cancel = context.WithTimeout(ctx, time.Second*time.Duration(timeoutSeconds))
+		defer cancel()
+	}
+
+	cmd := exec.CommandContext(execCtx, command[0], command[1:]...)
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	st := time.Now()
+	err = cmd.Run()
+	et := time.Now()
+	stdout = stdoutBuf.String()
+	stderr := stderrBuf.String()
+
+	fields := map[string]any{
+		log.FnType:         "exec",
+		log.FnResponseTime: et.Sub(st).Seconds(),
+		"command":          strings.Join(command, " "),
+	}
+	if stdout != "" {
+		fields["stdout"] = stdout
+	}
+	if stderr != "" {
+		fields["stderr"] = stderr
+	}
+
+	if err != nil {
+		fields[log.FnError] = err
+
+		// Logs the failure causes in detail here for diagnosability.
+		// The raw error is not returned to the caller since that detail is already recorded in the log.
+		switch {
+		case ctx.Err() != nil:
+			log.Error("exec: context done", fields)
+			return stdout, errContextDone
+		case timeoutSeconds != 0 && execCtx.Err() == context.DeadlineExceeded:
+			log.Error("exec: timed out", fields)
+			return stdout, errCommandTimedOut
+		default:
+			log.Error("exec: failed", fields)
+			return stdout, errCommandFailed
+		}
+	}
+
+	log.Info("exec: succeeded", fields)
+	return stdout, nil
+}

--- a/op/reboot.go
+++ b/op/reboot.go
@@ -399,18 +399,11 @@ func (c rebootRebootCommand) Run(ctx context.Context, inf cke.Infrastructure, _ 
 			}
 		RETRY:
 			for i := 0; i < attempts; i++ {
-				err := func() error {
-					ctx := ctx
-					if c.timeoutSeconds != nil && *c.timeoutSeconds != 0 {
-						var cancel context.CancelFunc
-						ctx, cancel = context.WithTimeout(ctx, time.Second*time.Duration(*c.timeoutSeconds))
-						defer cancel()
-					}
-
-					args := append(c.command[1:], entry.Node)
-					command := well.CommandContext(ctx, c.command[0], args...)
-					return command.Run()
-				}()
+				var timeout int
+				if c.timeoutSeconds != nil {
+					timeout = *c.timeoutSeconds
+				}
+				_, err := runCommand(ctx, timeout, append(c.command, entry.Node))
 				if err == nil {
 					return nil
 				}

--- a/op/reboot_decide.go
+++ b/op/reboot_decide.go
@@ -3,11 +3,11 @@ package op
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/cybozu-go/log"
-	"github.com/cybozu-go/well"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -400,37 +400,20 @@ func CheckRebootCancelled(ctx context.Context, c *cke.Cluster, rqEntries []*cke.
 }
 
 func rebootCompleted(ctx context.Context, c *cke.Cluster, entry *cke.RebootQueueEntry) bool {
-	if c.Reboot.CommandTimeoutSeconds != nil && *c.Reboot.CommandTimeoutSeconds != 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, time.Second*time.Duration(*c.Reboot.CommandTimeoutSeconds))
-		defer cancel()
+	var timeout int
+	if c.Reboot.CommandTimeoutSeconds != nil {
+		timeout = *c.Reboot.CommandTimeoutSeconds
 	}
 
-	result := false
-
-	env := well.NewEnvironment(ctx)
-	env.Go(func(ctx context.Context) error {
-		args := append(c.Reboot.BootCheckCommand[1:], entry.Node, fmt.Sprintf("%d", entry.LastTransitionTime.Unix()))
-		command := well.CommandContext(ctx, c.Reboot.BootCheckCommand[0], args...)
-		stdout, err := command.Output()
-		if err != nil {
-			return err
-		}
-
-		if strings.TrimSuffix(string(stdout), "\n") == "true" {
-			result = true
-		}
-		return nil
-	})
-	env.Stop()
-	err := env.Wait()
+	stdout, err := runCommand(ctx, timeout, append(c.Reboot.BootCheckCommand, entry.Node, strconv.FormatInt(entry.LastTransitionTime.Unix(), 10)))
 	if err != nil {
 		log.Warn("failed to check boot", map[string]any{
-			"name": entry.Node,
+			log.FnError: err,
+			"name":      entry.Node,
 		})
 		return false
 	}
-	return result
+	return strings.TrimSpace(stdout) == "true"
 }
 
 func checkVolumesInUse(ctx context.Context, cs kubernetes.Interface, node string) (bool, error) {

--- a/op/repair_execute.go
+++ b/op/repair_execute.go
@@ -1,13 +1,11 @@
 package op
 
 import (
-	"bytes"
 	"context"
 	"strings"
 	"time"
 
 	"github.com/cybozu-go/log"
-	"github.com/cybozu-go/well"
 
 	"github.com/cybozu-go/cke"
 )
@@ -76,31 +74,18 @@ func (c repairExecuteCommand) Run(ctx context.Context, inf cke.Infrastructure, _
 	}
 RETRY:
 	for i := 0; i < attempts; i++ {
-		var stderr bytes.Buffer
-		err := func() error {
-			ctx := ctx
-			timeout := cke.DefaultRepairCommandTimeoutSeconds
-			if c.timeoutSeconds != nil {
-				timeout = *c.timeoutSeconds
-			}
-			if timeout != 0 {
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithTimeout(ctx, time.Second*time.Duration(timeout))
-				defer cancel()
-			}
-
-			args := append(c.command[1:], c.entry.Address)
-			command := well.CommandContext(ctx, c.command[0], args...)
-			command.Stderr = &stderr
-			return command.Run()
-		}()
+		timeout := cke.DefaultRepairCommandTimeoutSeconds
+		if c.timeoutSeconds != nil {
+			timeout = *c.timeoutSeconds
+		}
+		_, err := runCommand(ctx, timeout, append(c.command, c.entry.Address))
 		if err == nil {
 			return nil
 		}
 
 		log.Warn("failed on executing repair command", map[string]any{
 			log.FnError: err,
-			"stderr":    stderr.String(),
+			"index":     c.entry.Index,
 			"address":   c.entry.Address,
 			"command":   strings.Join(c.command, " "),
 			"attempts":  i,
@@ -116,6 +101,7 @@ RETRY:
 
 	// The failure of a repair command should not be considered as a serious error of CKE.
 	log.Warn("given up repairing machine", map[string]any{
+		"index":   c.entry.Index,
 		"address": c.entry.Address,
 		"command": strings.Join(c.command, " "),
 	})

--- a/op/repair_finish.go
+++ b/op/repair_finish.go
@@ -1,12 +1,10 @@
 package op
 
 import (
-	"bytes"
 	"context"
 	"time"
 
 	"github.com/cybozu-go/log"
-	"github.com/cybozu-go/well"
 
 	"github.com/cybozu-go/cke"
 )
@@ -69,7 +67,6 @@ func repairFinish(ctx context.Context, inf cke.Infrastructure, entry *cke.Repair
 	if succeeded {
 		entry.Status = cke.RepairStatusSucceeded
 		// execute Success command
-		var stderr bytes.Buffer
 		err := func() error {
 			op, err := entry.GetMatchingRepairOperation(cluster)
 			if err != nil {
@@ -78,26 +75,17 @@ func repairFinish(ctx context.Context, inf cke.Infrastructure, entry *cke.Repair
 			if op.SuccessCommand == nil {
 				return nil
 			}
-			ctx := ctx
 			timeout := cke.DefaultRepairSuccessCommandTimeoutSeconds
 			if op.SuccessCommandTimeout != nil {
 				timeout = *op.SuccessCommandTimeout
 			}
-			if timeout != 0 {
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithTimeout(ctx, time.Second*time.Duration(timeout))
-				defer cancel()
-			}
-			args := append(op.SuccessCommand[1:], entry.Address)
-			command := well.CommandContext(ctx, op.SuccessCommand[0], args...)
-			command.Stderr = &stderr
-			return command.Run()
+			_, err = runCommand(ctx, timeout, append(op.SuccessCommand, entry.Address))
+			return err
 		}()
 		if err != nil {
 			entry.Status = cke.RepairStatusFailed
 			log.Warn("SuccessCommand failed", map[string]any{
 				log.FnError: err,
-				"stderr":    stderr.String(),
 				"index":     entry.Index,
 				"address":   entry.Address,
 			})

--- a/op/status.go
+++ b/op/status.go
@@ -10,10 +10,8 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/cybozu-go/log"
-	"github.com/cybozu-go/well"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -651,19 +649,12 @@ func isRepairTargetHealthy(ctx context.Context, entry *cke.RepairQueueEntry, clu
 	if op.CommandTimeoutSeconds != nil {
 		timeout = *op.CommandTimeoutSeconds
 	}
-	if timeout != 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, time.Second*time.Duration(timeout))
-		defer cancel()
-	}
 
-	args := append(op.HealthCheckCommand[1:], entry.Address)
-	command := well.CommandContext(ctx, op.HealthCheckCommand[0], args...)
-	stdout, err := command.Output()
+	stdout, err := runCommand(ctx, timeout, append(op.HealthCheckCommand, entry.Address))
 	if err != nil {
 		return false, err
 	}
-	return strings.TrimSpace(string(stdout)) == "true", nil
+	return strings.TrimSpace(stdout) == "true", nil
 }
 
 func GetRebootQueueStatus(ctx context.Context, inf cke.Infrastructure, n *cke.Node, cluster *cke.Cluster, apiServers map[string]bool) (cke.RebootQueueStatus, error) {


### PR DESCRIPTION
This PR changes the function for calling external commands in the reboot queue and the repair queue.

Previously, when an external command failed, only its stderr was recorded in the log; stdout was discarded.
As a result, when a command printed its actual error to stdout, that error was never logged.
And it making failure investigation impossible.

To fix this, I created a helper function to call an external command and replaced `well.CommandContext` with it.