### PR TITLE
Unify reboot/repair operation logging

### DIFF
--- a/op/constants.go
+++ b/op/constants.go
@@ -77,6 +77,13 @@ const (
 	ControllerManagerKubeConfigPath = "/etc/kubernetes/controller-manager/kubeconfig"
 )
 
+const (
+	// fnTypeReboot is the log.FnType value for reboot operation logs.
+	fnTypeReboot = "reboot"
+	// fnTypeRepair is the log.FnType value for repair operation logs.
+	fnTypeRepair = "repair"
+)
+
 // EtcdPKIPath returns a certificate file path for k8s.
 func EtcdPKIPath(p string) string {
 	return filepath.Join(etcdPKIPath, p)

--- a/op/exec.go
+++ b/op/exec.go
@@ -23,7 +23,7 @@ var (
 // runCommand runs a command (command[0] is the executable, the rest are its arguments). It blocks until the command exits.
 // If timeoutSeconds is nonzero, the command is killed after that many seconds; a zero value means no timeout is applied.
 // This function logs the result (elapsed time, stdout, and stderr of the command) and returns the captured stdout.
-func runCommand(ctx context.Context, timeoutSeconds int, command []string) (stdout string, err error) {
+func runCommand(ctx context.Context, timeoutSeconds int, fnType string, command []string) (stdout string, err error) {
 	execCtx := ctx
 	if timeoutSeconds != 0 {
 		var cancel context.CancelFunc
@@ -43,7 +43,7 @@ func runCommand(ctx context.Context, timeoutSeconds int, command []string) (stdo
 	stderr := stderrBuf.String()
 
 	fields := map[string]any{
-		log.FnType:         "exec",
+		log.FnType:         fnType,
 		log.FnResponseTime: et.Sub(st).Seconds(),
 		"command":          strings.Join(command, " "),
 	}

--- a/op/reboot.go
+++ b/op/reboot.go
@@ -149,18 +149,24 @@ func (c rebootDrainStartCommand) Run(ctx context.Context, inf cke.Infrastructure
 				return fmt.Errorf("failed to cordon node %s: %v", entry.Node, err)
 			}
 			log.Info("start eviction dry-run", map[string]any{
-				"name": entry.Node,
+				log.FnType: fnTypeReboot,
+				"index":    entry.Index,
+				"node":     entry.Node,
 			})
 			err = dryRunEvictOrDeleteNodePod(ctx, cs, entry.Node, protected, c.protectedJobPods)
 			if err != nil {
 				log.Warn("eviction dry-run failed", map[string]any{
-					"name":      entry.Node,
+					log.FnType:  fnTypeReboot,
 					log.FnError: err,
+					"index":     entry.Index,
+					"node":      entry.Node,
 				})
 				return err
 			}
 			log.Info("eviction dry-run succeeded", map[string]any{
-				"name": entry.Node,
+				log.FnType: fnTypeReboot,
+				"index":    entry.Index,
+				"node":     entry.Node,
 			})
 			return nil
 		}()
@@ -178,13 +184,17 @@ func (c rebootDrainStartCommand) Run(ctx context.Context, inf cke.Infrastructure
 	// next, evict pods on each node
 	for _, entry := range evictNodes {
 		log.Info("start eviction", map[string]any{
-			"name": entry.Node,
+			log.FnType: fnTypeReboot,
+			"index":    entry.Index,
+			"node":     entry.Node,
 		})
 		err := evictOrDeleteNodePod(ctx, cs, entry.Node, protected, c.protectedJobPods, c.evictAttempts, c.evictInterval)
 		if err != nil {
 			log.Warn("eviction failed", map[string]any{
-				"name":      entry.Node,
+				log.FnType:  fnTypeReboot,
 				log.FnError: err,
+				"index":     entry.Index,
+				"node":      entry.Node,
 			})
 			c.notifyFailedNode(entry.Node)
 			err = drainBackOff(ctx, inf, entry, err)
@@ -192,7 +202,9 @@ func (c rebootDrainStartCommand) Run(ctx context.Context, inf cke.Infrastructure
 				return err
 			}
 			log.Info("eviction succeeded", map[string]any{
-				"name": entry.Node,
+				log.FnType: fnTypeReboot,
+				"index":    entry.Index,
+				"node":     entry.Node,
 			})
 		}
 	}
@@ -288,13 +300,17 @@ func (c rebootDeleteDaemonSetPodCommand) Run(ctx context.Context, inf cke.Infras
 		// keep entry.Status as RebootStatusDraining and don't update it here.
 
 		log.Info("start deletion of DaemonSet pod", map[string]any{
-			"name": entry.Node,
+			log.FnType: fnTypeReboot,
+			"index":    entry.Index,
+			"node":     entry.Node,
 		})
 		err := deleteOnDeleteDaemonSetPod(ctx, cs, entry.Node)
 		if err != nil {
 			log.Warn("deletion of DaemonSet pod failed", map[string]any{
-				"name":      entry.Node,
+				log.FnType:  fnTypeReboot,
 				log.FnError: err,
+				"index":     entry.Index,
+				"node":      entry.Node,
 			})
 			c.notifyFailedNode(entry.Node)
 		}
@@ -403,13 +419,15 @@ func (c rebootRebootCommand) Run(ctx context.Context, inf cke.Infrastructure, _ 
 				if c.timeoutSeconds != nil {
 					timeout = *c.timeoutSeconds
 				}
-				_, err := runCommand(ctx, timeout, append(c.command, entry.Node))
+				_, err := runCommand(ctx, timeout, fnTypeReboot, append(c.command, entry.Node))
 				if err == nil {
 					return nil
 				}
 
 				log.Warn("failed on rebooting node", map[string]any{
+					log.FnType:  fnTypeReboot,
 					log.FnError: err,
+					"index":     entry.Index,
 					"node":      entry.Node,
 					"attempts":  i,
 				})
@@ -423,7 +441,9 @@ func (c rebootRebootCommand) Run(ctx context.Context, inf cke.Infrastructure, _ 
 			}
 			c.notifyFailedNode(entry.Node)
 			log.Warn("given up rebooting node", map[string]any{
-				"node": entry.Node,
+				log.FnType: fnTypeReboot,
+				"index":    entry.Index,
+				"node":     entry.Node,
 			})
 			return nil
 		})
@@ -680,8 +700,10 @@ func listProtectedNamespaces(ctx context.Context, cs kubernetes.Interface, ls *m
 
 func drainBackOff(ctx context.Context, inf cke.Infrastructure, entry *cke.RebootQueueEntry, err error) error {
 	log.Warn("failed to drain node", map[string]any{
-		"name":      entry.Node,
+		log.FnType:  fnTypeReboot,
 		log.FnError: err,
+		"index":     entry.Index,
+		"node":      entry.Node,
 	})
 	etcdEntry, err := inf.Storage().GetRebootsEntry(ctx, entry.Index)
 	if err != nil {

--- a/op/reboot_decide.go
+++ b/op/reboot_decide.go
@@ -405,11 +405,13 @@ func rebootCompleted(ctx context.Context, c *cke.Cluster, entry *cke.RebootQueue
 		timeout = *c.Reboot.CommandTimeoutSeconds
 	}
 
-	stdout, err := runCommand(ctx, timeout, append(c.Reboot.BootCheckCommand, entry.Node, strconv.FormatInt(entry.LastTransitionTime.Unix(), 10)))
+	stdout, err := runCommand(ctx, timeout, fnTypeReboot, append(c.Reboot.BootCheckCommand, entry.Node, strconv.FormatInt(entry.LastTransitionTime.Unix(), 10)))
 	if err != nil {
 		log.Warn("failed to check boot", map[string]any{
+			log.FnType:  fnTypeReboot,
 			log.FnError: err,
-			"name":      entry.Node,
+			"index":     entry.Index,
+			"node":      entry.Node,
 		})
 		return false
 	}

--- a/op/repair_drain_start.go
+++ b/op/repair_drain_start.go
@@ -92,18 +92,24 @@ func (c repairDrainStartCommand) Run(ctx context.Context, inf cke.Infrastructure
 		}
 
 		log.Info("start eviction dry-run", map[string]any{
-			"address": c.entry.Address,
+			log.FnType: fnTypeRepair,
+			"index":    c.entry.Index,
+			"address":  c.entry.Address,
 		})
 		err = dryRunEvictOrDeleteNodePod(ctx, cs, c.entry.Nodename, protected, c.protectedJobPods)
 		if err != nil {
 			log.Warn("eviction dry-run failed", map[string]any{
-				"address":   c.entry.Address,
+				log.FnType:  fnTypeRepair,
 				log.FnError: err,
+				"index":     c.entry.Index,
+				"address":   c.entry.Address,
 			})
 			return err
 		}
 		log.Info("eviction dry-run succeeded", map[string]any{
-			"address": c.entry.Address,
+			log.FnType: fnTypeRepair,
+			"index":    c.entry.Index,
+			"address":  c.entry.Address,
 		})
 
 		// Note: The annotation name is shared with reboot operations.
@@ -124,18 +130,24 @@ func (c repairDrainStartCommand) Run(ctx context.Context, inf cke.Infrastructure
 	}
 
 	log.Info("start eviction", map[string]any{
-		"address": c.entry.Address,
+		log.FnType: fnTypeRepair,
+		"index":    c.entry.Index,
+		"address":  c.entry.Address,
 	})
 	err = evictOrDeleteNodePod(ctx, cs, c.entry.Nodename, protected, c.protectedJobPods, c.evictAttempts, c.evictInterval)
 	if err != nil {
 		log.Warn("eviction failed", map[string]any{
-			"address":   c.entry.Address,
+			log.FnType:  fnTypeRepair,
 			log.FnError: err,
+			"index":     c.entry.Index,
+			"address":   c.entry.Address,
 		})
 		return repairDrainBackOff(ctx, inf, c.entry, err)
 	}
 	log.Info("eviction succeeded", map[string]any{
-		"address": c.entry.Address,
+		log.FnType: fnTypeRepair,
+		"index":    c.entry.Index,
+		"address":  c.entry.Address,
 	})
 
 	return nil

--- a/op/repair_drain_timeout.go
+++ b/op/repair_drain_timeout.go
@@ -59,8 +59,10 @@ func (c repairDrainTimeoutCommand) Command() cke.Command {
 
 func repairDrainBackOff(ctx context.Context, inf cke.Infrastructure, entry *cke.RepairQueueEntry, err error) error {
 	log.Warn("failed to drain node for repair", map[string]any{
-		"address":   entry.Address,
+		log.FnType:  fnTypeRepair,
 		log.FnError: err,
+		"index":     entry.Index,
+		"address":   entry.Address,
 	})
 	entry.Status = cke.RepairStatusProcessing
 	entry.StepStatus = cke.RepairStepStatusWaiting

--- a/op/repair_execute.go
+++ b/op/repair_execute.go
@@ -2,7 +2,6 @@ package op
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/cybozu-go/log"
@@ -78,16 +77,16 @@ RETRY:
 		if c.timeoutSeconds != nil {
 			timeout = *c.timeoutSeconds
 		}
-		_, err := runCommand(ctx, timeout, append(c.command, c.entry.Address))
+		_, err := runCommand(ctx, timeout, fnTypeRepair, append(c.command, c.entry.Address))
 		if err == nil {
 			return nil
 		}
 
 		log.Warn("failed on executing repair command", map[string]any{
+			log.FnType:  fnTypeRepair,
 			log.FnError: err,
 			"index":     c.entry.Index,
 			"address":   c.entry.Address,
-			"command":   strings.Join(c.command, " "),
 			"attempts":  i,
 		})
 		if c.interval != nil && *c.interval != 0 {
@@ -101,9 +100,9 @@ RETRY:
 
 	// The failure of a repair command should not be considered as a serious error of CKE.
 	log.Warn("given up repairing machine", map[string]any{
-		"index":   c.entry.Index,
-		"address": c.entry.Address,
-		"command": strings.Join(c.command, " "),
+		log.FnType: fnTypeRepair,
+		"index":    c.entry.Index,
+		"address":  c.entry.Address,
 	})
 	return repairFinish(ctx, inf, c.entry, false, c.cluster)
 }

--- a/op/repair_finish.go
+++ b/op/repair_finish.go
@@ -79,12 +79,13 @@ func repairFinish(ctx context.Context, inf cke.Infrastructure, entry *cke.Repair
 			if op.SuccessCommandTimeout != nil {
 				timeout = *op.SuccessCommandTimeout
 			}
-			_, err = runCommand(ctx, timeout, append(op.SuccessCommand, entry.Address))
+			_, err = runCommand(ctx, timeout, fnTypeRepair, append(op.SuccessCommand, entry.Address))
 			return err
 		}()
 		if err != nil {
 			entry.Status = cke.RepairStatusFailed
 			log.Warn("SuccessCommand failed", map[string]any{
+				log.FnType:  fnTypeRepair,
 				log.FnError: err,
 				"index":     entry.Index,
 				"address":   entry.Address,

--- a/op/status.go
+++ b/op/status.go
@@ -650,7 +650,7 @@ func isRepairTargetHealthy(ctx context.Context, entry *cke.RepairQueueEntry, clu
 		timeout = *op.CommandTimeoutSeconds
 	}
 
-	stdout, err := runCommand(ctx, timeout, append(op.HealthCheckCommand, entry.Address))
+	stdout, err := runCommand(ctx, timeout, fnTypeRepair, append(op.HealthCheckCommand, entry.Address))
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This PR cleans up the log fields emitted by the reboot and repair queues.
It uses `FnType` (defined in `cybozu-go/log`) to make it clear which feature emitted each log entry.