### PR TITLE
Remove well.Go from ckecli commands

### DIFF
--- a/pkg/ckecli/cmd/auto_repair_disable.go
+++ b/pkg/ckecli/cmd/auto_repair_disable.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"context"
-
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -13,11 +10,7 @@ var autoRepairDisableCmd = &cobra.Command{
 	Long:  `Disable sabakan-triggered automatic repair.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			return storage.EnableAutoRepair(ctx, false)
-		})
-		well.Stop()
-		return well.Wait()
+		return storage.EnableAutoRepair(cmd.Context(), false)
 	},
 }
 

--- a/pkg/ckecli/cmd/auto_repair_enable.go
+++ b/pkg/ckecli/cmd/auto_repair_enable.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"context"
-
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -13,11 +10,7 @@ var autoRepairEnableCmd = &cobra.Command{
 	Long:  `Enable sabakan-triggered automatic repair.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			return storage.EnableAutoRepair(ctx, true)
-		})
-		well.Stop()
-		return well.Wait()
+		return storage.EnableAutoRepair(cmd.Context(), true)
 	},
 }
 

--- a/pkg/ckecli/cmd/auto_repair_get_variables.go
+++ b/pkg/ckecli/cmd/auto_repair_get_variables.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"os"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -15,16 +13,12 @@ var autoRepairGetVariablesCmd = &cobra.Command{
 	Long:  `Get the query variables to search non-healthy machines in sabakan.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			data, err := storage.GetAutoRepairQueryVariables(ctx)
-			if err != nil {
-				return err
-			}
-			os.Stdout.Write(data)
-			return nil
-		})
-		well.Stop()
-		return well.Wait()
+		data, err := storage.GetAutoRepairQueryVariables(cmd.Context())
+		if err != nil {
+			return err
+		}
+		os.Stdout.Write(data)
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/auto_repair_is_enabled.go
+++ b/pkg/ckecli/cmd/auto_repair_is_enabled.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -14,16 +12,12 @@ var autoRepairIsEnabledCmd = &cobra.Command{
 	Long:  `Show whether sabakan-triggered automatic repair is enabled or not.  "true" if enabled.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			disabled, err := storage.IsAutoRepairDisabled(ctx)
-			if err != nil {
-				return err
-			}
-			fmt.Println(!disabled)
-			return nil
-		})
-		well.Stop()
-		return well.Wait()
+		disabled, err := storage.IsAutoRepairDisabled(cmd.Context())
+		if err != nil {
+			return err
+		}
+		fmt.Println(!disabled)
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/auto_repair_set_variables.go
+++ b/pkg/ckecli/cmd/auto_repair_set_variables.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 
 	"github.com/cybozu-go/cke/sabakan"
@@ -49,11 +47,7 @@ FILE should contain a JSON object like this:
 			return err
 		}
 
-		well.Go(func(ctx context.Context) error {
-			return storage.SetAutoRepairQueryVariables(ctx, string(data))
-		})
-		well.Stop()
-		return well.Wait()
+		return storage.SetAutoRepairQueryVariables(cmd.Context(), string(data))
 	},
 }
 

--- a/pkg/ckecli/cmd/ca_get.go
+++ b/pkg/ckecli/cmd/ca_get.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"os"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -33,17 +31,13 @@ NAME is one of:
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			pem, err := storage.GetCACertificate(ctx, args[0])
-			if err != nil {
-				return err
-			}
-
-			_, err = os.Stdout.WriteString(pem)
+		pem, err := storage.GetCACertificate(cmd.Context(), args[0])
+		if err != nil {
 			return err
-		})
-		well.Stop()
-		return well.Wait()
+		}
+
+		_, err = os.Stdout.WriteString(pem)
+		return err
 	},
 }
 

--- a/pkg/ckecli/cmd/ca_set.go
+++ b/pkg/ckecli/cmd/ca_set.go
@@ -1,13 +1,11 @@
 package cmd
 
 import (
-	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"os"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -54,11 +52,7 @@ In fact, these CA should be created in Vault.`,
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			return storage.PutCACertificate(ctx, args[0], string(caData))
-		})
-		well.Stop()
-		return well.Wait()
+		return storage.PutCACertificate(cmd.Context(), args[0], string(caData))
 	},
 }
 

--- a/pkg/ckecli/cmd/cluster_get.go
+++ b/pkg/ckecli/cmd/cluster_get.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"os"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 )
@@ -16,22 +14,18 @@ var clusterGetCmd = &cobra.Command{
 	Long:  `Dump cluster configuration stored in etcd.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			cfg, err := storage.GetCluster(ctx)
-			if err != nil {
-				return err
-			}
-
-			b, err := yaml.Marshal(cfg)
-			if err != nil {
-				return nil
-			}
-
-			_, err = os.Stdout.Write(b)
+		cfg, err := storage.GetCluster(cmd.Context())
+		if err != nil {
 			return err
-		})
-		well.Stop()
-		return well.Wait()
+		}
+
+		b, err := yaml.Marshal(cfg)
+		if err != nil {
+			return nil
+		}
+
+		_, err = os.Stdout.Write(b)
+		return err
 	},
 }
 

--- a/pkg/ckecli/cmd/cluster_set.go
+++ b/pkg/ckecli/cmd/cluster_set.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"os"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 
@@ -21,6 +19,8 @@ The file must be either YAML or JSON.`,
 
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
 		b, err := os.ReadFile(args[0])
 		if err != nil {
 			return err
@@ -36,25 +36,21 @@ The file must be either YAML or JSON.`,
 			return err
 		}
 
-		well.Go(func(ctx context.Context) error {
-			constraints, err := storage.GetConstraints(ctx)
-			switch err {
-			case cke.ErrNotFound:
-				constraints = cke.DefaultConstraints()
-				fallthrough
-			case nil:
-				err = constraints.Check(cfg)
-				if err != nil {
-					return err
-				}
-			default:
+		constraints, err := storage.GetConstraints(ctx)
+		switch err {
+		case cke.ErrNotFound:
+			constraints = cke.DefaultConstraints()
+			fallthrough
+		case nil:
+			err = constraints.Check(cfg)
+			if err != nil {
 				return err
 			}
+		default:
+			return err
+		}
 
-			return storage.PutCluster(ctx, cfg)
-		})
-		well.Stop()
-		return well.Wait()
+		return storage.PutCluster(ctx, cfg)
 	},
 }
 

--- a/pkg/ckecli/cmd/constraints_set.go
+++ b/pkg/ckecli/cmd/constraints_set.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"strconv"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 
 	"github.com/cybozu-go/cke"
@@ -66,21 +64,19 @@ VALUE is an integer.`,
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			cstr, err := storage.GetConstraints(ctx)
-			switch err {
-			case cke.ErrNotFound:
-				cstr = cke.DefaultConstraints()
-			case nil:
-			default:
-				return err
-			}
+		ctx := cmd.Context()
 
-			cstrSet(cstr)
-			return storage.PutConstraints(ctx, cstr)
-		})
-		well.Stop()
-		return well.Wait()
+		cstr, err := storage.GetConstraints(ctx)
+		switch err {
+		case cke.ErrNotFound:
+			cstr = cke.DefaultConstraints()
+		case nil:
+		default:
+			return err
+		}
+
+		cstrSet(cstr)
+		return storage.PutConstraints(ctx, cstr)
 	},
 }
 

--- a/pkg/ckecli/cmd/constraints_show.go
+++ b/pkg/ckecli/cmd/constraints_show.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -16,18 +14,14 @@ var constraintsShowCmd = &cobra.Command{
 	Long:  `Show the list of current constraint values.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			cstr, err := storage.GetConstraints(ctx)
-			if err != nil {
-				return err
-			}
+		cstr, err := storage.GetConstraints(cmd.Context())
+		if err != nil {
+			return err
+		}
 
-			enc := json.NewEncoder(os.Stdout)
-			enc.SetIndent("", "    ")
-			return enc.Encode(cstr)
-		})
-		well.Stop()
-		return well.Wait()
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "    ")
+		return enc.Encode(cstr)
 	},
 }
 

--- a/pkg/ckecli/cmd/etcd_issue.go
+++ b/pkg/ckecli/cmd/etcd_issue.go
@@ -1,13 +1,11 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 
 	"github.com/cybozu-go/cke"
@@ -42,47 +40,43 @@ NAME is the username of etcd user to be authenticated.`,
 			return errors.New("invalid option: output=" + etcdIssueOpts.Output)
 		}
 
-		well.Go(func(ctx context.Context) error {
-			cert, key, err := cke.IssueEtcdClientCertificate(inf, username, etcdIssueOpts.TTL)
-			if err != nil {
-				return err
-			}
+		cert, key, err := cke.IssueEtcdClientCertificate(inf, username, etcdIssueOpts.TTL)
+		if err != nil {
+			return err
+		}
 
-			cacert, err := storage.GetCACertificate(ctx, cke.CAServer)
-			if err != nil {
-				return err
-			}
+		cacert, err := storage.GetCACertificate(cmd.Context(), cke.CAServer)
+		if err != nil {
+			return err
+		}
 
-			if outputJSON {
-				enc := json.NewEncoder(os.Stdout)
-				enc.SetIndent("", "  ")
-				return enc.Encode(cke.IssueResponse{
-					Cert:   cert,
-					Key:    key,
-					CACert: cacert,
-				})
-			}
+		if outputJSON {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(cke.IssueResponse{
+				Cert:   cert,
+				Key:    key,
+				CACert: cacert,
+			})
+		}
 
-			cacertFile := "etcd-ca.crt"
-			certFile := fmt.Sprintf("etcd-%s.crt", username)
-			keyFile := fmt.Sprintf("etcd-%s.key", username)
-			err = os.WriteFile(cacertFile, []byte(cacert), 0o644)
-			if err != nil {
-				return err
-			}
-			err = os.WriteFile(certFile, []byte(cert), 0o644)
-			if err != nil {
-				return err
-			}
-			err = os.WriteFile(keyFile, []byte(key), 0o600)
-			if err != nil {
-				return err
-			}
-			fmt.Println("cert files: ", cacertFile, certFile, keyFile)
-			return nil
-		})
-		well.Stop()
-		return well.Wait()
+		cacertFile := "etcd-ca.crt"
+		certFile := fmt.Sprintf("etcd-%s.crt", username)
+		keyFile := fmt.Sprintf("etcd-%s.key", username)
+		err = os.WriteFile(cacertFile, []byte(cacert), 0o644)
+		if err != nil {
+			return err
+		}
+		err = os.WriteFile(certFile, []byte(cert), 0o644)
+		if err != nil {
+			return err
+		}
+		err = os.WriteFile(keyFile, []byte(key), 0o600)
+		if err != nil {
+			return err
+		}
+		fmt.Println("cert files: ", cacertFile, certFile, keyFile)
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/etcd_localbackup.go
+++ b/pkg/ckecli/cmd/etcd_localbackup.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/etcdutl/v3/snapshot"
@@ -41,19 +40,17 @@ exceed the maximum specified with --max-backups flag.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
-		well.Go(func(ctx context.Context) error {
-			etcd, err := inf.NewEtcdClient(ctx, nil)
-			if err != nil {
-				return err
-			}
-			err = backup(ctx, etcd)
-			if err != nil {
-				return fmt.Errorf("failed to take a backup: %w", err)
-			}
-			return removeOldBackups()
-		})
-		well.Stop()
-		return well.Wait()
+		ctx := cmd.Context()
+
+		etcd, err := inf.NewEtcdClient(ctx, nil)
+		if err != nil {
+			return err
+		}
+		err = backup(ctx, etcd)
+		if err != nil {
+			return fmt.Errorf("failed to take a backup: %w", err)
+		}
+		return removeOldBackups()
 	},
 }
 

--- a/pkg/ckecli/cmd/etcd_root_issue.go
+++ b/pkg/ckecli/cmd/etcd_root_issue.go
@@ -1,13 +1,11 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 
 	"github.com/cybozu-go/cke"
@@ -24,6 +22,8 @@ var etcdRootIssueCmd = &cobra.Command{
 	Long:  `Issue TLS client certificates for etcd root user.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
 		outputJSON := false
 		switch etcdRootIssueOpts.Output {
 		case "json":
@@ -33,47 +33,43 @@ var etcdRootIssueCmd = &cobra.Command{
 			return errors.New("invalid option: output=" + etcdRootIssueOpts.Output)
 		}
 
-		well.Go(func(ctx context.Context) error {
-			cert, key, err := cke.EtcdCA{}.IssueRoot(ctx, inf)
-			if err != nil {
-				return err
-			}
+		cert, key, err := cke.EtcdCA{}.IssueRoot(ctx, inf)
+		if err != nil {
+			return err
+		}
 
-			cacert, err := storage.GetCACertificate(ctx, cke.CAServer)
-			if err != nil {
-				return err
-			}
+		cacert, err := storage.GetCACertificate(ctx, cke.CAServer)
+		if err != nil {
+			return err
+		}
 
-			if outputJSON {
-				enc := json.NewEncoder(os.Stdout)
-				enc.SetIndent("", "  ")
-				return enc.Encode(cke.IssueResponse{
-					Cert:   cert,
-					Key:    key,
-					CACert: cacert,
-				})
-			}
+		if outputJSON {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(cke.IssueResponse{
+				Cert:   cert,
+				Key:    key,
+				CACert: cacert,
+			})
+		}
 
-			cacertFile := "etcd-ca.crt"
-			certFile := "etcd-root.crt"
-			keyFile := "etcd-root.key"
-			err = os.WriteFile(cacertFile, []byte(cacert), 0o644)
-			if err != nil {
-				return err
-			}
-			err = os.WriteFile(certFile, []byte(cert), 0o644)
-			if err != nil {
-				return err
-			}
-			err = os.WriteFile(keyFile, []byte(key), 0o600)
-			if err != nil {
-				return err
-			}
-			fmt.Println("cert files: ", cacertFile, certFile, keyFile)
-			return nil
-		})
-		well.Stop()
-		return well.Wait()
+		cacertFile := "etcd-ca.crt"
+		certFile := "etcd-root.crt"
+		keyFile := "etcd-root.key"
+		err = os.WriteFile(cacertFile, []byte(cacert), 0o644)
+		if err != nil {
+			return err
+		}
+		err = os.WriteFile(certFile, []byte(cert), 0o644)
+		if err != nil {
+			return err
+		}
+		err = os.WriteFile(keyFile, []byte(key), 0o600)
+		if err != nil {
+			return err
+		}
+		fmt.Println("cert files: ", cacertFile, certFile, keyFile)
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/etcd_useradd.go
+++ b/pkg/ckecli/cmd/etcd_useradd.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 
 	"github.com/cybozu-go/cke"
@@ -36,18 +34,16 @@ PREFIX limits the user's privilege to keys having the prefix.`,
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
 		username := args[0]
 		prefix := args[1]
 
-		well.Go(func(ctx context.Context) error {
-			etcd, err := inf.NewEtcdClient(ctx, nil)
-			if err != nil {
-				return err
-			}
-			return cke.AddUserRole(ctx, etcd, username, prefix)
-		})
-		well.Stop()
-		return well.Wait()
+		etcd, err := inf.NewEtcdClient(ctx, nil)
+		if err != nil {
+			return err
+		}
+		return cke.AddUserRole(ctx, etcd, username, prefix)
 	},
 }
 

--- a/pkg/ckecli/cmd/history.go
+++ b/pkg/ckecli/cmd/history.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -21,40 +19,38 @@ var historyCmd = &cobra.Command{
 	Long:  `Show the hostname of the current history process.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			enc := json.NewEncoder(os.Stdout)
-			enc.SetIndent("", "    ")
+		ctx := cmd.Context()
 
-			if followMode {
-				recordCh, err := storage.WatchRecords(ctx, int64(historyCount))
-				if err != nil {
-					return err
-				}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "    ")
 
-				for r := range recordCh {
-					err := enc.Encode(r)
-					if err != nil {
-						return err
-					}
-				}
-				return nil
-			}
-
-			records, err := storage.GetRecords(ctx, int64(historyCount))
+		if followMode {
+			recordCh, err := storage.WatchRecords(ctx, int64(historyCount))
 			if err != nil {
 				return err
 			}
 
-			for _, r := range records {
-				err = enc.Encode(r)
+			for r := range recordCh {
+				err := enc.Encode(r)
 				if err != nil {
 					return err
 				}
 			}
 			return nil
-		})
-		well.Stop()
-		return well.Wait()
+		}
+
+		records, err := storage.GetRecords(ctx, int64(historyCount))
+		if err != nil {
+			return err
+		}
+
+		for _, r := range records {
+			err = enc.Encode(r)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/kubernetes_issue.go
+++ b/pkg/ckecli/cmd/kubernetes_issue.go
@@ -1,13 +1,11 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net"
 	"os"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -27,6 +25,8 @@ var kubernetesIssueCmd = &cobra.Command{
 	Long:  `Issue TLS client certificates for k8s user.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
 		// TODO: delete this notice after CKE 1.35.5.
 		if !cmd.Flags().Changed("user") {
 			// stderr, because stdout carries the kubeconfig.
@@ -36,40 +36,36 @@ var kubernetesIssueCmd = &cobra.Command{
 				kubernetesIssueOpts.UserName, cke.RoleAdmin)
 		}
 
-		well.Go(func(ctx context.Context) error {
-			cluster, err := storage.GetCluster(ctx)
-			if err != nil {
-				return err
-			}
-
-			server := "https://kubernetes.default.svc"
-			if _, err := net.LookupHost("kubernetes.default.svc"); err != nil {
-				cpNodes := cke.ControlPlanes(cluster.Nodes)
-				if len(cpNodes) == 0 {
-					return errors.New("no control plane")
-				}
-				server = "https://" + cpNodes[0].Address + ":6443"
-			}
-
-			cacert, err := storage.GetCACertificate(ctx, cke.CAKubernetes)
-			if err != nil {
-				return err
-			}
-
-			cert, key, err := cke.KubernetesCA{}.IssueUserCert(ctx, inf, kubernetesIssueOpts.UserName, kubernetesIssueOpts.GroupName, kubernetesIssueOpts.TTL)
-			if err != nil {
-				return err
-			}
-			cfg := cke.UserKubeconfig(cluster.Name, kubernetesIssueOpts.UserName, cacert, cert, key, server)
-			src, err := clientcmd.Write(*cfg)
-			if err != nil {
-				return err
-			}
-			_, err = fmt.Println(string(src))
+		cluster, err := storage.GetCluster(ctx)
+		if err != nil {
 			return err
-		})
-		well.Stop()
-		return well.Wait()
+		}
+
+		server := "https://kubernetes.default.svc"
+		if _, err := net.LookupHost("kubernetes.default.svc"); err != nil {
+			cpNodes := cke.ControlPlanes(cluster.Nodes)
+			if len(cpNodes) == 0 {
+				return errors.New("no control plane")
+			}
+			server = "https://" + cpNodes[0].Address + ":6443"
+		}
+
+		cacert, err := storage.GetCACertificate(ctx, cke.CAKubernetes)
+		if err != nil {
+			return err
+		}
+
+		cert, key, err := cke.KubernetesCA{}.IssueUserCert(ctx, inf, kubernetesIssueOpts.UserName, kubernetesIssueOpts.GroupName, kubernetesIssueOpts.TTL)
+		if err != nil {
+			return err
+		}
+		cfg := cke.UserKubeconfig(cluster.Name, kubernetesIssueOpts.UserName, cacert, cert, key, server)
+		src, err := clientcmd.Write(*cfg)
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Println(string(src))
+		return err
 	},
 }
 

--- a/pkg/ckecli/cmd/leader.go
+++ b/pkg/ckecli/cmd/leader.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -15,17 +13,13 @@ var leaderCmd = &cobra.Command{
 	Long:  `Show the hostname of the current leader process.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			leader, err := storage.GetLeaderHostname(ctx)
-			if err != nil {
-				return err
-			}
+		leader, err := storage.GetLeaderHostname(cmd.Context())
+		if err != nil {
+			return err
+		}
 
-			fmt.Println(leader)
-			return nil
-		})
-		well.Stop()
-		return well.Wait()
+		fmt.Println(leader)
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/reboot_queue_add.go
+++ b/pkg/ckecli/cmd/reboot_queue_add.go
@@ -1,13 +1,11 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 
 	"github.com/cybozu-go/cke"
@@ -22,6 +20,8 @@ The nodes should be specified with their IP addresses.
 If FILE is -, the contents are read from stdin.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
 		f := os.Stdin
 		if args[0] != "-" {
 			var err error
@@ -36,29 +36,25 @@ If FILE is -, the contents are read from stdin.`,
 		if err != nil {
 			return err
 		}
-		nodes := strings.Fields(string(data))
+		nodes := strings.FieldsSeq(string(data))
 
-		well.Go(func(ctx context.Context) error {
-			for _, node := range nodes {
-				entry := cke.NewRebootQueueEntry(node)
-				cluster, err := storage.GetCluster(ctx)
-				if err != nil {
-					return err
-				}
-				err = validateNode(node, cluster)
-				if err != nil {
-					return err
-				}
-
-				err = storage.RegisterRebootsEntry(ctx, entry)
-				if err != nil {
-					return err
-				}
+		for node := range nodes {
+			entry := cke.NewRebootQueueEntry(node)
+			cluster, err := storage.GetCluster(ctx)
+			if err != nil {
+				return err
 			}
-			return nil
-		})
-		well.Stop()
-		return well.Wait()
+			err = validateNode(node, cluster)
+			if err != nil {
+				return err
+			}
+
+			err = storage.RegisterRebootsEntry(ctx, entry)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/reboot_queue_cancel.go
+++ b/pkg/ckecli/cmd/reboot_queue_cancel.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"strconv"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 
 	"github.com/cybozu-go/cke"
@@ -16,22 +14,20 @@ var rebootQueueCancelCmd = &cobra.Command{
 	Long:  `Cancel the specified reboot queue entry.`,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
 		index, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return err
 		}
 
-		well.Go(func(ctx context.Context) error {
-			entry, err := storage.GetRebootsEntry(ctx, index)
-			if err != nil {
-				return err
-			}
+		entry, err := storage.GetRebootsEntry(ctx, index)
+		if err != nil {
+			return err
+		}
 
-			entry.Status = cke.RebootStatusCancelled
-			return storage.UpdateRebootsEntry(ctx, entry)
-		})
-		well.Stop()
-		return well.Wait()
+		entry.Status = cke.RebootStatusCancelled
+		return storage.UpdateRebootsEntry(ctx, entry)
 	},
 }
 

--- a/pkg/ckecli/cmd/reboot_queue_cancel_all.go
+++ b/pkg/ckecli/cmd/reboot_queue_cancel_all.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"context"
-
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 
 	"github.com/cybozu-go/cke"
@@ -15,31 +12,29 @@ var rebootQueueCancelAllCmd = &cobra.Command{
 	Long:  `Cancel all the reboot queue entries.`,
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			entries, err := storage.GetRebootsEntries(ctx)
+		ctx := cmd.Context()
+
+		entries, err := storage.GetRebootsEntries(ctx)
+		if err != nil {
+			return err
+		}
+
+		for _, entry := range entries {
+			if entry.Status == cke.RebootStatusCancelled {
+				continue
+			}
+
+			entry.Status = cke.RebootStatusCancelled
+			err := storage.UpdateRebootsEntry(ctx, entry)
+			if err == cke.ErrNotFound {
+				// The entry has just finished
+				continue
+			}
 			if err != nil {
 				return err
 			}
-
-			for _, entry := range entries {
-				if entry.Status == cke.RebootStatusCancelled {
-					continue
-				}
-
-				entry.Status = cke.RebootStatusCancelled
-				err := storage.UpdateRebootsEntry(ctx, entry)
-				if err == cke.ErrNotFound {
-					// The entry has just finished
-					continue
-				}
-				if err != nil {
-					return err
-				}
-			}
-			return nil
-		})
-		well.Stop()
-		return well.Wait()
+		}
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/reboot_queue_disable.go
+++ b/pkg/ckecli/cmd/reboot_queue_disable.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"context"
-
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -13,11 +10,7 @@ var rebootQueueDisableCmd = &cobra.Command{
 	Long:  `Disable reboot queue processing.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			return storage.EnableRebootQueue(ctx, false)
-		})
-		well.Stop()
-		return well.Wait()
+		return storage.EnableRebootQueue(cmd.Context(), false)
 	},
 }
 

--- a/pkg/ckecli/cmd/reboot_queue_enable.go
+++ b/pkg/ckecli/cmd/reboot_queue_enable.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"context"
-
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -13,11 +10,7 @@ var rebootQueueEnableCmd = &cobra.Command{
 	Long:  `Enable reboot queue processing.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			return storage.EnableRebootQueue(ctx, true)
-		})
-		well.Stop()
-		return well.Wait()
+		return storage.EnableRebootQueue(cmd.Context(), true)
 	},
 }
 

--- a/pkg/ckecli/cmd/reboot_queue_is_enabled.go
+++ b/pkg/ckecli/cmd/reboot_queue_is_enabled.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -14,16 +12,12 @@ var rebootQueueIsEnabledCmd = &cobra.Command{
 	Long:  `Show whether the processing of the reboot queue is enabled or not.  "true" if enabled.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			disabled, err := storage.IsRebootQueueDisabled(ctx)
-			if err != nil {
-				return err
-			}
-			fmt.Println(!disabled)
-			return nil
-		})
-		well.Stop()
-		return well.Wait()
+		disabled, err := storage.IsRebootQueueDisabled(cmd.Context())
+		if err != nil {
+			return err
+		}
+		fmt.Println(!disabled)
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/reboot_queue_list.go
+++ b/pkg/ckecli/cmd/reboot_queue_list.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,7 +8,6 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -25,36 +23,32 @@ var rebootQueueListCmd = &cobra.Command{
 The output is a list of RebootQueueEntry formatted in JSON.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			if rebootQueueListOptions.Output != "json" && rebootQueueListOptions.Output != "simple" {
-				return errors.New("invalid output format")
-			}
-			entries, err := storage.GetRebootsEntries(ctx)
-			if err != nil {
+		if rebootQueueListOptions.Output != "json" && rebootQueueListOptions.Output != "simple" {
+			return errors.New("invalid output format")
+		}
+		entries, err := storage.GetRebootsEntries(cmd.Context())
+		if err != nil {
+			return err
+		}
+		if rebootQueueListOptions.Output == "simple" {
+			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 1, 1, ' ', 0)
+			if _, err := w.Write([]byte("Index\tNode\tStatus\tLastTransitionTime\tDrainBackOffCount\tDrainBackOffExpire\n")); err != nil {
 				return err
 			}
-			if rebootQueueListOptions.Output == "simple" {
-				w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 1, 1, ' ', 0)
-				if _, err := w.Write([]byte("Index\tNode\tStatus\tLastTransitionTime\tDrainBackOffCount\tDrainBackOffExpire\n")); err != nil {
-					return err
-				}
-				for _, entry := range entries {
-					if _, err := fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t\n", entry.Index, entry.Node, entry.Status, entry.LastTransitionTime.Format(time.RFC3339), entry.DrainBackOffCount, entry.DrainBackOffExpire.Format(time.RFC3339)); err != nil {
-						return err
-					}
-				}
-				return w.Flush()
-			} else {
-				enc := json.NewEncoder(os.Stdout)
-				enc.SetIndent("", "    ")
-				if err := enc.Encode(entries); err != nil {
+			for _, entry := range entries {
+				if _, err := fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t\n", entry.Index, entry.Node, entry.Status, entry.LastTransitionTime.Format(time.RFC3339), entry.DrainBackOffCount, entry.DrainBackOffExpire.Format(time.RFC3339)); err != nil {
 					return err
 				}
 			}
-			return nil
-		})
-		well.Stop()
-		return well.Wait()
+			return w.Flush()
+		} else {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "    ")
+			if err := enc.Encode(entries); err != nil {
+				return err
+			}
+		}
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/reboot_queue_reset_backoff.go
+++ b/pkg/ckecli/cmd/reboot_queue_reset_backoff.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"time"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 
 	"github.com/cybozu-go/cke"
@@ -15,27 +13,25 @@ var rebootQueueResetBackoffCmd = &cobra.Command{
 	Short: "Reset drain backoff of the entries in reboot queue",
 	Long:  `Reset drain_backoff_count and drain_backoff_expire of the entries in reboot queue`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			entries, err := storage.GetRebootsEntries(ctx)
+		ctx := cmd.Context()
+
+		entries, err := storage.GetRebootsEntries(ctx)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			entry.DrainBackOffCount = 0
+			entry.DrainBackOffExpire = time.Time{}
+			err := storage.UpdateRebootsEntry(ctx, entry)
+			if err == cke.ErrNotFound {
+				// The entry has just finished
+				continue
+			}
 			if err != nil {
 				return err
 			}
-			for _, entry := range entries {
-				entry.DrainBackOffCount = 0
-				entry.DrainBackOffExpire = time.Time{}
-				err := storage.UpdateRebootsEntry(ctx, entry)
-				if err == cke.ErrNotFound {
-					// The entry has just finished
-					continue
-				}
-				if err != nil {
-					return err
-				}
-			}
-			return nil
-		})
-		well.Stop()
-		return well.Wait()
+		}
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/repair_queue_add.go
+++ b/pkg/ckecli/cmd/repair_queue_add.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"context"
-
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 
 	"github.com/cybozu-go/cke"
@@ -19,6 +16,8 @@ The machine should be processed with an operation OPERATION.
 Optionally, you can specify the machine's serial number as the fourth argument.`,
 	Args: cobra.RangeArgs(3, 4),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
 		operation := args[0]
 		machineType := args[1]
 		address := args[2]
@@ -27,20 +26,16 @@ Optionally, you can specify the machine's serial number as the fourth argument.`
 			serial = args[3]
 		}
 
-		well.Go(func(ctx context.Context) error {
-			entry := cke.NewRepairQueueEntry(operation, machineType, address, serial)
-			cluster, err := storage.GetCluster(ctx)
-			if err != nil {
-				return err
-			}
-			if _, err := entry.GetMatchingRepairOperation(cluster); err != nil {
-				return err
-			}
+		entry := cke.NewRepairQueueEntry(operation, machineType, address, serial)
+		cluster, err := storage.GetCluster(ctx)
+		if err != nil {
+			return err
+		}
+		if _, err := entry.GetMatchingRepairOperation(cluster); err != nil {
+			return err
+		}
 
-			return storage.RegisterRepairsEntry(ctx, entry)
-		})
-		well.Stop()
-		return well.Wait()
+		return storage.RegisterRepairsEntry(ctx, entry)
 	},
 }
 

--- a/pkg/ckecli/cmd/repair_queue_delete.go
+++ b/pkg/ckecli/cmd/repair_queue_delete.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"strconv"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -14,26 +12,24 @@ var repairQueueDeleteCmd = &cobra.Command{
 	Long:  `Delete the specified repair queue entry.`,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
 		index, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			return err
 		}
 
-		well.Go(func(ctx context.Context) error {
-			entry, err := storage.GetRepairsEntry(ctx, index)
-			if err != nil {
-				return err
-			}
+		entry, err := storage.GetRepairsEntry(ctx, index)
+		if err != nil {
+			return err
+		}
 
-			if entry.Deleted {
-				return nil
-			}
+		if entry.Deleted {
+			return nil
+		}
 
-			entry.Deleted = true
-			return storage.UpdateRepairsEntry(ctx, entry)
-		})
-		well.Stop()
-		return well.Wait()
+		entry.Deleted = true
+		return storage.UpdateRepairsEntry(ctx, entry)
 	},
 }
 

--- a/pkg/ckecli/cmd/repair_queue_delete_finished.go
+++ b/pkg/ckecli/cmd/repair_queue_delete_finished.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 
 	"github.com/cybozu-go/cke"
@@ -19,34 +17,32 @@ Entries in "succeeded" or "failed" status are deleted.
 This displays the index numbers of deleted entries, one per line.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			entries, err := storage.GetRepairsEntries(ctx)
+		ctx := cmd.Context()
+
+		entries, err := storage.GetRepairsEntries(ctx)
+		if err != nil {
+			return err
+		}
+
+		for _, entry := range entries {
+			if entry.Deleted || !entry.HasFinished() {
+				continue
+			}
+
+			entry.Deleted = true
+			err := storage.UpdateRepairsEntry(ctx, entry)
+			if err == cke.ErrNotFound {
+				// The entry has just been dequeued.
+				continue
+			}
 			if err != nil {
 				return err
 			}
 
-			for _, entry := range entries {
-				if entry.Deleted || !entry.HasFinished() {
-					continue
-				}
+			fmt.Println(entry.Index)
+		}
 
-				entry.Deleted = true
-				err := storage.UpdateRepairsEntry(ctx, entry)
-				if err == cke.ErrNotFound {
-					// The entry has just been dequeued.
-					continue
-				}
-				if err != nil {
-					return err
-				}
-
-				fmt.Println(entry.Index)
-			}
-
-			return nil
-		})
-		well.Stop()
-		return well.Wait()
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/repair_queue_delete_unfinished.go
+++ b/pkg/ckecli/cmd/repair_queue_delete_unfinished.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 
 	"github.com/cybozu-go/cke"
@@ -19,34 +17,32 @@ Entries not in "succeeded" or "failed" status are deleted.
 This displays the index numbers of deleted entries, one per line.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			entries, err := storage.GetRepairsEntries(ctx)
+		ctx := cmd.Context()
+
+		entries, err := storage.GetRepairsEntries(ctx)
+		if err != nil {
+			return err
+		}
+
+		for _, entry := range entries {
+			if entry.Deleted || entry.HasFinished() {
+				continue
+			}
+
+			entry.Deleted = true
+			err := storage.UpdateRepairsEntry(ctx, entry)
+			if err == cke.ErrNotFound {
+				// The entry has just been dequeued.
+				continue
+			}
 			if err != nil {
 				return err
 			}
 
-			for _, entry := range entries {
-				if entry.Deleted || entry.HasFinished() {
-					continue
-				}
+			fmt.Println(entry.Index)
+		}
 
-				entry.Deleted = true
-				err := storage.UpdateRepairsEntry(ctx, entry)
-				if err == cke.ErrNotFound {
-					// The entry has just been dequeued.
-					continue
-				}
-				if err != nil {
-					return err
-				}
-
-				fmt.Println(entry.Index)
-			}
-
-			return nil
-		})
-		well.Stop()
-		return well.Wait()
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/repair_queue_disable.go
+++ b/pkg/ckecli/cmd/repair_queue_disable.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"context"
-
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -13,11 +10,7 @@ var repairQueueDisableCmd = &cobra.Command{
 	Long:  `Disable repair queue processing.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			return storage.EnableRepairQueue(ctx, false)
-		})
-		well.Stop()
-		return well.Wait()
+		return storage.EnableRepairQueue(cmd.Context(), false)
 	},
 }
 

--- a/pkg/ckecli/cmd/repair_queue_enable.go
+++ b/pkg/ckecli/cmd/repair_queue_enable.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"context"
-
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -13,11 +10,7 @@ var repairQueueEnableCmd = &cobra.Command{
 	Long:  `Enable repair queue processing.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			return storage.EnableRepairQueue(ctx, true)
-		})
-		well.Stop()
-		return well.Wait()
+		return storage.EnableRepairQueue(cmd.Context(), true)
 	},
 }
 

--- a/pkg/ckecli/cmd/repair_queue_is_enabled.go
+++ b/pkg/ckecli/cmd/repair_queue_is_enabled.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -14,16 +12,12 @@ var repairQueueIsEnabledCmd = &cobra.Command{
 	Long:  `Show whether the processing of the repair queue is enabled or not.  "true" if enabled.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			disabled, err := storage.IsRepairQueueDisabled(ctx)
-			if err != nil {
-				return err
-			}
-			fmt.Println(!disabled)
-			return nil
-		})
-		well.Stop()
-		return well.Wait()
+		disabled, err := storage.IsRepairQueueDisabled(cmd.Context())
+		if err != nil {
+			return err
+		}
+		fmt.Println(!disabled)
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/repair_queue_list.go
+++ b/pkg/ckecli/cmd/repair_queue_list.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -17,18 +15,14 @@ var repairQueueListCmd = &cobra.Command{
 The output is a list of RepairQueueEntry formatted in JSON.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			entries, err := storage.GetRepairsEntries(ctx)
-			if err != nil {
-				return err
-			}
+		entries, err := storage.GetRepairsEntries(cmd.Context())
+		if err != nil {
+			return err
+		}
 
-			enc := json.NewEncoder(os.Stdout)
-			enc.SetIndent("", "    ")
-			return enc.Encode(entries)
-		})
-		well.Stop()
-		return well.Wait()
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "    ")
+		return enc.Encode(entries)
 	},
 }
 

--- a/pkg/ckecli/cmd/repair_queue_reset_backoff.go
+++ b/pkg/ckecli/cmd/repair_queue_reset_backoff.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"time"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 
 	"github.com/cybozu-go/cke"
@@ -15,27 +13,25 @@ var repairQueueResetBackoffCmd = &cobra.Command{
 	Short: "Reset drain backoff of the entries in repair queue",
 	Long:  `Reset drain_backoff_count and drain_backoff_expire of the entries in repair queue`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			entries, err := storage.GetRepairsEntries(ctx)
+		ctx := cmd.Context()
+
+		entries, err := storage.GetRepairsEntries(ctx)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			entry.DrainBackOffCount = 0
+			entry.DrainBackOffExpire = time.Time{}
+			err := storage.UpdateRepairsEntry(ctx, entry)
+			if err == cke.ErrNotFound {
+				// The entry has just been dequeued.
+				continue
+			}
 			if err != nil {
 				return err
 			}
-			for _, entry := range entries {
-				entry.DrainBackOffCount = 0
-				entry.DrainBackOffExpire = time.Time{}
-				err := storage.UpdateRepairsEntry(ctx, entry)
-				if err == cke.ErrNotFound {
-					// The entry has just been dequeued.
-					continue
-				}
-				if err != nil {
-					return err
-				}
-			}
-			return nil
-		})
-		well.Stop()
-		return well.Wait()
+		}
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/resource_delete.go
+++ b/pkg/ckecli/cmd/resource_delete.go
@@ -2,11 +2,9 @@ package cmd
 
 import (
 	"bufio"
-	"context"
 	"io"
 	"os"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 
 	"github.com/cybozu-go/cke"
@@ -36,28 +34,24 @@ Note that resources in Kubernetes will not be removed automatically.`,
 			r = f
 		}
 
-		well.Go(func(ctx context.Context) error {
-			y := k8sYaml.NewYAMLReader(bufio.NewReader(r))
-			for {
-				data, err := y.Read()
-				if err == io.EOF {
-					break
-				} else if err != nil {
-					return err
-				}
-				key, err := cke.ParseResource(data)
-				if err != nil {
-					return err
-				}
-				err = storage.DeleteResource(ctx, key)
-				if err != nil {
-					return err
-				}
+		y := k8sYaml.NewYAMLReader(bufio.NewReader(r))
+		for {
+			data, err := y.Read()
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				return err
 			}
-			return nil
-		})
-		well.Stop()
-		return well.Wait()
+			key, err := cke.ParseResource(data)
+			if err != nil {
+				return err
+			}
+			err = storage.DeleteResource(cmd.Context(), key)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/resource_get.go
+++ b/pkg/ckecli/cmd/resource_get.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -15,17 +13,13 @@ var resourceGetCmd = &cobra.Command{
 	Long:  `Get a user-defined resource by key.`,
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			data, _, err := storage.GetResource(ctx, args[0])
-			if err != nil {
-				return err
-			}
+		data, _, err := storage.GetResource(cmd.Context(), args[0])
+		if err != nil {
+			return err
+		}
 
-			fmt.Println(strings.TrimSpace(string(data)))
-			return nil
-		})
-		well.Stop()
-		return well.Wait()
+		fmt.Println(strings.TrimSpace(string(data)))
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/resource_list.go
+++ b/pkg/ckecli/cmd/resource_list.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -14,19 +12,15 @@ var resourceListCmd = &cobra.Command{
 	Long:  `List keys of registered user resources.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			keys, err := storage.ListResources(ctx)
-			if err != nil {
-				return err
-			}
+		keys, err := storage.ListResources(cmd.Context())
+		if err != nil {
+			return err
+		}
 
-			for _, key := range keys {
-				fmt.Println(key)
-			}
-			return nil
-		})
-		well.Stop()
-		return well.Wait()
+		for _, key := range keys {
+			fmt.Println(key)
+		}
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/resource_set.go
+++ b/pkg/ckecli/cmd/resource_set.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 
 	"github.com/cybozu-go/cke"
@@ -33,6 +32,8 @@ If FILE is "-", then data is read from stdin.`,
 
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
 		r := os.Stdin
 		if args[0] != "-" {
 			f, err := os.Open(args[0])
@@ -43,25 +44,21 @@ If FILE is "-", then data is read from stdin.`,
 			r = f
 		}
 
-		well.Go(func(ctx context.Context) error {
-			y := k8sYaml.NewYAMLReader(bufio.NewReader(r))
-			for {
-				data, err := y.Read()
-				if err == io.EOF {
-					return nil
-				}
-				if err != nil {
-					return err
-				}
-
-				err = updateResource(ctx, data)
-				if err != nil {
-					return err
-				}
+		y := k8sYaml.NewYAMLReader(bufio.NewReader(r))
+		for {
+			data, err := y.Read()
+			if err == io.EOF {
+				return nil
 			}
-		})
-		well.Stop()
-		return well.Wait()
+			if err != nil {
+				return err
+			}
+
+			err = updateResource(ctx, data)
+			if err != nil {
+				return err
+			}
+		}
 	},
 }
 

--- a/pkg/ckecli/cmd/root.go
+++ b/pkg/ckecli/cmd/root.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"os"
 	"os/signal"
 	"syscall"
@@ -83,34 +83,18 @@ with etcd.  CKE server watches etcd to receive any updates.`,
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-	defer signal.Stop(sigCh)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	received := make(chan os.Signal, 1)
-	go func() {
-		select {
-		case s := <-sigCh:
-			received <- s
-			cancel()
-		case <-ctx.Done():
-		}
-	}()
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
 	err := rootCmd.ExecuteContext(ctx)
-	if err == nil {
+	switch {
+	case err == nil:
 		return
-	}
-
-	select {
-	case s := <-received:
-		err = fmt.Errorf("signaled: %s", s)
+	case ctx.Err() != nil:
+		log.ErrorExit(errors.New("interrupted"))
 	default:
+		log.ErrorExit(err)
 	}
-	log.ErrorExit(err)
 }
 
 func init() {

--- a/pkg/ckecli/cmd/root.go
+++ b/pkg/ckecli/cmd/root.go
@@ -1,7 +1,11 @@
 package cmd
 
 import (
+	"context"
+	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/cybozu-go/etcdutil"
 	"github.com/cybozu-go/log"
@@ -79,9 +83,34 @@ with etcd.  CKE server watches etcd to receive any updates.`,
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		log.ErrorExit(err)
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	received := make(chan os.Signal, 1)
+	go func() {
+		select {
+		case s := <-sigCh:
+			received <- s
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	err := rootCmd.ExecuteContext(ctx)
+	if err == nil {
+		return
 	}
+
+	select {
+	case s := <-received:
+		err = fmt.Errorf("signaled: %s", s)
+	default:
+	}
+	log.ErrorExit(err)
 }
 
 func init() {

--- a/pkg/ckecli/cmd/sabakan_disable.go
+++ b/pkg/ckecli/cmd/sabakan_disable.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"context"
-
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -13,11 +10,7 @@ var sabakanDisableCmd = &cobra.Command{
 	Long:  `Disable sabakan integration.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			return storage.EnableSabakan(ctx, false)
-		})
-		well.Stop()
-		return well.Wait()
+		return storage.EnableSabakan(cmd.Context(), false)
 	},
 }
 

--- a/pkg/ckecli/cmd/sabakan_enable.go
+++ b/pkg/ckecli/cmd/sabakan_enable.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"context"
-
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -13,11 +10,7 @@ var sabakanEnableCmd = &cobra.Command{
 	Long:  `Enable sabakan integration.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			return storage.EnableSabakan(ctx, true)
-		})
-		well.Stop()
-		return well.Wait()
+		return storage.EnableSabakan(cmd.Context(), true)
 	},
 }
 

--- a/pkg/ckecli/cmd/sabakan_get_temlate.go
+++ b/pkg/ckecli/cmd/sabakan_get_temlate.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"os"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 )
@@ -16,22 +14,18 @@ var sabakanGetTemplateCmd = &cobra.Command{
 	Long:  `Get the cluster configuration template.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			tmpl, _, err := storage.GetSabakanTemplate(ctx)
-			if err != nil {
-				return err
-			}
-
-			b, err := yaml.Marshal(tmpl)
-			if err != nil {
-				return nil
-			}
-
-			_, err = os.Stdout.Write(b)
+		tmpl, _, err := storage.GetSabakanTemplate(cmd.Context())
+		if err != nil {
 			return err
-		})
-		well.Stop()
-		return well.Wait()
+		}
+
+		b, err := yaml.Marshal(tmpl)
+		if err != nil {
+			return nil
+		}
+
+		_, err = os.Stdout.Write(b)
+		return err
 	},
 }
 

--- a/pkg/ckecli/cmd/sabakan_get_url.go
+++ b/pkg/ckecli/cmd/sabakan_get_url.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -15,16 +13,12 @@ var sabakanGetURLCmd = &cobra.Command{
 	Long:  `get stored URL of sabakan server.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			u, err := storage.GetSabakanURL(ctx)
-			if err != nil {
-				return err
-			}
-			fmt.Println(u)
-			return nil
-		})
-		well.Stop()
-		return well.Wait()
+		u, err := storage.GetSabakanURL(cmd.Context())
+		if err != nil {
+			return err
+		}
+		fmt.Println(u)
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/sabakan_get_variables.go
+++ b/pkg/ckecli/cmd/sabakan_get_variables.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"os"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -15,16 +13,12 @@ var sabakanGetVariablesCmd = &cobra.Command{
 	Long:  `Get the query variables to search available machines in sabakan.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			data, err := storage.GetSabakanQueryVariables(ctx)
-			if err != nil {
-				return err
-			}
-			os.Stdout.Write(data)
-			return nil
-		})
-		well.Stop()
-		return well.Wait()
+		data, err := storage.GetSabakanQueryVariables(cmd.Context())
+		if err != nil {
+			return err
+		}
+		os.Stdout.Write(data)
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/sabakan_is_enabled.go
+++ b/pkg/ckecli/cmd/sabakan_is_enabled.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -14,16 +12,12 @@ var sabakanIsEnabledCmd = &cobra.Command{
 	Long:  `Show whether sabakan integration is enabled or not.  "true" if enabled.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			disabled, err := storage.IsSabakanDisabled(ctx)
-			if err != nil {
-				return err
-			}
-			fmt.Println(!disabled)
-			return nil
-		})
-		well.Stop()
-		return well.Wait()
+		disabled, err := storage.IsSabakanDisabled(cmd.Context())
+		if err != nil {
+			return err
+		}
+		fmt.Println(!disabled)
+		return nil
 	},
 }
 

--- a/pkg/ckecli/cmd/sabakan_set_template.go
+++ b/pkg/ckecli/cmd/sabakan_set_template.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"context"
 	"os"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 
@@ -39,11 +37,7 @@ just one control-plane node and one non contorl-plane node.`,
 			return err
 		}
 
-		well.Go(func(ctx context.Context) error {
-			return storage.SetSabakanTemplate(ctx, tmpl)
-		})
-		well.Stop()
-		return well.Wait()
+		return storage.SetSabakanTemplate(cmd.Context(), tmpl)
 	},
 }
 

--- a/pkg/ckecli/cmd/sabakan_set_url.go
+++ b/pkg/ckecli/cmd/sabakan_set_url.go
@@ -1,13 +1,11 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"net/url"
 	"path"
 	"strings"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -32,11 +30,7 @@ var sabakanSetURLCmd = &cobra.Command{
 			u.Path = path.Join(u.Path, "/graphql")
 		}
 
-		well.Go(func(ctx context.Context) error {
-			return storage.SetSabakanURL(ctx, u.String())
-		})
-		well.Stop()
-		return well.Wait()
+		return storage.SetSabakanURL(cmd.Context(), u.String())
 	},
 }
 

--- a/pkg/ckecli/cmd/sabakan_set_variables.go
+++ b/pkg/ckecli/cmd/sabakan_set_variables.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 
 	"github.com/cybozu-go/cke/sabakan"
@@ -49,11 +47,7 @@ FILE should contain a JSON object like this:
 			return err
 		}
 
-		well.Go(func(ctx context.Context) error {
-			return storage.SetSabakanQueryVariables(ctx, string(data))
-		})
-		well.Stop()
-		return well.Wait()
+		return storage.SetSabakanQueryVariables(cmd.Context(), string(data))
 	},
 }
 

--- a/pkg/ckecli/cmd/scp.go
+++ b/pkg/ckecli/cmd/scp.go
@@ -45,7 +45,7 @@ func scpSubMain(ctx context.Context, args []string) error {
 		return err
 	}
 
-	pirvateKey, err := getPrivateKey(node)
+	pirvateKey, err := getPrivateKey(ctx, node)
 	if err != nil {
 		log.Error("failed to get the private key for scp", map[string]any{
 			log.FnError: err,
@@ -63,7 +63,7 @@ func scpSubMain(ctx context.Context, args []string) error {
 	}()
 	defer killSshAgent()
 
-	if err = writeToFifo(pipeFilename, pirvateKey); err != nil {
+	if err = writeToFifo(ctx, pipeFilename, pirvateKey); err != nil {
 		log.Error("failed to write the named pipe", map[string]any{
 			log.FnError: err,
 			"pipe":      pipeFilename,

--- a/pkg/ckecli/cmd/scp.go
+++ b/pkg/ckecli/cmd/scp.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/cybozu-go/log"
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 )
 
@@ -104,11 +103,7 @@ NODE is IP address or hostname of the node.
 
 	Args: cobra.MinimumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			return scpSubMain(ctx, args)
-		})
-		well.Stop()
-		return well.Wait()
+		return scpSubMain(cmd.Context(), args)
 	},
 }
 

--- a/pkg/ckecli/cmd/scp.go
+++ b/pkg/ckecli/cmd/scp.go
@@ -45,7 +45,7 @@ func scpSubMain(ctx context.Context, args []string) error {
 		return err
 	}
 
-	pirvateKey, err := getPrivateKey(ctx, node)
+	privateKey, err := getPrivateKey(ctx, node)
 	if err != nil {
 		log.Error("failed to get the private key for scp", map[string]any{
 			log.FnError: err,
@@ -63,7 +63,7 @@ func scpSubMain(ctx context.Context, args []string) error {
 	}()
 	defer killSshAgent()
 
-	if err = writeToFifo(ctx, pipeFilename, pirvateKey); err != nil {
+	if err = writeToFifo(ctx, pipeFilename, privateKey); err != nil {
 		log.Error("failed to write the named pipe", map[string]any{
 			log.FnError: err,
 			"pipe":      pipeFilename,

--- a/pkg/ckecli/cmd/scp.go
+++ b/pkg/ckecli/cmd/scp.go
@@ -61,7 +61,7 @@ func scpSubMain(ctx context.Context, args []string) error {
 			})
 		}
 	}()
-	defer func() { _ = killSshAgent(ctx) }()
+	defer killSshAgent()
 
 	if err = writeToFifo(pipeFilename, pirvateKey); err != nil {
 		log.Error("failed to write the named pipe", map[string]any{

--- a/pkg/ckecli/cmd/ssh.go
+++ b/pkg/ckecli/cmd/ssh.go
@@ -12,7 +12,6 @@ import (
 	"syscall"
 
 	"github.com/cybozu-go/log"
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 
 	"github.com/cybozu-go/cke"
@@ -222,11 +221,7 @@ If COMMAND is specified, it will be executed on the node.
 
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(func(ctx context.Context) error {
-			return sshSubMain(ctx, args)
-		})
-		well.Stop()
-		return well.Wait()
+		return sshSubMain(cmd.Context(), args)
 	},
 }
 

--- a/pkg/ckecli/cmd/ssh.go
+++ b/pkg/ckecli/cmd/ssh.go
@@ -54,13 +54,13 @@ func createFifo() (string, error) {
 	return fifoFilePath, err
 }
 
-func getPrivateKey(nodeName string) (string, error) {
+func getPrivateKey(ctx context.Context, nodeName string) (string, error) {
 	vc, err := inf.Vault()
 	if err != nil {
 		return "", err
 	}
 
-	secret, err := vc.Logical().Read(cke.SSHSecret)
+	secret, err := vc.Logical().ReadWithContext(ctx, cke.SSHSecret)
 	if err != nil {
 		return "", err
 	}
@@ -151,13 +151,32 @@ func killSshAgent() {
 	})
 }
 
-func writeToFifo(fifo string, data string) error {
-	f, err := os.OpenFile(fifo, os.O_WRONLY|os.O_APPEND, os.ModeNamedPipe)
-	if err != nil {
-		return err
+func writeToFifo(ctx context.Context, fifo string, data string) error {
+	// Opening a FIFO for writing blocks until a reader appears, so do it in
+	// a goroutine and let this function return as soon as ctx is done.
+	type result struct {
+		f   *os.File
+		err error
+	}
+	openDone := make(chan result, 1)
+	go func() {
+		f, err := os.OpenFile(fifo, os.O_WRONLY|os.O_APPEND, os.ModeNamedPipe)
+		openDone <- result{f, err}
+	}()
+
+	var f *os.File
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case r := <-openDone:
+		if r.err != nil {
+			return r.err
+		}
+		f = r.f
 	}
 	defer f.Close()
-	if _, err = f.Write([]byte(data)); err != nil {
+
+	if _, err := f.Write([]byte(data)); err != nil {
 		return err
 	}
 	return nil
@@ -174,7 +193,7 @@ func sshSubMain(ctx context.Context, args []string) error {
 	defer os.Remove(pipeFilename)
 
 	node := detectSSHNode(args[0])
-	pirvateKey, err := getPrivateKey(node)
+	pirvateKey, err := getPrivateKey(ctx, node)
 	if err != nil {
 		log.Error("failed to get the private key for ssh", map[string]any{
 			log.FnError: err,
@@ -192,7 +211,7 @@ func sshSubMain(ctx context.Context, args []string) error {
 	}()
 	defer killSshAgent()
 
-	if err = writeToFifo(pipeFilename, pirvateKey); err != nil {
+	if err = writeToFifo(ctx, pipeFilename, pirvateKey); err != nil {
 		log.Error("failed to write the named pipe", map[string]any{
 			log.FnError: err,
 			"pipe":      pipeFilename,

--- a/pkg/ckecli/cmd/ssh.go
+++ b/pkg/ckecli/cmd/ssh.go
@@ -193,7 +193,7 @@ func sshSubMain(ctx context.Context, args []string) error {
 	defer os.Remove(pipeFilename)
 
 	node := detectSSHNode(args[0])
-	pirvateKey, err := getPrivateKey(ctx, node)
+	privateKey, err := getPrivateKey(ctx, node)
 	if err != nil {
 		log.Error("failed to get the private key for ssh", map[string]any{
 			log.FnError: err,
@@ -211,7 +211,7 @@ func sshSubMain(ctx context.Context, args []string) error {
 	}()
 	defer killSshAgent()
 
-	if err = writeToFifo(ctx, pipeFilename, pirvateKey); err != nil {
+	if err = writeToFifo(ctx, pipeFilename, privateKey); err != nil {
 		log.Error("failed to write the named pipe", map[string]any{
 			log.FnError: err,
 			"pipe":      pipeFilename,

--- a/pkg/ckecli/cmd/ssh.go
+++ b/pkg/ckecli/cmd/ssh.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/cybozu-go/log"
 	"github.com/spf13/cobra"
@@ -131,19 +132,23 @@ func startSshAgent(ctx context.Context, privateKeyFile string) (map[string]strin
 	return myEnv, nil
 }
 
-func killSshAgent(ctx context.Context) error {
+func killSshAgent() {
+	// Use an independent context so cleanup still runs even when the
+	// caller's context is already canceled (e.g. by a signal).
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	cmd := exec.CommandContext(ctx, "ssh-agent", "-k")
 	stdoutStderr, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Error("failed to run ssh-agent -k", map[string]any{
 			log.FnError: err,
 		})
-		return err
+		return
 	}
 	log.Debug("killed ssh-agent", map[string]any{
 		"stdout_stderr": string(stdoutStderr),
 	})
-	return nil
 }
 
 func writeToFifo(fifo string, data string) error {
@@ -185,7 +190,7 @@ func sshSubMain(ctx context.Context, args []string) error {
 			})
 		}
 	}()
-	defer func() { _ = killSshAgent(ctx) }()
+	defer killSshAgent()
 
 	if err = writeToFifo(pipeFilename, pirvateKey); err != nil {
 		log.Error("failed to write the named pipe", map[string]any{

--- a/pkg/ckecli/cmd/vault_config.go
+++ b/pkg/ckecli/cmd/vault_config.go
@@ -1,11 +1,9 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"os"
 
-	"github.com/cybozu-go/well"
 	"github.com/spf13/cobra"
 
 	"github.com/cybozu-go/cke"
@@ -49,11 +47,7 @@ If the argument is "-", the JSON is read from stdin.`,
 			return err
 		}
 
-		well.Go(func(ctx context.Context) error {
-			return storage.PutVaultConfig(ctx, cfg)
-		})
-		well.Stop()
-		return well.Wait()
+		return storage.PutVaultConfig(cmd.Context(), cfg)
 	},
 }
 

--- a/pkg/ckecli/cmd/vault_init.go
+++ b/pkg/ckecli/cmd/vault_init.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 
-	"github.com/cybozu-go/well"
 	vault "github.com/hashicorp/vault/api"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -315,9 +314,7 @@ This command will ask username and password for Vault authentication
 when VAULT_TOKEN environment variable is not set.`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
-		well.Go(initVault)
-		well.Stop()
-		return well.Wait()
+		return initVault(cmd.Context())
 	},
 }
 


### PR DESCRIPTION
This is the first step toward removing the dependency on cybozu-go/well.

This PR stops using `well.Go` in ckecli, which was mainly used for signal handling.
Signal handling is now done once in `Execute()`, and subcommands use its context instead.