### PR TITLE
rivers: Drop cybozu-go/log and cybozu-go/well dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	go.etcd.io/etcd/etcdutl/v3 v3.6.11
 	go.etcd.io/gofail v0.2.0
 	golang.org/x/crypto v0.51.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.43.0
 	k8s.io/api v0.35.5
 	k8s.io/apimachinery v0.35.5
@@ -293,7 +294,6 @@ require (
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.12.0 // indirect

--- a/tools/rivers/README.md
+++ b/tools/rivers/README.md
@@ -29,12 +29,6 @@ The upstream server is selected at random.
         Timeout for dial to an upstream server (default "10s")
   -listen string
         Listen address and port (address:port)
-  -logfile string
-        Log filename
-  -logformat string
-        Log format [plain,logfmt,json]
-  -loglevel string
-        Log level [critical,error,warning,info,debug]
   -shutdown-timeout string
         Timeout for server shutting-down gracefully (disabled if specified "0") (default "10s")
   -upstreams string

--- a/tools/rivers/health.go
+++ b/tools/rivers/health.go
@@ -3,27 +3,25 @@ package main
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net"
 	"sync"
 	"time"
-
-	"github.com/cybozu-go/log"
-	"github.com/cybozu-go/well"
 )
 
 // HealthCheckerConfig represents configuration for health checker
 type HealthCheckerConfig struct {
-	CheckInterval time.Duration
-	Logger        *log.Logger
 	Dialer        Dialer
+	Logger        *slog.Logger
+	CheckInterval time.Duration
 }
 
 // HealthChecker represents upstream health checker
 type HealthChecker struct {
+	dialer        Dialer
+	logger        *slog.Logger
 	upstreams     []*Upstream
 	checkInterval time.Duration
-	logger        *log.Logger
-	dialer        Dialer
 }
 
 // NewHealthChecker creates a new health checker
@@ -34,67 +32,65 @@ func NewHealthChecker(upstreams []*Upstream, cfg HealthCheckerConfig) *HealthChe
 	}
 	logger := cfg.Logger
 	if logger == nil {
-		logger = log.DefaultLogger()
+		logger = slog.Default()
 	}
 
 	return &HealthChecker{
-		upstreams:     upstreams,
-		checkInterval: cfg.CheckInterval,
-		logger:        logger,
 		dialer:        dialer,
+		logger:        logger,
+		checkInterval: cfg.CheckInterval,
+		upstreams:     upstreams,
 	}
 }
 
-// Start starts health checking
-func (hc *HealthChecker) Start() {
-	well.Go(func(ctx context.Context) error {
-		hc.doHealthCheck(ctx, true)
-		ticker := time.NewTicker(hc.checkInterval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return nil
-			case <-ticker.C:
-				hc.doHealthCheck(ctx, false)
-			}
+// Run runs health checking until ctx is canceled. It always returns nil.
+func (hc *HealthChecker) Run(ctx context.Context) error {
+	hc.doHealthCheck(ctx, true)
+	ticker := time.NewTicker(hc.checkInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			hc.doHealthCheck(ctx, false)
 		}
-	})
+	}
 }
 
 // doHealthCheck do actual health checking at each interval
 func (hc *HealthChecker) doHealthCheck(ctx context.Context, first bool) {
 	var wg sync.WaitGroup
-	for _, tu := range hc.upstreams {
-		wg.Add(1)
 
-		go func(u *Upstream) {
-			defer wg.Done()
-
+	for _, u := range hc.upstreams {
+		wg.Go(func() {
 			conn, err := hc.dialer.DialContext(ctx, "tcp", u.address)
 			if errors.Is(err, context.Canceled) {
 				return
 			}
 
-			if err == nil {
-				conn.Close()
-				if first || !u.IsHealthy() {
-					hc.logger.Info("an upstream becomes healthy", map[string]any{
-						"address": u.address,
-					})
-					u.SetHealthy(true)
+			if err != nil {
+				switch {
+				case first:
+					hc.logger.Error("initial health check: upstream is unhealthy", "address", u.address, "error", err)
+					u.SetHealthy(false)
+				case u.IsHealthy():
+					hc.logger.Error("upstream health changed: now unhealthy", "address", u.address, "error", err)
+					u.SetHealthy(false)
 				}
 				return
 			}
 
-			if first || u.IsHealthy() {
-				hc.logger.Error("an upstream becomes unhealthy", map[string]any{
-					log.FnError: err.Error(),
-					"address":   u.address,
-				})
-				u.SetHealthy(false)
+			conn.Close()
+			switch {
+			case first:
+				hc.logger.Info("initial health check: upstream is healthy", "address", u.address)
+				u.SetHealthy(true)
+			case !u.IsHealthy():
+				hc.logger.Info("upstream health changed: now healthy", "address", u.address)
+				u.SetHealthy(true)
 			}
-		}(tu)
+		})
 	}
 
 	wg.Wait()

--- a/tools/rivers/health_test.go
+++ b/tools/rivers/health_test.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"bytes"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/cybozu-go/log"
+	"github.com/onsi/gomega/gbytes"
 )
 
 func TestHealthChecker(t *testing.T) {
@@ -14,33 +14,35 @@ func TestHealthChecker(t *testing.T) {
 		address: "0",
 	}}
 	dialer := &testDialer{}
-	logger := log.NewLogger()
-	buf := &bytes.Buffer{}
-	logger.SetOutput(buf)
+	buf := gbytes.NewBuffer()
+	logger := slog.New(slog.NewTextHandler(buf, nil))
 	cfg := HealthCheckerConfig{
-		CheckInterval: time.Millisecond * 100,
 		Dialer:        dialer,
 		Logger:        logger,
+		CheckInterval: time.Millisecond * 100,
 	}
 	hc := NewHealthChecker(upstreams, cfg)
-	hc.Start()
+	go func() {
+		_ = hc.Run(t.Context())
+	}()
 
 	time.Sleep(time.Millisecond * 200)
 	if !upstreams[0].IsHealthy() {
 		t.Errorf("HealthChecker did not change upstream healthy\n")
 	}
-	if !strings.Contains(buf.String(), "becomes healthy") {
-		t.Errorf("HealthChecker did not output status change log")
+	if !strings.Contains(string(buf.Contents()), "initial health check") {
+		t.Errorf("HealthChecker did not output initial status log")
 	}
 
-	buf = &bytes.Buffer{}
-	logger.SetOutput(buf)
+	if err := buf.Clear(); err != nil {
+		t.Fatal(err)
+	}
 	dialer.SetErrorAddress("0")
 	time.Sleep(time.Millisecond * 300)
 	if upstreams[0].IsHealthy() {
 		t.Errorf("HealthChecker did not change upstream unhealthy\n")
 	}
-	if !strings.Contains(buf.String(), "becomes unhealthy") {
+	if !strings.Contains(string(buf.Contents()), "health changed: now unhealthy") {
 		t.Errorf("HealthChecker did not output status change log")
 	}
 }

--- a/tools/rivers/health_test.go
+++ b/tools/rivers/health_test.go
@@ -10,9 +10,7 @@ import (
 )
 
 func TestHealthChecker(t *testing.T) {
-	upstreams := []*Upstream{{
-		address: "0",
-	}}
+	upstreams := []*Upstream{NewUpstream("0")}
 	dialer := &testDialer{}
 	buf := gbytes.NewBuffer()
 	logger := slog.New(slog.NewTextHandler(buf, nil))

--- a/tools/rivers/main.go
+++ b/tools/rivers/main.go
@@ -35,10 +35,7 @@ func main() {
 	upstreamAddrs := strings.Split(*flgUpstreams, ",")
 	upstreams := make([]*Upstream, len(upstreamAddrs))
 	for i, a := range upstreamAddrs {
-		upstreams[i] = &Upstream{
-			address: a,
-			conns:   make(map[net.Conn]func()),
-		}
+		upstreams[i] = NewUpstream(a)
 	}
 
 	dialer := &net.Dialer{}

--- a/tools/rivers/main.go
+++ b/tools/rivers/main.go
@@ -1,16 +1,19 @@
 package main
 
 import (
-	"errors"
+	"context"
 	"flag"
+	"fmt"
+	"log/slog"
 	"net"
+	"os"
+	"os/signal"
 	"strings"
 	"sync"
-	"sync/atomic"
+	"syscall"
 	"time"
 
-	"github.com/cybozu-go/log"
-	"github.com/cybozu-go/well"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -22,58 +25,16 @@ var (
 	flgCheckInterval   = flag.String("check-interval", "20s", "Interval for health check")
 )
 
-// Upstream represents upstream server
-type Upstream struct {
-	address string
+func main() {
+	flag.Parse()
 
-	health atomic.Int32 // must be accessed through SetHealthy / IsHealthy
-
-	m     sync.Mutex
-	conns map[net.Conn]func()
-}
-
-func (u *Upstream) SetHealthy(b bool) {
-	if b {
-		u.health.Store(1)
-		return
-	}
-
-	u.health.Store(0)
-	u.m.Lock()
-	conns := u.conns
-	u.conns = make(map[net.Conn]func())
-	u.m.Unlock()
-
-	for _, c := range conns {
-		c()
-	}
-}
-
-func (u *Upstream) IsHealthy() bool {
-	return u.health.Load() != 0
-}
-
-func (u *Upstream) AddConn(conn net.Conn, cancelFunc func()) {
-	u.m.Lock()
-	defer u.m.Unlock()
-
-	u.conns[conn] = cancelFunc
-}
-
-func (u *Upstream) RemoveConn(conn net.Conn) {
-	u.m.Lock()
-	defer u.m.Unlock()
-
-	delete(u.conns, conn)
-}
-
-func run() error {
 	if len(*flgUpstreams) == 0 {
-		return errors.New("--upstreams is blank")
+		slog.Error("rivers exited with an error", "error", "--upstreams is blank")
+		os.Exit(1)
 	}
-	upstreamAddresses := strings.Split(*flgUpstreams, ",")
-	upstreams := make([]*Upstream, len(upstreamAddresses))
-	for i, a := range upstreamAddresses {
+	upstreamAddrs := strings.Split(*flgUpstreams, ",")
+	upstreams := make([]*Upstream, len(upstreamAddrs))
+	for i, a := range upstreamAddrs {
 		upstreams[i] = &Upstream{
 			address: a,
 			conns:   make(map[net.Conn]func()),
@@ -84,49 +45,79 @@ func run() error {
 	var err error
 	dialer.Timeout, err = time.ParseDuration(*flgDialTimeout)
 	if err != nil {
-		return err
+		slog.Error("rivers exited with an error", "error", fmt.Errorf("--dial-timeout: %w", err))
+		os.Exit(1)
 	}
 	dialer.KeepAlive, err = time.ParseDuration(*flgDialKeepAlive)
 	if err != nil {
-		return err
+		slog.Error("rivers exited with an error", "error", fmt.Errorf("--dial-keep-alive: %w", err))
+		os.Exit(1)
 	}
 
-	cfg := Config{Dialer: dialer}
-	cfg.ShutdownTimeout, err = time.ParseDuration(*flgShutdownTimeout)
+	serverCfg := ServerConfig{Dialer: dialer}
+	serverCfg.ShutdownTimeout, err = time.ParseDuration(*flgShutdownTimeout)
 	if err != nil {
-		return err
+		slog.Error("rivers exited with an error", "error", fmt.Errorf("--shutdown-timeout: %w", err))
+		os.Exit(1)
 	}
 
-	hcConfig := HealthCheckerConfig{Dialer: dialer}
-	hcConfig.CheckInterval, err = time.ParseDuration(*flgCheckInterval)
+	healthCfg := HealthCheckerConfig{Dialer: dialer}
+	healthCfg.CheckInterval, err = time.ParseDuration(*flgCheckInterval)
 	if err != nil {
-		return err
+		slog.Error("rivers exited with an error", "error", fmt.Errorf("--check-interval: %w", err))
+		os.Exit(1)
 	}
 
 	if len(*flgListen) == 0 {
-		return errors.New("--listen is blank")
+		slog.Error("rivers exited with an error", "error", "--listen is blank")
+		os.Exit(1)
 	}
-	listen, err := net.Listen("tcp", *flgListen)
+
+	slog.Info("rivers started", "listen", *flgListen, "upstreams", upstreamAddrs)
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	waitSignalLog := logReceivedSignal(ctx)
+
+	err = run(ctx, upstreams, healthCfg, *flgListen, serverCfg)
+
+	// Stop and wait for the log output goroutine to finish.
+	stop()
+	waitSignalLog()
+
+	if err != nil {
+		slog.Error("rivers exited with an error", "error", err)
+		os.Exit(1)
+	}
+
+	slog.Info("rivers stopped")
+}
+
+// logReceivedSignal starts a goroutine that logs a received signal.
+// It returns a function that blocks until that goroutine has finished.
+func logReceivedSignal(ctx context.Context) (wait func()) {
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		<-ctx.Done()
+		if cause := context.Cause(ctx); cause != context.Canceled {
+			slog.Warn("received signal, shutting down", "cause", cause)
+		}
+	})
+	return wg.Wait
+}
+
+// run runs rivers until ctx is canceled or an unrecoverable error occurs.
+func run(ctx context.Context, upstreams []*Upstream, healthCfg HealthCheckerConfig, listenAddr string, serverCfg ServerConfig) error {
+	listen, err := (&net.ListenConfig{}).Listen(ctx, "tcp", listenAddr)
 	if err != nil {
 		return err
 	}
 
-	hc := NewHealthChecker(upstreams, hcConfig)
-	hc.Start()
+	hc := NewHealthChecker(upstreams, healthCfg)
+	s := NewServer(upstreams, serverCfg)
 
-	s := NewServer(upstreams, cfg)
-	s.Serve(listen)
-
-	well.Stop()
-	return well.Wait()
-}
-
-func main() {
-	flag.Parse()
-	well.LogConfig{}.Apply()
-
-	err := run()
-	if err != nil && !well.IsSignaled(err) {
-		log.ErrorExit(err)
-	}
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error { return hc.Run(ctx) })
+	eg.Go(func() error { return s.Serve(ctx, listen) })
+	return eg.Wait()
 }

--- a/tools/rivers/server.go
+++ b/tools/rivers/server.go
@@ -4,18 +4,19 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"math/rand"
 	"net"
+	"slices"
 	"sync"
 	"time"
 
-	"github.com/cybozu-go/log"
-	"github.com/cybozu-go/netutil"
-	"github.com/cybozu-go/well"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
-	copyBufferSize = 64 << 10
+	copyBufferSize     = 64 << 10
+	tcpKeepAlivePeriod = 3 * time.Minute
 )
 
 type Dialer interface {
@@ -23,42 +24,47 @@ type Dialer interface {
 	DialContext(ctx context.Context, network, address string) (net.Conn, error)
 }
 
-// Config represents TCP servers
-type Config struct {
-	ShutdownTimeout time.Duration
-	Logger          *log.Logger
+// halfCloser is satisfied by connections that can be half-closed, such as
+// *net.TCPConn and *net.UnixConn. It lets randomUpstream's Dialer return
+// non-TCP connections; half-close is just skipped for anything that
+// doesn't support it.
+type halfCloser interface {
+	CloseRead() error
+	CloseWrite() error
+}
+
+// ServerConfig represents TCP servers
+type ServerConfig struct {
 	Dialer          Dialer
+	Logger          *slog.Logger
+	ShutdownTimeout time.Duration
 }
 
 // Server represents TCP proxy server
 type Server struct {
-	well.Server
-
-	upstreams []*Upstream
-	logger    *log.Logger
-	dialer    Dialer
-	pool      sync.Pool
+	dialer          Dialer
+	logger          *slog.Logger
+	shutdownTimeout time.Duration
+	upstreams       []*Upstream
+	pool            sync.Pool
 }
 
 // NewServer creates a new Server
-func NewServer(upstreams []*Upstream, cfg Config) *Server {
+func NewServer(upstreams []*Upstream, cfg ServerConfig) *Server {
 	dialer := cfg.Dialer
 	if dialer == nil {
 		dialer = &net.Dialer{}
 	}
 	logger := cfg.Logger
 	if logger == nil {
-		logger = log.DefaultLogger()
+		logger = slog.Default()
 	}
 
-	s := &Server{
-		Server: well.Server{
-			ShutdownTimeout: cfg.ShutdownTimeout,
-		},
-
-		upstreams: upstreams,
-		logger:    logger,
-		dialer:    dialer,
+	return &Server{
+		dialer:          dialer,
+		logger:          logger,
+		shutdownTimeout: cfg.ShutdownTimeout,
+		upstreams:       upstreams,
 		pool: sync.Pool{
 			New: func() any {
 				buf := make([]byte, copyBufferSize)
@@ -66,28 +72,80 @@ func NewServer(upstreams []*Upstream, cfg Config) *Server {
 			},
 		},
 	}
-	s.Handler = s.handleConnection
-
-	return s
 }
 
-func (s *Server) handleConnection(ctx context.Context, conn net.Conn) {
-	fields := well.FieldsFromContext(ctx)
-	fields[log.FnType] = "access"
-	fields["client_addr"] = conn.RemoteAddr().String()
+// Serve accepts connections on l, handling each in its own goroutine, until
+// ctx is canceled.  It then blocks until all connections are closed, or
+// shutdownTimeout elapses, whichever comes first.
+//
+// It returns nil when ctx is canceled, or the error from l.Accept if
+// accepting fails for any other reason.
+func (s *Server) Serve(ctx context.Context, l net.Listener) error {
+	go func() {
+		<-ctx.Done()
+		l.Close()
+	}()
+
+	var acceptErr error
+	var wg sync.WaitGroup
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			if ctx.Err() == nil {
+				acceptErr = err
+			}
+			break
+		}
+
+		if tc, ok := conn.(*net.TCPConn); ok {
+			_ = tc.SetKeepAlive(true)
+			_ = tc.SetKeepAlivePeriod(tcpKeepAlivePeriod)
+		}
+
+		wg.Go(func() {
+			defer conn.Close()
+			s.handleConnection(conn)
+		})
+	}
+
+	s.waitShutdown(&wg)
+	return acceptErr
+}
+
+// waitShutdown blocks until wg is done, or s.shutdownTimeout elapses,
+// whichever comes first.  A zero shutdownTimeout disables the timeout and
+// waits indefinitely.
+func (s *Server) waitShutdown(wg *sync.WaitGroup) {
+	if s.shutdownTimeout == 0 {
+		wg.Wait()
+		return
+	}
+
+	ch := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	select {
+	case <-ch:
+	case <-time.After(s.shutdownTimeout):
+		s.logger.Warn("timeout waiting for shutdown")
+	}
+}
+
+func (s *Server) handleConnection(conn net.Conn) {
+	logger := s.logger.With("client_addr", conn.RemoteAddr().String())
 
 	tc, ok := conn.(*net.TCPConn)
 	if !ok {
-		s.logger.Error("non-TCP connection", map[string]any{
-			"conn": conn,
-		})
+		logger.Error("non-TCP connection", "conn", conn)
 		return
 	}
 
 	destConn, u, err := s.randomUpstream()
 	if err != nil {
-		fields[log.FnError] = err.Error()
-		s.logger.Error("failed to connect to upstream servers", fields)
+		logger.Error("failed to connect to upstream servers", "error", err)
 		return
 	}
 	defer destConn.Close()
@@ -99,43 +157,41 @@ func (s *Server) handleConnection(ctx context.Context, conn net.Conn) {
 	defer u.RemoveConn(conn)
 
 	st := time.Now()
-	env := well.NewEnvironment(ctx)
-	env.Go(func(_ context.Context) error {
+
+	var eg errgroup.Group
+	eg.Go(func() error {
 		buf := s.pool.Get().(*[]byte)
 		_, err := io.CopyBuffer(destConn, tc, *buf)
 		s.pool.Put(buf)
-		if hc, ok := destConn.(netutil.HalfCloser); ok {
+		if hc, ok := destConn.(halfCloser); ok {
 			_ = hc.CloseWrite()
 		}
 		_ = tc.CloseRead()
 		return err
 	})
-	env.Go(func(_ context.Context) error {
+	eg.Go(func() error {
 		buf := s.pool.Get().(*[]byte)
 		_, err := io.CopyBuffer(tc, destConn, *buf)
 		s.pool.Put(buf)
 		_ = tc.CloseWrite()
-		if hc, ok := destConn.(netutil.HalfCloser); ok {
+		if hc, ok := destConn.(halfCloser); ok {
 			_ = hc.CloseRead()
 		}
 		return err
 	})
-	env.Stop()
-	err = env.Wait()
+	err = eg.Wait()
 
-	fields = well.FieldsFromContext(ctx)
-	fields["elapsed"] = time.Since(st).Seconds()
+	elapsed := time.Since(st).Seconds()
+
 	if err != nil {
-		fields[log.FnError] = err.Error()
-		s.logger.Error("proxy ends with an error", fields)
+		logger.Error("proxy ends with an error", "elapsed", elapsed, "error", err)
 		return
 	}
-	s.logger.Info("proxy ends", fields)
+	logger.Info("proxy ends", "elapsed", elapsed)
 }
 
 func (s *Server) randomUpstream() (net.Conn, *Upstream, error) {
-	ups := make([]*Upstream, len(s.upstreams))
-	copy(ups, s.upstreams)
+	ups := slices.Clone(s.upstreams)
 	rand.Shuffle(len(ups), func(i, j int) {
 		ups[i], ups[j] = ups[j], ups[i]
 	})
@@ -150,9 +206,7 @@ func (s *Server) randomUpstream() (net.Conn, *Upstream, error) {
 			return conn, u, nil
 		}
 
-		s.logger.Warn("failed to connect to proxy server", map[string]any{
-			"upstream": a,
-		})
+		s.logger.Warn("failed to connect to proxy server", "upstream", a)
 	}
 	return nil, nil, errors.New("no available upstreams servers")
 }

--- a/tools/rivers/server_test.go
+++ b/tools/rivers/server_test.go
@@ -17,9 +17,7 @@ func TestEmptyServer(t *testing.T) {
 }
 
 func TestServerWithUnhealthyUpstream(t *testing.T) {
-	upstreams := []*Upstream{{
-		address: "0",
-	}}
+	upstreams := []*Upstream{NewUpstream("0")}
 	buf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(buf, nil))
 	cfg := ServerConfig{
@@ -37,9 +35,7 @@ func TestServerWithUnhealthyUpstream(t *testing.T) {
 }
 
 func TestServerWithUnconnectableUpstream(t *testing.T) {
-	upstreams := []*Upstream{{
-		address: "0",
-	}}
+	upstreams := []*Upstream{NewUpstream("0")}
 	upstreams[0].SetHealthy(true)
 	buf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(buf, nil))
@@ -61,15 +57,9 @@ func TestServerWithUnconnectableUpstream(t *testing.T) {
 
 func TestServerRandomUpstream(t *testing.T) {
 	upstreams := []*Upstream{
-		{
-			address: "0",
-		},
-		{
-			address: "1",
-		},
-		{
-			address: "2",
-		},
+		NewUpstream("0"),
+		NewUpstream("1"),
+		NewUpstream("2"),
 	}
 	for _, u := range upstreams {
 		u.SetHealthy(true)

--- a/tools/rivers/server_test.go
+++ b/tools/rivers/server_test.go
@@ -2,18 +2,14 @@ package main
 
 import (
 	"bytes"
+	"io"
+	"log/slog"
 	"strings"
 	"testing"
-	"time"
-
-	"github.com/cybozu-go/log"
 )
 
 func TestEmptyServer(t *testing.T) {
-	cfg := Config{
-		ShutdownTimeout: time.Second,
-	}
-	s := NewServer(nil, cfg)
+	s := NewServer(nil, ServerConfig{})
 	_, _, err := s.randomUpstream()
 	if err == nil {
 		t.Errorf("empty server should return error for randomUpstream()\n")
@@ -24,13 +20,11 @@ func TestServerWithUnhealthyUpstream(t *testing.T) {
 	upstreams := []*Upstream{{
 		address: "0",
 	}}
-	logger := log.NewLogger()
 	buf := &bytes.Buffer{}
-	logger.SetOutput(buf)
-	cfg := Config{
-		ShutdownTimeout: time.Second,
-		Dialer:          &testDialer{},
-		Logger:          logger,
+	logger := slog.New(slog.NewTextHandler(buf, nil))
+	cfg := ServerConfig{
+		Dialer: &testDialer{},
+		Logger: logger,
 	}
 	s := NewServer(upstreams, cfg)
 	_, _, err := s.randomUpstream()
@@ -47,11 +41,9 @@ func TestServerWithUnconnectableUpstream(t *testing.T) {
 		address: "0",
 	}}
 	upstreams[0].SetHealthy(true)
-	logger := log.NewLogger()
 	buf := &bytes.Buffer{}
-	logger.SetOutput(buf)
-	cfg := Config{
-		ShutdownTimeout: time.Second,
+	logger := slog.New(slog.NewTextHandler(buf, nil))
+	cfg := ServerConfig{
 		Dialer: &testDialer{
 			errorAddress: "0",
 		},
@@ -62,7 +54,7 @@ func TestServerWithUnconnectableUpstream(t *testing.T) {
 	if err == nil {
 		t.Errorf("unconnectable upstream server should return error for randomUpstream()\n")
 	}
-	if !strings.Contains(buf.String(), "warning: \"failed to connect") {
+	if !strings.Contains(buf.String(), "level=WARN") || !strings.Contains(buf.String(), "failed to connect") {
 		t.Errorf("unconnectable upstream server should output warning log\n")
 	}
 }
@@ -82,10 +74,8 @@ func TestServerRandomUpstream(t *testing.T) {
 	for _, u := range upstreams {
 		u.SetHealthy(true)
 	}
-	logger := log.NewLogger()
-	logger.SetOutput(nil)
-	cfg := Config{
-		ShutdownTimeout: time.Second,
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cfg := ServerConfig{
 		Dialer: &testDialer{
 			errorAddress: "1",
 		},

--- a/tools/rivers/upstream.go
+++ b/tools/rivers/upstream.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"net"
+	"sync"
+	"sync/atomic"
+)
+
+// Upstream represents upstream server
+type Upstream struct {
+	address string
+
+	health atomic.Int32 // must be accessed through SetHealthy / IsHealthy
+
+	m     sync.Mutex
+	conns map[net.Conn]func()
+}
+
+func (u *Upstream) SetHealthy(b bool) {
+	if b {
+		u.health.Store(1)
+		return
+	}
+
+	u.health.Store(0)
+	u.m.Lock()
+	conns := u.conns
+	u.conns = make(map[net.Conn]func())
+	u.m.Unlock()
+
+	for _, c := range conns {
+		c()
+	}
+}
+
+func (u *Upstream) IsHealthy() bool {
+	return u.health.Load() != 0
+}
+
+func (u *Upstream) AddConn(conn net.Conn, cancelFunc func()) {
+	u.m.Lock()
+	defer u.m.Unlock()
+
+	if u.conns == nil {
+		u.conns = make(map[net.Conn]func())
+	}
+	u.conns[conn] = cancelFunc
+}
+
+func (u *Upstream) RemoveConn(conn net.Conn) {
+	u.m.Lock()
+	defer u.m.Unlock()
+
+	delete(u.conns, conn)
+}

--- a/tools/rivers/upstream.go
+++ b/tools/rivers/upstream.go
@@ -9,11 +9,14 @@ import (
 // Upstream represents upstream server
 type Upstream struct {
 	address string
+	health  atomic.Int32 // must be accessed through SetHealthy / IsHealthy
+	m       sync.Mutex
+	conns   map[net.Conn]func()
+}
 
-	health atomic.Int32 // must be accessed through SetHealthy / IsHealthy
-
-	m     sync.Mutex
-	conns map[net.Conn]func()
+// NewUpstream creates an Upstream for the given address.
+func NewUpstream(address string) *Upstream {
+	return &Upstream{address: address}
 }
 
 func (u *Upstream) SetHealthy(b bool) {


### PR DESCRIPTION
This PR removes the `github.com/cybozu-go/log` and `github.com/cybozu-go/well` dependencies from `tools/rivers`, replacing them with the standard libraries.

While rewriting the signal/shutdown handling that `well` used to provide, I also took the opportunity to clean up rivers' internal structure a bit.